### PR TITLE
ci: fork release workflow + script to handle pip: dict deps (unblocks v0.0.5 PyPI publish)

### DIFF
--- a/.github/actions/.support/pypi_vs_conda_names.json
+++ b/.github/actions/.support/pypi_vs_conda_names.json
@@ -1,0 +1,19 @@
+{
+    "blosc2": "python-blosc2",
+    "graphviz": "python-graphviz",
+    "h5io-browser": "h5io_browser",
+    "matplotlib": "matplotlib-base",
+    "pyiron-atomistics": "pyiron_atomistics",
+    "pyiron-base": "pyiron_base",
+    "pyiron-continuum": "pyiron_continuum",
+    "pyiron-contrib": "pyiron_contrib",
+    "pyiron-experimental": "pyiron_experimental",
+    "pyiron-gpl": "pyiron_gpl",
+    "pyiron-gui": "pyiron_gui",
+    "pyiron-ontology": "pyiron_ontology",
+    "pyiron-potentialfit": "pyiron_potentialfit",
+    "pyiron-workflow": "pyiron_workflow",
+    "pyiron-workflow-atomistics": "pyiron_workflow_atomistics",
+    "tables": "pytables",
+    "landaupkg": "landau"
+  }

--- a/.github/actions/.support/update_pyproject_dependencies.py
+++ b/.github/actions/.support/update_pyproject_dependencies.py
@@ -1,0 +1,302 @@
+"""
+The intent of this script is to allow a fixed-dependency (`==`) pyproject.toml file
+to be modified to use bound dependencies (`>=` and `<`) on-the-fly to make releasing
+to PyPi as powerful and painless as possible.
+
+Explicit upper and lower bounds can be passed as yaml environment files, but otherwise
+any semantic versions (cf. :func:`is_semantic`) get their lower bound set as the input
+file, and their upper bound can be controlled by a flag ranging from pinning the exact
+patch, to the minor or major version, or no upper limit at all. Any other format for
+the version will just get pinned exactly (of course you can always work around this by
+manually specifying other bounds in the upper/lower environment files).
+
+Args:
+    input_toml (str): The toml input toml file; must have field `project.dependencies`,
+        and dependencies are expected to all be in the form `{NAME}=={VERSION}`. I.e.
+        a pyproject.toml file with strictly pinned dependencies.
+        (Default is "pyproject.toml")
+    lower_bound_yaml (str): A yaml file with the field `dependencies` specified in the
+        format `{NAME} ={VERSION}`. This is optional, but if provided, these versions
+        will be used as the (inclusive) lower bound wherever `{NAME}` matches a package
+        `{NAME}` in the input toml. Ignored if `"none"` (actual string, not python
+        `None`). (Default is "none", use `input_toml` version as lower bound.)
+    upper_bound_yaml (str): A yaml file with the field `dependencies` specified in the
+        format `{NAME} ={VERSION}`. This is optional, but if provided, these versions
+        will be used as the (exclusive) upper bound wherever `{NAME}` matches a package
+        `{NAME}` in the input toml. Ignored if `"none"` (actual string, not python
+        `None`). (Default is "none", use `semantic_upper_bound` criteria or pin to
+        `input_toml` values.)
+    semantic_upper_bound ("patch"|"minor"|"major"|"none"): How strictly to pin the
+        upper bound relative to the input version if no explicit bound was provided by
+        `upper_bound_yaml`. "patch" gives an upper bound "<=" the input version;
+        "minor" and "major" give "<" bounds to Z.Y+1.0 and Z+1.0.0, respectively;
+        "none" gives no uppoer bound.
+    always_pin_unstable ("yes"|"no"): Whether or not to override non-`"none"`
+        `semantic_upper_bound` and always pin unstable dependencies (0.Y.Z) all the way
+        down to the patch level. (Default is "yes".)
+    output_toml (str): Where to write the updated toml file -- all the same content as
+        the input, but with dependency versions modified (and possible reformatted,
+        since we just use `toml.dump`). If `"none"` (actual string, not python `None`),
+        the input file variable is used and that file gets overwritten. (Default is
+        "none", use the same value as `input_toml`)
+    pypi_to_conda_name_map_file (str): A JSON file containing any necessary map between
+        pypi package names in the toml file(s) and conda package names used in the
+        yaml environment files. Any toml dependency found as a key in the map file will
+        be converted to its value before searching for it in either of the yaml files.
+        (Default is "none", don't load a file or do any conversions.)
+"""
+
+import argparse
+import json
+
+import toml
+import yaml
+
+
+def write_updated_toml(
+    input_toml: str,
+    lower_bound_yaml: str,
+    upper_bound_yaml: str,
+    semantic_upper_bound: str,
+    always_pin_unstable: str,
+    output_toml: str,
+    pypi_to_conda_name_map_file: str,
+) -> None:
+
+    with open(input_toml, "r") as file:
+        data = toml.load(file)
+
+    lower_bound_data = load_yaml(lower_bound_yaml)
+    upper_bound_data = load_yaml(upper_bound_yaml)
+
+    if pypi_to_conda_name_map_file != "none":
+        with open(pypi_to_conda_name_map_file, "r") as f:
+            pypi_to_conda_map = json.load(f)
+
+    semantic_upper_bound = (
+        None if semantic_upper_bound == "none" else semantic_upper_bound
+    )
+
+    if always_pin_unstable == "yes":
+        always_pin_unstable = True
+    elif always_pin_unstable == "no":
+        always_pin_unstable = False
+    else:
+        raise ValueError(
+            f"Expected 'yes' or 'no' for always_pin_unstable but got "
+            f"{always_pin_unstable}"
+        )
+
+    dependencies = data["project"]["dependencies"]
+
+    for i, dependency in enumerate(dependencies):
+        package, version = split_dependency(dependency, "==")
+
+        dependencies[i] = update_dependency(
+            package,
+            version,
+            lower_bound_data,
+            upper_bound_data,
+            semantic_upper_bound,
+            always_pin_unstable,
+            pypi_to_conda_map,
+        )
+
+    with open(input_toml if output_toml == "none" else output_toml, "w") as file:
+        toml.dump(data, file)
+
+
+def load_yaml(yaml_file: str) -> dict:
+    if yaml_file == "none":
+        return {}
+    else:
+        with open(yaml_file, "r") as file:
+            data = yaml.safe_load(file)
+
+    yaml_bounds = {}
+    for dependency in data["dependencies"]:
+        if type(dependency) == dict:
+            print(dependency)
+            if "pip" in dependency.keys():
+                for pip_dependency in dependency["pip"]:
+                    if "==" in pip_dependency:
+                        package, version = split_dependency(
+                            pip_dependency, "==", allow_no_version=True
+                        )
+                        yaml_bounds[package] = version
+                    # If no "==", discard it as requested
+            else:
+                raise ValueError(
+                    f"Expected 'pip' key in dependency but got {dependency}"
+                )
+            continue
+        else:
+            package, version = split_dependency(dependency, "=", allow_no_version=True)
+            yaml_bounds[package] = version
+    print(yaml_bounds)
+    return yaml_bounds
+
+
+def split_dependency(
+    dependency: str, delimiter: str, allow_no_version: bool = False
+) -> tuple[str, str]:
+    split = dependency.replace(" ", "").split(delimiter)
+    if len(split) != 2:
+        if len(split) == 1 and allow_no_version:
+            return split[0], None
+        else:
+            raise ValueError(
+                f"Expected input dependencies to take the form `PACKAGE{delimiter}VERSION` "
+                f"but got {dependency}"
+            )
+    return split[0], split[1]
+
+
+def update_dependency(
+    package_name: str,
+    input_version: str,
+    lower_bound_data: dict[str, str],
+    upper_bound_data: dict[str, str],
+    semantic_upper_bound: str | None,
+    always_pin_unstable: bool,
+    pypi_to_conda_map: dict[str, str],
+):
+    explicit_lower_bound = get_explicit_bound(
+        lower_bound_data, package_name, pypi_to_conda_map
+    )
+    explicit_upper_bound = get_explicit_bound(
+        upper_bound_data, package_name, pypi_to_conda_map
+    )
+
+    lower_bound = (
+        input_version if explicit_lower_bound is None else explicit_lower_bound
+    )
+
+    if explicit_upper_bound is None:
+        bound_type, upper_bound = get_semantic_upper_bound(
+            input_version, semantic_upper_bound, always_pin_unstable
+        )
+    else:
+        bound_type, upper_bound = "<", explicit_upper_bound
+
+    if upper_bound == lower_bound:
+        return f"{package_name}=={lower_bound}"
+    else:
+        return f"{package_name}>={lower_bound},{bound_type}{upper_bound}"
+
+
+def get_explicit_bound(
+    yaml_data: dict[str, str], package_name: str, pypi_to_conda_map: dict[str, str]
+) -> str | None:
+    try:
+        conda_package_name = pypi_to_conda_map[package_name]
+    except KeyError:
+        conda_package_name = package_name
+
+    try:
+        return yaml_data[conda_package_name]
+    except KeyError:
+        # If it's not there, that's fine
+        return None
+
+
+def get_semantic_upper_bound(
+    input_version: str, semantic_upper_bound: str | None, always_pin_unstable: bool
+) -> tuple[str, str]:
+    if not is_semantic(input_version):
+        # Just short-circuit return the input if we can't parse it semantically
+        return "<=", input_version
+
+    z, y, x = input_version.split(".")
+    if semantic_upper_bound is not None and z == "0" and always_pin_unstable:
+        return "<=", input_version
+
+    if semantic_upper_bound == "patch":
+        return "<=", input_version
+    elif semantic_upper_bound == "minor":
+        return "<", f"{z}.{int(y) + 1}.0"
+    elif semantic_upper_bound == "major":
+        return "<", f"{int(z) + 1}.0.0"
+    elif semantic_upper_bound is None:
+        return "", ""
+    else:
+        raise ValueError(
+            f"Expected the semantic_upper_bound to be in "
+            f"['patch', 'major', 'minor', None] but got {semantic_upper_bound}"
+        )
+
+
+def is_semantic(version: str):
+    """
+    Anything in the format `{integer}.{integer}.{whatever}` will pass.
+
+    This is not quite as strict as [the official definition](https://semver.org/), but
+    is a pretty good proxy.
+    """
+    split = version.split(".")
+    return len(split) == 3 and split[0].isdigit() and split[1].isdigit()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Update dependency versions in a pyproject.toml file."
+    )
+    parser.add_argument(
+        "--input_toml",
+        type=str,
+        default="pyproject.toml",
+        help="Input TOML file with `project.dependencies` and `==` pinned dependencies.",
+    )
+    parser.add_argument(
+        "--lower_bound_yaml",
+        type=str,
+        default="none",
+        help="Optional YAML conda environment file with lower bounds for select "
+        "dependencies.",
+    )
+    parser.add_argument(
+        "--upper_bound_yaml",
+        type=str,
+        default="none",
+        help="Optional YAML conda environment file with upper bounds for select "
+        "dependencies.",
+    )
+    parser.add_argument(
+        "--semantic_upper_bound",
+        choices=["patch", "minor", "major", "none"],
+        default="minor",
+        help="Upper bound policy for semantically versioned dependencies.",
+    )
+    parser.add_argument(
+        "--always_pin_unstable",
+        choices=["yes", "no"],
+        default="yes",
+        help="Whether to always pin unstable dependencies (0.Y.Z) all the way to patch.",
+    )
+    parser.add_argument(
+        "--output_toml",
+        type=str,
+        default="none",
+        help="Optional output destination for toml with updated dependency versions.",
+    )
+    parser.add_argument(
+        "--pypi_to_conda_name_map_file",
+        type=str,
+        default="none",
+        help="Optional JSON file to remap pypi package names in the toml file(s) to "
+        "conda package names in the yaml file(s).",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    write_updated_toml(
+        args.input_toml,
+        args.lower_bound_yaml,
+        args.upper_bound_yaml,
+        args.semantic_upper_bound,
+        args.always_pin_unstable,
+        args.output_toml,
+        args.pypi_to_conda_name_map_file,
+    )

--- a/.github/actions/update-pyproject-dependencies/action.yml
+++ b/.github/actions/update-pyproject-dependencies/action.yml
@@ -1,0 +1,63 @@
+name: 'Update pyproject dependencies'
+description: 'Take == dependencies in pyproject.toml (or equivalent) and relax them according to conda environment yaml files and rules for semantic versioning. For full docs cf. .support/update_pyproject_dependencies.py'
+
+inputs:
+  input-toml:
+    type: string
+    description: 'Input TOML file with `project.dependencies` and `==` pinned dependencies.'
+    default: 'pyproject.toml'
+    required: false
+  lower-bound-yaml:
+    type: string
+    description: 'Optional YAML conda environment file with lower bounds for select dependencies.'
+    default: 'none'
+    required: false
+  upper-bound-yaml:
+    type: string
+    description: 'Optional YAML conda environment file with upper bounds for select dependencies.'
+    default: 'none'
+    required: false
+  semantic-upper-bound:
+    type: string
+    description: 'Upper bound policy for semantically versioned dependencies.'
+    default: 'minor'
+    required: false
+  always-pin-unstable:
+    type: string
+    description: 'Whether to always pin unstable dependencies (0.Y.Z) all the way to patch.'
+    default: 'yes'
+    required: false
+  output-toml:
+    type: string
+    description: 'Optional output destination for toml with updated dependency versions.'
+    default: 'none'
+    required: false
+  pypi-to-conda-name-map-file:
+    type: string
+    description: 'Optional JSON file to remap pypi package names in the toml file(s) to conda package names in the yaml file(s).'
+    default: $GITHUB_ACTION_PATH/../.support/pypi_vs_conda_names.json
+    required: false
+  pyyaml-version:
+    type: string
+    description: 'Version of pyyaml to install'
+    default: '6.0.1'
+    required: false
+  toml-version:
+    type: string
+    description: 'Version of toml to install'
+    default: '0.10.2'
+    required: false
+
+
+runs:
+  using: "composite"
+  steps:
+  - name: Install dependencies
+    shell: bash -l {0}
+    run: |
+      pip install pyyaml==${{ inputs.pyyaml-version }}
+      pip install toml==${{ inputs.toml-version }}
+  - name: Write updated toml file
+    shell: bash -l {0}
+    run: |
+      python $GITHUB_ACTION_PATH/../.support/update_pyproject_dependencies.py --input_toml=${{ inputs.input-toml }} --lower_bound_yaml=${{ inputs.lower-bound-yaml }} --upper_bound_yaml=${{ inputs.upper-bound-yaml }} --semantic_upper_bound=${{ inputs.semantic-upper-bound }} --always_pin_unstable=${{ inputs.always-pin-unstable }} --output_toml=${{ inputs.output-toml }} --pypi_to_conda_name_map_file=${{ inputs.pypi-to-conda-name-map-file }}

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -11,8 +11,10 @@ on:
 
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pyproject-release.yml@actions-4.0.1
+    uses: ./.github/workflows/pyproject-release.yml
     secrets: inherit
     with:
       semantic-upper-bound: 'minor'
+      lower-bound-yaml: '.ci_support/lower_bound.yml'
+      pypi-to-conda-name-map-file: '.github/actions/.support/pypi_vs_conda_names.json'
       publish-to-pypi: false

--- a/.github/workflows/pyproject-release.yml
+++ b/.github/workflows/pyproject-release.yml
@@ -1,0 +1,119 @@
+# Take == dependencies in pyproject.toml (or equivalent) and relax them
+# according to conda environment yaml files and rules for semantic versioning,
+# then make a pypi release.
+# For full docs cf. .support/update_pyproject_dependencies.py'
+# Usage:
+#   on:
+#     release:
+#       types: [published]
+
+name: Pyproject Release
+
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        type: string
+        description: 'Cached python versions'
+        default: '3.12'
+        required: false
+      env-files:
+        type: string
+        description: 'Conda environment(S)'
+        default: .ci_support/environment.yml
+        required: false
+      input-toml:
+        type: string
+        description: 'Input TOML file with `project.dependencies` and `==` pinned dependencies.'
+        default: 'pyproject.toml'
+        required: false
+      lower-bound-yaml:
+        type: string
+        description: 'Optional YAML conda environment file with lower bounds for select dependencies.'
+        default: 'none'
+        required: false
+      upper-bound-yaml:
+        type: string
+        description: 'Optional YAML conda environment file with upper bounds for select dependencies.'
+        default: 'none'
+        required: false
+      semantic-upper-bound:
+        type: string
+        description: 'Upper bound policy for semantically versioned dependencies.'
+        default: 'patch'
+        required: false
+      always-pin-unstable:
+        type: string
+        description: 'Whether to always pin unstable dependencies (0.Y.Z) all the way to patch.'
+        default: 'yes'
+        required: false
+      output-toml:
+        type: string
+        description: 'Optional output destination for toml with updated dependency versions.'
+        default: 'none'
+        required: false
+      pypi-to-conda-name-map-file:
+        type: string
+        description: 'Optional JSON file to remap pypi package names in the toml file(s) to conda package names in the yaml file(s).'
+        default: $GITHUB_ACTION_PATH/../.support/pypi_vs_conda_names.json
+        required: false
+      pyyaml-version:
+        type: string
+        description: 'Version of pyyaml to install'
+        default: '6.0.1'
+        required: false
+      toml-version:
+        type: string
+        description: 'Version of toml to install'
+        default: '0.10.2'
+        required: false
+      publish-to-pypi:
+        type: boolean
+        description: 'Whether to actually publish the result. Turning it off is useful for debugging new builds.'
+        default: true
+        required: false
+      runner:
+        type: string
+        description: 'The main runner to use everywhere'
+        default: 'ubuntu-22.04'
+        required: false
+
+jobs:
+  pypi-release:
+    runs-on: ${{ inputs.runner }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: pyiron/actions/cached-miniforge@actions-4.0.8
+      with:
+        python-version: ${{ inputs.python-version }}
+        env-files: ${{ inputs.env-files }}
+    - uses: ./.github/actions/update-pyproject-dependencies
+      with:
+        input-toml: ${{ inputs.input-toml }}
+        lower-bound-yaml: ${{ inputs.lower-bound-yaml }}
+        upper-bound-yaml: ${{ inputs.upper-bound-yaml }}
+        semantic-upper-bound: ${{ inputs.semantic-upper-bound }}
+        always-pin-unstable: ${{ inputs.always-pin-unstable }}
+        output-toml: ${{ inputs.output-toml }}
+        pypi-to-conda-name-map-file: ${{ inputs.pypi-to-conda-name-map-file }}
+        pyyaml-version: ${{ inputs.pyyaml-version }}
+        toml-version: ${{ inputs.toml-version }}
+    - name: Print output toml
+      if: inputs.output-toml != 'none'
+      shell: bash -l {0}
+      run: cat ${{ inputs.output-toml }}
+    - name: Print output toml (overwrote input)
+      if: inputs.output-toml == 'none'
+      shell: bash -l {0}
+      run: cat ${{ inputs.input-toml }}
+    - name: Build
+      shell: bash -l {0}
+      run: |
+        pip install versioneer[toml]==0.29
+        python setup.py sdist bdist_wheel
+    - name: Publish distribution 📦 to PyPI
+      if: inputs.publish-to-pypi
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with: # Remove once trusted publisher works with reusable workflows
+        user: __token__  # Remove once trusted publisher works with reusable workflows
+        password: ${{ secrets.pypi_password }}  # Remove once trusted publisher works with reusable workflows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,17 +2,15 @@
 name: Release
 
 on:
-  # pull_request:
+#  pull_request:
   release:
     types: [ published ]
 
-
-
 jobs:
   pyiron:
-    uses: pyiron/actions/.github/workflows/pyproject-release.yml@actions-4.0.8
+    uses: ./.github/workflows/pyproject-release.yml
     secrets: inherit
     with:
       semantic-upper-bound: 'minor'
       lower-bound-yaml: '.ci_support/lower_bound.yml'
-      # publish-to-pypi: true
+      pypi-to-conda-name-map-file: '.github/actions/.support/pypi_vs_conda_names.json'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ include = [ "pyiron_workflow_atomistics*",]
 attr = "pyiron_workflow_atomistics.__version__"
 
 [tool.ruff]
-exclude = ["docs", "notebooks", "setup.py", "_version.py", "versioneer.py"]
+exclude = ["docs", "notebooks", "setup.py", "_version.py", "versioneer.py", ".github"]
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
## Problem

The 0.0.5 GitHub Release workflow crashed:

\`\`\`
File ".../update_pyproject_dependencies.py", line 126, in split_dependency
    split = dependency.replace(" ", "").split(delimiter)
AttributeError: 'dict' object has no attribute 'replace'
\`\`\`

The upstream \`pyiron/actions@4.0.8\` \`update_pyproject_dependencies.py\` script iterates \`data["dependencies"]\` and calls \`.replace()\` on each entry. Our \`.ci_support/lower_bound.yml\` (added in the v0.0.5 PR cycle) contains a \`- pip:\` block with PyPI-only deps like \`lz-GB-code==0.1.0\`, which YAML loads as a \`dict\` — boom.

## Fix

Mirror the fix already in \`pyiron/pyiron_workflow_lammps@main\`: fork the script + workflow locally, add a \`dict\` branch in \`load_yaml\` that descends into the \`pip:\` list, point \`release.yml\` at the local fork.

## Files changed

- \`.github/actions/.support/update_pyproject_dependencies.py\` — local fork with the \`dict\`-aware fix.
- \`.github/actions/.support/pypi_vs_conda_names.json\` — pypi↔conda name map.
- \`.github/actions/update-pyproject-dependencies/action.yml\` — composite action wrapping the local script.
- \`.github/workflows/pyproject-release.yml\` — local fork of the upstream workflow that uses the composite action.
- \`.github/workflows/release.yml\` — rewire to local fork; drop commented \`publish-to-pypi\` (local workflow defaults that to \`true\`).
- \`.github/workflows/preview-release.yml\` — same rewire; keep \`publish-to-pypi: false\` for PR previews.

All copied verbatim from the lammps fix (see \`pyiron_workflow_lammps@main:.github/\`).

## After merge

Re-publish the v0.0.5 GitHub Release (delete the existing one, recreate from the existing tag) to fire the release workflow against the fixed script. The tag itself doesn't need to change.

## Test plan

- [ ] CI passes (Push-Pull) on this PR. The Preview Release workflow now runs against the local fork — should succeed since the dict-fix is identical to lammps where it's been green.
- [ ] After merge, re-publishing the GitHub Release for \`pyiron_workflow_atomistics-0.0.5\` produces a successful Release workflow run + publish to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)