### PR TITLE
feat(notebooks): foundation MLIP example (MACE / GRACE) + fix vacancy formation formula

### DIFF
--- a/notebooks/foundation_model_example.ipynb
+++ b/notebooks/foundation_model_example.ipynb
@@ -1,0 +1,438 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e692499e",
+   "metadata": {},
+   "source": [
+    "# Foundation MLIPs as ASE calculators (MACE-MP & GRACE-FS)\n",
+    "\n",
+    "Demonstrates that the `Engine` Protocol composes with **any** ASE calculator, including the recent universal/foundation interatomic potentials:\n",
+    "\n",
+    "- [**MACE-MP**](https://github.com/ACEsuit/mace) — `mace.calculators.mace_mp(...)`\n",
+    "- [**GRACE-FS**](https://gracemaker.readthedocs.io) — `tensorpotential.calculator.grace_fm(...)`\n",
+    "\n",
+    "Both ship ASE-compatible calculator wrappers, so the *only* line that changes between EMT, MACE, and GRACE is the `calculator=` argument to `ASEEngine`. The physics task description (vacancy formation energy on a small FCC Al supercell, below) is identical across all three backends.\n",
+    "\n",
+    "If MACE / GRACE aren't installed, the corresponding cells skip with an `Install with: ...` hint so the notebook still runs end-to-end."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f32f42fd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T15:51:21.550167Z",
+     "iopub.status.busy": "2026-05-12T15:51:21.549686Z",
+     "iopub.status.idle": "2026-05-12T15:51:22.059829Z",
+     "shell.execute_reply": "2026-05-12T15:51:22.056361Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Al bulk: Al4, n=4\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os, warnings, logging\n",
+    "\n",
+    "# Quiet down TensorFlow / e3nn / pyiron-workflow startup chatter.\n",
+    "os.environ.setdefault(\"CUDA_VISIBLE_DEVICES\", \"\")\n",
+    "os.environ.setdefault(\"TF_CPP_MIN_LOG_LEVEL\", \"3\")\n",
+    "os.environ.setdefault(\"TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD\", \"1\")\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "logging.disable(logging.WARNING)\n",
+    "\n",
+    "from ase.build import bulk\n",
+    "from ase.calculators.emt import EMT\n",
+    "\n",
+    "from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputMinimize\n",
+    "from pyiron_workflow_atomistics.physics.point_defect import get_vacancy_formation_energy\n",
+    "\n",
+    "al_bulk = bulk(\"Al\", \"fcc\", a=4.05, cubic=True)\n",
+    "print(f\"Al bulk: {al_bulk.get_chemical_formula()}, n={len(al_bulk)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea03d5b7",
+   "metadata": {},
+   "source": [
+    "## Helper: build an ASEEngine + vacancy-formation workflow from any calculator\n",
+    "\n",
+    "The same `get_vacancy_formation_energy` macro is reused with each backend; only the `calculator=` field of the engine changes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b9f8cd2c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T15:51:22.063932Z",
+     "iopub.status.busy": "2026-05-12T15:51:22.063639Z",
+     "iopub.status.idle": "2026-05-12T15:51:22.074302Z",
+     "shell.execute_reply": "2026-05-12T15:51:22.070777Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def vacancy_e_form(calculator, label, workdir):\n",
+    "    engine = ASEEngine(\n",
+    "        EngineInput=CalcInputMinimize(force_convergence_tolerance=0.05, max_iterations=100),\n",
+    "        calculator=calculator,\n",
+    "        working_directory=workdir,\n",
+    "    )\n",
+    "    wf = get_vacancy_formation_energy(\n",
+    "        structure=al_bulk,\n",
+    "        engine=engine,\n",
+    "        min_dimensions=[8, 8, 8],  # ~3x3x3 FCC Al primitive ~ 108 atoms\n",
+    "    )\n",
+    "    wf.run()\n",
+    "    e_f = wf.outputs.vacancy_formation_energy.value\n",
+    "    print(f\"{label:8s}  E_vac_form(Al FCC) = {e_f:.3f} eV\")\n",
+    "    return e_f"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2b48f16",
+   "metadata": {},
+   "source": [
+    "## 1. EMT (classical, fast reference)\n",
+    "\n",
+    "EMT is a coarse but-always-available potential for Al/Cu/Ni/Pd/Ag/Pt/Au. It under-predicts vacancy energies versus DFT."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5f4aaf87",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T15:51:22.079075Z",
+     "iopub.status.busy": "2026-05-12T15:51:22.078706Z",
+     "iopub.status.idle": "2026-05-12T15:51:22.605284Z",
+     "shell.execute_reply": "2026-05-12T15:51:22.602306Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:51:22        0.926900        0.067070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFGS:    1 17:51:22        0.926106        0.063977\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFGS:    2 17:51:22        0.918670        0.019346\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:51:22       -0.048066        0.000000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "EMT       E_vac_form(Al FCC) = 0.965 eV\n"
+     ]
+    }
+   ],
+   "source": [
+    "e_emt = vacancy_e_form(EMT(), label=\"EMT\", workdir=\"./_fm_emt\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1695439f",
+   "metadata": {},
+   "source": [
+    "## 2. MACE-MP (universal foundation model)\n",
+    "\n",
+    "`mace_mp(model=\"small\")` downloads the universal MACE-MP-0 small foundation potential on first use (~30 MB) and caches it under `~/.cache/mace/`. Trained on Materials Project — works for any element combination in MP.\n",
+    "\n",
+    "Install: `pip install mace-torch` (or `uv pip install mace-torch`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fe950daf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T15:51:22.609682Z",
+     "iopub.status.busy": "2026-05-12T15:51:22.609318Z",
+     "iopub.status.idle": "2026-05-12T15:51:31.423436Z",
+     "shell.execute_reply": "2026-05-12T15:51:31.420548Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cuequivariance or cuequivariance_torch is not available. Cuequivariance acceleration will be disabled.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using Materials Project MACE for MACECalculator with /home/liger/.cache/mace/20231210mace128L0_energy_epoch249model\n",
+      "Using float64 for MACECalculator, which is slower but more accurate. Recommended for geometry optimization.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:51:29     -114.379872        0.134386\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFGS:    1 17:51:30     -114.382950        0.126796\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFGS:    2 17:51:31     -114.407101        0.029141\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:51:31     -118.706220        0.000000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MACE-MP   E_vac_form(Al FCC) = 0.590 eV\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    from mace.calculators import mace_mp\n",
+    "    mace_calc = mace_mp(model=\"small\", default_dtype=\"float64\", device=\"cpu\")\n",
+    "    e_mace = vacancy_e_form(mace_calc, label=\"MACE-MP\", workdir=\"./_fm_mace\")\n",
+    "except ImportError:\n",
+    "    e_mace = None\n",
+    "    print(\"MACE not installed - skipping.\\nInstall with: pip install mace-torch  (or `uv pip install mace-torch`)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eeb095db",
+   "metadata": {},
+   "source": [
+    "## 3. GRACE-FS (universal foundation model)\n",
+    "\n",
+    "`grace_fm(\"GRACE-FS-OAM\")` downloads the GRACE-FS foundation potential on first use and caches it under `~/.cache/grace/`. Trained on OMat24 + sAlex + MPTraj — typically faster than MACE-MP on CPU thanks to a compact graph formulation.\n",
+    "\n",
+    "Install: `pip install tensorpotential` (or `uv pip install tensorpotential`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e4fe790d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T15:51:31.427071Z",
+     "iopub.status.busy": "2026-05-12T15:51:31.426738Z",
+     "iopub.status.idle": "2026-05-12T15:51:49.282547Z",
+     "shell.execute_reply": "2026-05-12T15:51:49.279280Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[tensorpotential] Info: Environment variable TF_USE_LEGACY_KERAS is automatically set to '1'.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+      "E0000 00:00:1778601091.957808  144665 cuda_dnn.cc:8579] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
+      "E0000 00:00:1778601091.963574  144665 cuda_blas.cc:1407] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
+      "W0000 00:00:1778601091.981449  144665 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+      "W0000 00:00:1778601091.981486  144665 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+      "W0000 00:00:1778601091.981489  144665 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+      "W0000 00:00:1778601091.981491  144665 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using cached GRACE model from /home/liger/.cache/grace/GRACE-FS-OAM\n",
+      "Model license: Academic Software License\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+      "I0000 00:00:1778601099.077412  144665 service.cc:152] XLA service 0x585292a7c610 initialized for platform Host (this does not guarantee that XLA will be used). Devices:\n",
+      "I0000 00:00:1778601099.077558  144665 service.cc:160]   StreamExecutor device (0): Host, Default Version\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:51:43     -115.172399        0.128413\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0000 00:00:1778601103.909415  144665 device_compiler.h:188] Compiled cluster using XLA!  This line is logged at most once for the lifetime of the process.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFGS:    1 17:51:44     -115.175619        0.122301\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFGS:    2 17:51:44     -115.204123        0.023990\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:51:49     -119.204487        0.000000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GRACE-FS  E_vac_form(Al FCC) = 0.275 eV\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    from tensorpotential.calculator import grace_fm\n",
+    "    grace_calc = grace_fm(\"GRACE-FS-OAM\")\n",
+    "    e_grace = vacancy_e_form(grace_calc, label=\"GRACE-FS\", workdir=\"./_fm_grace\")\n",
+    "except ImportError:\n",
+    "    e_grace = None\n",
+    "    print(\"GRACE / tensorpotential not installed - skipping.\\nInstall with: pip install tensorpotential  (or `uv pip install tensorpotential`)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25b4bec8",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "Same `get_vacancy_formation_energy` macro, same `al_bulk` structure, three calculators. Foundation MLIPs (MACE, GRACE) target DFT-PBE quality (~0.6 eV for Al vacancy in PBE); EMT systematically under-predicts.\n",
+    "\n",
+    "To plug in your own potential — Quip GAP, NequIP, Allegro, an ASE-wrapped DFT code, anything — just hand its ASE calculator to `ASEEngine(calculator=...)` and reuse the rest."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "275eea6f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-12T15:51:49.287419Z",
+     "iopub.status.busy": "2026-05-12T15:51:49.286897Z",
+     "iopub.status.idle": "2026-05-12T15:51:49.297532Z",
+     "shell.execute_reply": "2026-05-12T15:51:49.294626Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "backend      E_vac (eV)\n",
+      "-----------------------\n",
+      "EMT        0.9652331842740964\n",
+      "MACE-MP    0.5895501101056055\n",
+      "GRACE-FS   0.27522344315511305\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"{'backend':10s} {'E_vac (eV)':>12s}\")\n",
+    "print(\"-\" * 23)\n",
+    "for label, val in [(\"EMT\", e_emt), (\"MACE-MP\", e_mace), (\"GRACE-FS\", e_grace)]:\n",
+    "    print(f\"{label:10s} {val if val is not None else 'skipped':>12}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/foundation_model_example.ipynb
+++ b/notebooks/foundation_model_example.ipynb
@@ -23,10 +23,10 @@
    "id": "f32f42fd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T15:51:21.550167Z",
-     "iopub.status.busy": "2026-05-12T15:51:21.549686Z",
-     "iopub.status.idle": "2026-05-12T15:51:22.059829Z",
-     "shell.execute_reply": "2026-05-12T15:51:22.056361Z"
+     "iopub.execute_input": "2026-05-12T15:59:16.367580Z",
+     "iopub.status.busy": "2026-05-12T15:59:16.367053Z",
+     "iopub.status.idle": "2026-05-12T15:59:18.447083Z",
+     "shell.execute_reply": "2026-05-12T15:59:18.443659Z"
     }
    },
    "outputs": [
@@ -74,10 +74,10 @@
    "id": "b9f8cd2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T15:51:22.063932Z",
-     "iopub.status.busy": "2026-05-12T15:51:22.063639Z",
-     "iopub.status.idle": "2026-05-12T15:51:22.074302Z",
-     "shell.execute_reply": "2026-05-12T15:51:22.070777Z"
+     "iopub.execute_input": "2026-05-12T15:59:18.452432Z",
+     "iopub.status.busy": "2026-05-12T15:59:18.452072Z",
+     "iopub.status.idle": "2026-05-12T15:59:18.461727Z",
+     "shell.execute_reply": "2026-05-12T15:59:18.458835Z"
     }
    },
    "outputs": [],
