### PR TITLE
fix(physics/surface): use bulk_structure as the bulk reference for mu_bulk

### DIFF
--- a/notebooks/surface_energy.ipynb
+++ b/notebooks/surface_energy.ipynb
@@ -19,10 +19,10 @@
    "id": "0472c8d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:53:10.656479Z",
-     "iopub.status.busy": "2026-05-12T12:53:10.656159Z",
-     "iopub.status.idle": "2026-05-12T12:53:11.228357Z",
-     "shell.execute_reply": "2026-05-12T12:53:11.225569Z"
+     "iopub.execute_input": "2026-05-12T15:33:05.153019Z",
+     "iopub.status.busy": "2026-05-12T15:33:05.152636Z",
+     "iopub.status.idle": "2026-05-12T15:33:06.106778Z",
+     "shell.execute_reply": "2026-05-12T15:33:06.105330Z"
     }
    },
    "outputs": [],
@@ -50,10 +50,10 @@
    "id": "2b625a50",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:53:11.233090Z",
-     "iopub.status.busy": "2026-05-12T12:53:11.232212Z",
-     "iopub.status.idle": "2026-05-12T12:53:15.255376Z",
-     "shell.execute_reply": "2026-05-12T12:53:15.252292Z"
+     "iopub.execute_input": "2026-05-12T15:33:06.108973Z",
+     "iopub.status.busy": "2026-05-12T15:33:06.108602Z",
+     "iopub.status.idle": "2026-05-12T15:33:06.379124Z",
+     "shell.execute_reply": "2026-05-12T15:33:06.377737Z"
     }
    },
    "outputs": [
@@ -62,28 +62,7 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 14:53:11      -28.624013        0.294117\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    1 14:53:11      -28.627320        0.248189\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    2 14:53:11      -28.637682        0.057145\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    3 14:53:11      -28.637890        0.048423\n"
+      "BFGS:    0 17:33:06       -8.025561        0.000000\n"
      ]
     },
     {
@@ -91,105 +70,35 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 14:53:11      454.682470     1119.786250\n"
+      "BFGS:    0 17:33:06      -28.624013        0.294117\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    1 14:53:12       51.470839      191.462051\n"
+      "BFGS:    1 17:33:06      -28.627320        0.248189\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    2 14:53:12       24.971845      132.623909\n"
+      "BFGS:    2 17:33:06      -28.637682        0.057145\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    3 14:53:12       -7.903744       53.871546\n"
+      "BFGS:    3 17:33:06      -28.637890        0.048423\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    4 14:53:12      -17.902603       27.274251\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    5 14:53:13      -22.694086       11.389051\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    6 14:53:13      -24.143167        4.478543\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    7 14:53:13      -24.424585        1.207532\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    8 14:53:13      -24.465186        0.647817\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    9 14:53:14      -24.493432        1.048542\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:   10 14:53:14      -24.538643        1.283222\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:   11 14:53:14      -24.562530        0.762880\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:   12 14:53:14      -24.573099        0.106502\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:   13 14:53:15      -24.573446        0.021873\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fe(111) surface energy (Al-Fe.eam.fs): -2.314 J/m^2 (-0.144 eV/A^2)\n",
+      "Fe(111) surface energy (Al-Fe.eam.fs): 1.973 J/m^2 (0.123 eV/A^2)\n",
       "n atoms in relaxed slab: 8\n"
      ]
     },

--- a/pyiron_workflow_atomistics/physics/surface.py
+++ b/pyiron_workflow_atomistics/physics/surface.py
@@ -6,15 +6,22 @@ import numpy as np
 import pyiron_workflow as pwf
 from ase import Atoms
 
-from pyiron_workflow_atomistics.engine import Engine, run
+from pyiron_workflow_atomistics.engine import Engine, run, subengine
 from pyiron_workflow_atomistics.structure.build import create_surface_slab
 
 
 @pwf.as_function_node("mu_bulk_out")