@@ -115,10 +115,10 @@
    "id": "5f4aaf87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T15:51:22.079075Z",
-     "iopub.status.busy": "2026-05-12T15:51:22.078706Z",
-     "iopub.status.idle": "2026-05-12T15:51:22.605284Z",
-     "shell.execute_reply": "2026-05-12T15:51:22.602306Z"
+     "iopub.execute_input": "2026-05-12T15:59:18.467133Z",
+     "iopub.status.busy": "2026-05-12T15:59:18.466805Z",
+     "iopub.status.idle": "2026-05-12T15:59:18.812643Z",
+     "shell.execute_reply": "2026-05-12T15:59:18.809564Z"
     }
    },
    "outputs": [
@@ -127,21 +127,7 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:51:22        0.926900        0.067070\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    1 17:51:22        0.926106        0.063977\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    2 17:51:22        0.918670        0.019346\n"
+      "BFGS:    0 17:59:18       -0.048066        0.000000\n"
      ]
     },
     {
@@ -149,7 +135,21 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:51:22       -0.048066        0.000000\n"
+      "BFGS:    0 17:59:18        0.926900        0.067070\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFGS:    1 17:59:18        0.926106        0.063977\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFGS:    2 17:59:18        0.918670        0.019346\n"
      ]
     },
     {
@@ -182,10 +182,10 @@
    "id": "fe950daf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T15:51:22.609682Z",
-     "iopub.status.busy": "2026-05-12T15:51:22.609318Z",
-     "iopub.status.idle": "2026-05-12T15:51:31.423436Z",
-     "shell.execute_reply": "2026-05-12T15:51:31.420548Z"
+     "iopub.execute_input": "2026-05-12T15:59:18.825597Z",
+     "iopub.status.busy": "2026-05-12T15:59:18.824949Z",
+     "iopub.status.idle": "2026-05-12T15:59:28.141770Z",
+     "shell.execute_reply": "2026-05-12T15:59:28.138808Z"
     }
    },
    "outputs": [
@@ -209,21 +209,7 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:51:29     -114.379872        0.134386\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    1 17:51:30     -114.382950        0.126796\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    2 17:51:31     -114.407101        0.029141\n"
+      "BFGS:    0 17:59:26     -118.706220        0.000000\n"
      ]
     },
     {
@@ -231,7 +217,21 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:51:31     -118.706220        0.000000\n"
+      "BFGS:    0 17:59:27     -114.379872        0.134386\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFGS:    1 17:59:27     -114.382950        0.126796\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFGS:    2 17:59:28     -114.407101        0.029141\n"
      ]
     },
     {
@@ -270,10 +270,10 @@
    "id": "e4fe790d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T15:51:31.427071Z",
-     "iopub.status.busy": "2026-05-12T15:51:31.426738Z",
-     "iopub.status.idle": "2026-05-12T15:51:49.282547Z",
-     "shell.execute_reply": "2026-05-12T15:51:49.279280Z"
+     "iopub.execute_input": "2026-05-12T15:59:28.146993Z",
+     "iopub.status.busy": "2026-05-12T15:59:28.146584Z",
+     "iopub.status.idle": "2026-05-12T15:59:40.168991Z",
+     "shell.execute_reply": "2026-05-12T15:59:40.165486Z"
     }
    },
    "outputs": [
@@ -289,12 +289,12 @@
      "output_type": "stream",
      "text": [
       "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
-      "E0000 00:00:1778601091.957808  144665 cuda_dnn.cc:8579] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
-      "E0000 00:00:1778601091.963574  144665 cuda_blas.cc:1407] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
-      "W0000 00:00:1778601091.981449  144665 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
-      "W0000 00:00:1778601091.981486  144665 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
-      "W0000 00:00:1778601091.981489  144665 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
-      "W0000 00:00:1778601091.981491  144665 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n"
+      "E0000 00:00:1778601568.738634  148815 cuda_dnn.cc:8579] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
+      "E0000 00:00:1778601568.746124  148815 cuda_blas.cc:1407] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
+      "W0000 00:00:1778601568.762432  148815 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+      "W0000 00:00:1778601568.762472  148815 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+      "W0000 00:00:1778601568.762475  148815 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
+      "W0000 00:00:1778601568.762477  148815 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n"
      ]
     },
     {
@@ -310,8 +310,8 @@
      "output_type": "stream",
      "text": [
       "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
-      "I0000 00:00:1778601099.077412  144665 service.cc:152] XLA service 0x585292a7c610 initialized for platform Host (this does not guarantee that XLA will be used). Devices:\n",
-      "I0000 00:00:1778601099.077558  144665 service.cc:160]   StreamExecutor device (0): Host, Default Version\n"
+      "I0000 00:00:1778601574.527422  148815 service.cc:152] XLA service 0x58f69f3f6240 initialized for platform Host (this does not guarantee that XLA will be used). Devices:\n",
+      "I0000 00:00:1778601574.527612  148815 service.cc:160]   StreamExecutor device (0): Host, Default Version\n"
      ]
     },
     {
@@ -319,36 +319,36 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:51:43     -115.172399        0.128413\n"
+      "BFGS:    0 17:59:39     -119.204487        0.000000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:59:39     -115.172399        0.128413\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "I0000 00:00:1778601103.909415  144665 device_compiler.h:188] Compiled cluster using XLA!  This line is logged at most once for the lifetime of the process.\n"
+      "I0000 00:00:1778601579.642611  148815 device_compiler.h:188] Compiled cluster using XLA!  This line is logged at most once for the lifetime of the process.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    1 17:51:44     -115.175619        0.122301\n"
+      "BFGS:    1 17:59:39     -115.175619        0.122301\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    2 17:51:44     -115.204123        0.023990\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:51:49     -119.204487        0.000000\n"
+      "BFGS:    2 17:59:40     -115.204123        0.023990\n"
      ]
     },
     {
@@ -387,10 +387,10 @@
    "id": "275eea6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T15:51:49.287419Z",
-     "iopub.status.busy": "2026-05-12T15:51:49.286897Z",
-     "iopub.status.idle": "2026-05-12T15:51:49.297532Z",
-     "shell.execute_reply": "2026-05-12T15:51:49.294626Z"
+     "iopub.execute_input": "2026-05-12T15:59:40.173577Z",
+     "iopub.status.busy": "2026-05-12T15:59:40.173167Z",
+     "iopub.status.idle": "2026-05-12T15:59:40.187505Z",
+     "shell.execute_reply": "2026-05-12T15:59:40.183993Z"
     }
    },
    "outputs": [
@@ -402,7 +402,7 @@
       "-----------------------\n",
       "EMT        0.9652331842740964\n",
       "MACE-MP    0.5895501101056055\n",
-      "GRACE-FS   0.27522344315511305\n"
+      "GRACE-FS   0.2752234431551557\n"
      ]
     }
    ],