-def _calculate_if_not_present_(input_structure, engine: Engine, mu_bulk=None):
+def _bulk_per_atom_energy(bulk_structure, engine: Engine, mu_bulk=None):
+    """Return the bulk per-atom chemical potential.
+
+    If ``mu_bulk`` is supplied, return it as-is. Otherwise relax
+    ``bulk_structure`` with ``engine`` and divide the final energy by the
+    atom count. The input must be a true bulk cell (not a no-vacuum slab),
+    otherwise the per-atom energy will reflect surface/geometry artefacts.
+    """
     if mu_bulk is None:
-        output = run.node_function(input_structure, engine=engine)
-        mu_bulk_out = output.final_energy / len(input_structure)
+        output = run.node_function(bulk_structure, engine=engine)
+        mu_bulk_out = output.final_energy / len(bulk_structure)
     else:
         mu_bulk_out = mu_bulk
     return mu_bulk_out
@@ -59,17 +66,20 @@ def calculate_surface_energy(
 ):
     """Calculate the surface energy (J/m^2) of a slab cut from ``bulk_structure``.
 
-    Builds a vacuum-free reference slab and a vacuum-padded slab from the
-    same bulk crystal, relaxes the latter with ``engine``, and divides the
-    excess energy by twice the in-plane area.
+    Cuts a slab from ``bulk_structure`` along ``miller_indices`` with ``layers``
+    repeats and ``vacuum`` padding, relaxes the slab with ``engine``, and
+    divides the excess energy by twice the in-plane area:
+
+        gamma = (E_slab - N_slab * mu_bulk) / (2 * A)
+
+    The bulk per-atom chemical potential ``mu_bulk`` is computed by relaxing
+    ``bulk_structure`` itself with ``engine`` under a "bulk_ref" subdirectory,
+    unless an explicit ``mu_bulk`` is supplied.
+
+    NOTE: prior to 2026-05-12 this macro derived ``mu_bulk`` from a relaxed
+    no-vacuum slab, which gave physically wrong (often negative) surface
+    energies because a slab with ``vacuum=0`` is not equivalent to bulk.
     """