--- a/notebooks/vacancy_formation_energy.ipynb
+++ b/notebooks/vacancy_formation_energy.ipynb
@@ -21,10 +21,10 @@
    "id": "a3b24a65",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:53:17.030290Z",
-     "iopub.status.busy": "2026-05-12T12:53:17.029937Z",
-     "iopub.status.idle": "2026-05-12T12:53:18.697725Z",
-     "shell.execute_reply": "2026-05-12T12:53:18.694147Z"
+     "iopub.execute_input": "2026-05-12T15:56:05.237736Z",
+     "iopub.status.busy": "2026-05-12T15:56:05.237319Z",
+     "iopub.status.idle": "2026-05-12T15:56:07.193562Z",
+     "shell.execute_reply": "2026-05-12T15:56:07.189830Z"
     }
    },
    "outputs": [],
@@ -58,10 +58,10 @@
    "id": "02d7dc02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:53:18.701459Z",
-     "iopub.status.busy": "2026-05-12T12:53:18.700882Z",
-     "iopub.status.idle": "2026-05-12T12:53:23.458955Z",
-     "shell.execute_reply": "2026-05-12T12:53:23.455751Z"
+     "iopub.execute_input": "2026-05-12T15:56:07.198180Z",
+     "iopub.status.busy": "2026-05-12T15:56:07.197447Z",
+     "iopub.status.idle": "2026-05-12T15:56:12.605682Z",
+     "shell.execute_reply": "2026-05-12T15:56:12.603117Z"
     }
    },
    "outputs": [
@@ -69,8 +69,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 14:53:19     -216.690138        0.000000\n"
+      "supercell: 54 Fe atoms\n"
      ]
     },
     {
@@ -78,46 +77,62 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 14:53:20     -210.847774        0.368379\n"
+      "BFGS:    0 17:56:08     -216.690138        0.000000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    1 14:53:21     -210.864488        0.330939\n"
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:56:08     -210.847774        0.368379\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    2 14:53:21     -210.942616        0.131664\n"
+      "BFGS:    1 17:56:09     -210.864488        0.330939\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    3 14:53:22     -210.947698        0.119259\n"
+      "BFGS:    2 17:56:10     -210.942616        0.131664\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    4 14:53:23     -210.961581        0.038241\n"
+      "BFGS:    3 17:56:11     -210.947698        0.119259\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Vacancy formation energy (E_vac - E_bulk) of Fe in BCC Fe (Al-Fe.eam.fs): 5.729 eV\n"
+      "BFGS:    4 17:56:12     -210.961581        0.038241\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Vacancy formation energy of Fe in BCC Fe (Al-Fe.eam.fs): 1.716 eV\n"
      ]
     }
    ],
    "source": [
+    "# Pre-build the supercell so we know N at workflow-construction time —\n",
+    "# the corrected formula E_f = E_vac - ((N-1)/N) * E_bulk needs N as a scalar.\n",
+    "fe_supercell = create_supercell_with_min_dimensions.node_function(\n",
+    "    bulk(\"Fe\", a=2.85, cubic=True), min_dimensions=[7, 7, 7]\n",
+    ")\n",
+    "n_atoms_supercell = len(fe_supercell)\n",
+    "print(f\"supercell: {n_atoms_supercell} Fe atoms\")\n",
+    "\n",
     "wf = Workflow(\"vacancy_formation_energy\")\n",
     "wf.supercell = create_supercell_with_min_dimensions(\n",
     "    bulk(\"Fe\", a=2.85, cubic=True), min_dimensions=[7, 7, 7]\n",
@@ -132,12 +147,12 @@
     "wf.E_form = calculate_vacancy_formation_energy(\n",
     "    vacancy_energy=wf.calc_vac.outputs.engine_output.final_energy,\n",
     "    supercell_energy=wf.calc_bulk.outputs.engine_output.final_energy,\n",
+    "    n_atoms_supercell=n_atoms_supercell,\n",
     ")\n",
     "wf.run()\n",
     "\n",
     "e_f = wf.E_form.outputs.formation_energy.value\n",
-    "print(f\"Vacancy formation energy (E_vac - E_bulk) of Fe in BCC Fe \"\n",
-    "      f\"(Al-Fe.eam.fs): {e_f:.3f} eV\")\n"
+    "print(f\"Vacancy formation energy of Fe in BCC Fe (Al-Fe.eam.fs): {e_f:.3f} eV\")"
    ]
   }
  ],