-    wf.slab_novac = create_surface_slab(
-        bulk_structure=bulk_structure,
-        miller_indices=miller_indices,
-        layers=layers,
-        vacuum=0.0,
-        periodic=periodic,
-    )
     wf.slab_vac = create_surface_slab(
         bulk_structure=bulk_structure,
         miller_indices=miller_indices,
@@ -78,11 +88,14 @@ def calculate_surface_energy(
         periodic=periodic,
     )
     wf.calc_slab = run(wf.slab_vac, engine=engine, label="calc_slab")
-    wf.mu_bulk_out = _calculate_if_not_present_(
-        wf.slab_novac, engine=engine, mu_bulk=mu_bulk
+    wf.bulk_ref_engine = subengine(engine=engine, subdir="bulk_ref")
+    wf.mu_bulk_out = _bulk_per_atom_energy(
+        bulk_structure=bulk_structure,
+        engine=wf.bulk_ref_engine,
+        mu_bulk=mu_bulk,
     )
     wf.n_atoms_slab = get_n_atoms(wf.slab_vac)
-    wf.area_one_side = area_one_side(wf.slab_novac)
+    wf.area_one_side = area_one_side(wf.slab_vac)
     wf.surface_energy = get_surface_energy(
         E_slab=wf.calc_slab.outputs.engine_output.final_energy,
         E_bulk_per_atom=wf.mu_bulk_out,

--- a/tests/unit/physics/test_surface.py
+++ b/tests/unit/physics/test_surface.py
@@ -29,5 +29,38 @@ def test_calculate_surface_energy_runs(tmp_path):
     )
     out.run()
     se = out.outputs.surface_energy.value
-    assert se > 0
-    assert se < 5  # Cu(111) ~ 1.5 J/m^2 — generous upper bound
+    # EMT Cu(111) is ~1.0 J/m^2; DFT reports ~1.5. Bracket generously but
+    # keep the lower bound positive so the slab_novac-as-bulk-reference
+    # regression (which produced a sign-flipped result) cannot recur.
+    assert 0.3 < se < 3.0, f"Cu(111) EMT surface energy out of expected range: {se} J/m^2"
+
+
+@pytest.mark.slow
+def test_calculate_surface_energy_accepts_explicit_mu_bulk(tmp_path):
+    """When mu_bulk is supplied the macro must not relaunch a bulk calc."""
+    from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputMinimize
+    from pyiron_workflow_atomistics.physics.surface import calculate_surface_energy
+
+    cu_bulk = bulk("Cu", "fcc", a=3.6, cubic=True)
+    cu_bulk_for_ref = cu_bulk.copy()
+    cu_bulk_for_ref.calc = EMT()
+    mu_bulk_from_emt = cu_bulk_for_ref.get_potential_energy() / len(cu_bulk_for_ref)
+
+    engine = ASEEngine(
+        EngineInput=CalcInputMinimize(
+            force_convergence_tolerance=0.1, max_iterations=50
+        ),
+        calculator=EMT(),
+        working_directory=str(tmp_path),
+    )
+    out = calculate_surface_energy(
+        bulk_structure=cu_bulk,
+        engine=engine,
+        miller_indices=(1, 1, 1),
+        layers=3,
+        vacuum=8.0,
+        mu_bulk=mu_bulk_from_emt,
+    )
+    out.run()
+    se = out.outputs.surface_energy.value
+    assert 0.3 < se < 3.0


### PR DESCRIPTION
## Summary

`physics/surface.py:calculate_surface_energy` was computing `mu_bulk` from a *relaxed no-vacuum slab*, not the real bulk crystal. With `vacuum=0`, ASE's `surface()` builds a slab whose c-vector is the slab thickness — a geometry that is **not** equivalent to bulk, so the per-atom energy comes out ~1 eV/atom off. For Fe(111) BCC with `Al-Fe.eam.fs`, 4 layers, vacuum=10, this gave a sign-flipped result of **−2.314 J/m²**. The fix derives `mu_bulk` from the existing `bulk_structure` parameter instead, routed through a `subengine` "bulk_ref" subdir so the call is safe inside the macro graph. Same configuration now gives **1.973 J/m²**, in the expected range for this EAM potential (DFT says ~2.73 J/m²; EAM is known to underestimate).

This is the bug called out as Concern #2 in the cleanup-and-reorganise final review.

## Numerical evidence

Manual ASE+EAM check at the same Fe(111) BCC / 4 layers / vacuum=10 geometry:

| reference | per-atom energy | γ |
|---|---:|---:|
| True bulk Fe BCC (a=2.85, single-cell) | **−4.0128 eV/atom** | 1.97 J/m² ✅ |
| Relaxed no-vacuum slab (broken macro path) | −3.0717 eV/atom | −2.31 J/m² ❌ |

(The pre-relax no-vacuum slab energy is +56.84 eV/atom — atoms crammed in the wrong c-spacing.)

## Changes

- `pyiron_workflow_atomistics/physics/surface.py`: drop the `slab_novac` construction; rename `_calculate_if_not_present_` to `_bulk_per_atom_energy` and pass it the real `bulk_structure`; compute area from `slab_vac` (same in-plane vectors). User can still override with explicit `mu_bulk` float.
- `tests/unit/physics/test_surface.py`: tighten the existing `@slow` test to assert `0.3 < γ < 3.0` (the prior `γ > 0` bound would have caught the regression; the new bracket also flags wildly-wrong-but-positive values). Add a second test exercising the explicit `mu_bulk` path.
- `notebooks/surface_energy.ipynb`: re-executed; output line is now `Fe(111) surface energy (Al-Fe.eam.fs): 1.973 J/m^2 (0.123 eV/A^2)`.

## Test plan

- [ ] `pytest tests/unit -m "not slow"` — 87 passed + 3 pre-existing version baseline failures (unchanged)
- [ ] `pytest tests/unit/physics/test_surface.py -m slow` — both surface tests pass
- [ ] `pytest tests/integration/test_notebook_execution.py -m slow` — all 10 notebooks execute end-to-end (`~60 s` total)
- [ ] Spot-check the new surface energy value against the orange-bordered DFT-comparison note in the notebook

🤖 Generated with [Claude Code](https://claude.com/claude-code)