--- a/pyiron_workflow_atomistics/physics/point_defect.py
+++ b/pyiron_workflow_atomistics/physics/point_defect.py
@@ -15,21 +15,35 @@ from pyiron_workflow_atomistics.structure.transform import (
 )
 
 
+@pwf.as_function_node("n_atoms")
+def _count_atoms(structure: Atoms) -> int:
+    n_atoms = len(structure)
+    return n_atoms
+
+
 @pwf.as_function_node("formation_energy")
 def calculate_vacancy_formation_energy(
-    vacancy_energy: float, supercell_energy: float
+    vacancy_energy: float,
+    supercell_energy: float,
+    n_atoms_supercell: int,
 ) -> float:
-    """Vacancy formation energy as the bare difference (preserves the
-    existing semantics in ``bulk_defect/vacancy.py``).
+    """Vacancy formation energy with the correct (N−1)/N normalisation.
 
-    NOTE: the textbook formula uses the per-atom chemical potential
-    ``mu_bulk`` rather than the bulk supercell energy
-    (E_f = E_vac − (N−1)·mu_bulk). The current macro intentionally keeps
-    the simpler ``vacancy − supercell`` form for backwards compatibility;
-    switching to the (N−1)/N normalisation is tracked as a separate
-    physics improvement — out of scope for the cleanup.
+    .. math:: E_\\mathrm{f} = E_\\mathrm{vac} - \\frac{N-1}{N} E_\\mathrm{bulk}
+
+    where ``E_bulk`` is the perfect-supercell total energy with ``N`` atoms,
+    and ``E_vac`` is the supercell energy with one atom removed. Equivalent
+    to the textbook form ``E_vac − (N−1)·mu_bulk`` where
+    ``mu_bulk = E_bulk / N``.
+
+    The previous bare ``E_vac − E_bulk`` form was off by exactly ``mu_bulk``
+    (~3.7 eV/atom for typical foundation MLIPs in DFT-PBE; ~0.005 eV/atom
+    for EMT, which is why the bug was invisible against classical
+    references).
     """
-    formation_energy = vacancy_energy - supercell_energy
+    formation_energy = (
+        vacancy_energy - (n_atoms_supercell - 1) / n_atoms_supercell * supercell_energy
+    )
     return formation_energy
 
 
@@ -39,7 +53,7 @@ def get_vacancy_formation_energy(
     structure: Atoms,
     engine: Engine,
     remove_atom_index: int = 0,
-    min_dimensions: list = None,
+    min_dimensions: list | None = None,
     vacancy_subdir: str = "vacancy",
     supercell_subdir: str = "supercell",
 ):
@@ -65,9 +79,11 @@ def get_vacancy_formation_energy(
     wf.vacancy_calc = run(
         wf.structure_with_vacancy, engine=wf.vacancy_engine, label="vacancy_calc"
     )
+    wf.n_atoms_supercell = _count_atoms(wf.structure_supercell)
     wf.vacancy_formation_energy = calculate_vacancy_formation_energy(
         vacancy_energy=wf.vacancy_calc.outputs.engine_output.final_energy,
         supercell_energy=wf.supercell_calc.outputs.engine_output.final_energy,
+        n_atoms_supercell=wf.n_atoms_supercell,
     )
     return wf.supercell_calc, wf.vacancy_calc, wf.vacancy_formation_energy
 
@@ -91,7 +107,7 @@ def get_substitutional_formation_energy(
     new_symbol: str = "Ni",
     mu_solute: float = 0.0,
     mu_host: float = 0.0,
-    min_dimensions: list = None,
+    min_dimensions: list | None = None,
     sub_subdir: str = "substitutional",
     supercell_subdir: str = "supercell",
 ):


### PR DESCRIPTION
## Summary

Two related changes:

### 1. `notebooks/foundation_model_example.ipynb` (new)

Demonstrates that the `Engine` Protocol composes with **any** ASE-compatible calculator, including the recent universal/foundation MLIPs:

- [**MACE-MP**](https://github.com/ACEsuit/mace) via `mace.calculators.mace_mp(model=\"small\", default_dtype=\"float64\")`
- [**GRACE-FS**](https://gracemaker.readthedocs.io) via `tensorpotential.calculator.grace_fm(\"GRACE-FS-OAM\")`

Same physics task — vacancy formation in a small FCC Al supercell — run with EMT, MACE-MP, and GRACE-FS side-by-side. Notebook gracefully skips MACE/GRACE sections (with install hints) if the packages aren't installed, so it executes end-to-end in any environment. Runs in ~30 s on CPU after the foundation-model weights are cached.

| backend  | E_vac(Al FCC) | reference |
|----------|--------------:|-----------|
| EMT       | 0.965 eV | (classical) |
| MACE-MP   | 0.590 eV | DFT-PBE literature ~0.6 eV ✅ |
| GRACE-FS  | 0.275 eV | (foundation-model dependent) |

### 2. Fix: `calculate_vacancy_formation_energy` formula

The previous implementation used the bare difference `E_vac - E_bulk`. The docstring even acknowledged it disagreed with the textbook formula but kept it \"for backwards compatibility.\" The bug was invisible against EMT (energy zero ~0) but wildly wrong against any DFT-zero potential — the foundation-model demo originally printed `E_vac(Al) = 4.30 eV` instead of the literature `~0.6 eV`.

After: `E_f = E_vac - ((N-1)/N) * E_bulk`, equivalent to the textbook `E_vac - (N-1) * mu_bulk` with `mu_bulk = E_bulk / N`. The macro plumbs `n_atoms_supercell` automatically via a private `_count_atoms` function-node. Direct callers (e.g. `notebooks/vacancy_formation_energy.ipynb`) precompute the supercell and pass `n_atoms_supercell` as a scalar.

| | E_vac before | E_vac after | reference |
|---|---:|---:|---|
| EMT (Al) | 0.97 eV | 0.97 eV | (n/a) |
| MACE-MP (Al) | 4.30 eV | 0.59 eV | DFT-PBE ~0.6 eV |
| GRACE-FS (Al) | 4.00 eV | 0.28 eV | |
| EAM Fe BCC | 5.73 eV | **1.72 eV** | literature 1.55–1.8 eV ✅ |

### Bonus

Also fixed `min_dimensions: list = None` → `list | None = None` on the two `point_defect` macros — same B006-fix-broke-the-type-hint pattern I hit in `bulk.py:generate_structures`. pyiron_workflow 0.15.6 strict type-checking rejects the None default.

## Test plan

- [ ] `pytest tests/unit -m \"not slow\"` — 87 passed + 3 pre-existing version baseline failures (unchanged)
- [ ] `pytest tests/integration/test_notebook_execution.py -m slow` — all 11 notebooks execute end-to-end (~2 min) including the new foundation_model_example.ipynb
- [ ] Spot-check the foundation_model_example output table against DFT-PBE Al vacancy value ~0.6 eV
- [ ] Confirm `pip install mace-torch` and `pip install tensorpotential` (or `uv pip install ...`) bring in the optional foundation-model backends

🤖 Generated with [Claude Code](https://claude.com/claude-code)