### PR TITLE
test: bump unit-test coverage from 66% to 83%

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -15,6 +15,7 @@ dependencies:
 - tqdm
 - pytest
 - pytest-cov
+- pyscal3
 - nbformat
 - nbclient
 - phonopy

--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -14,6 +14,7 @@ dependencies:
 - pyiron_snippets
 - tqdm
 - pytest
+- pytest-cov
 - nbformat
 - nbclient
 - phonopy

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -21,6 +21,7 @@ dependencies:
   # Test runners / notebook execution
   - pytest
   - pytest-cov
+  - pyscal3  # used by structure/defects.py void-analysis helpers (Tier 2 tests)
   - nbformat
   - nbclient
 

--- a/.ci_support/environment.yml
+++ b/.ci_support/environment.yml
@@ -20,6 +20,7 @@ dependencies:
 
   # Test runners / notebook execution
   - pytest
+  - pytest-cov
   - nbformat
   - nbclient
 

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -7,6 +7,27 @@ on:
     - cron: '0 23 * * *'
 
 jobs:
-  codeql:
-    uses: pyiron/actions/.github/workflows/tests-and-coverage.yml@actions-4.0.1
-    secrets: inherit
+  pytest-coverage:
+    # The upstream tests-and-coverage workflow runs `unittest discover`, which
+    # silently skips every pytest-style test in this repo. Run pytest with
+    # coverage directly and upload to coveralls.
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pyiron/actions/cached-miniforge@actions-4.1.0
+        with:
+          python-version: '3.12'
+          env-files: .ci_support/environment.yml
+      - name: Run pytest with coverage
+        shell: bash -l {0}
+        run: |
+          pytest tests/unit tests/integration/test_gb_code_pipeline.py \
+            --cov=pyiron_workflow_atomistics \
+            --cov-report=xml \
+            --cov-report=term \
+            -m "not slow"
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          file: coverage.xml

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -25,8 +25,7 @@ jobs:
           pytest tests/unit tests/integration/test_gb_code_pipeline.py \
             --cov=pyiron_workflow_atomistics \
             --cov-report=xml \
-            --cov-report=term \
-            -m "not slow"
+            --cov-report=term
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -35,8 +35,7 @@ jobs:
           pytest tests/unit tests/integration/test_gb_code_pipeline.py \
             --cov=pyiron_workflow_atomistics \
             --cov-report=xml \
-            --cov-report=term \
-            -m "not slow"
+            --cov-report=term
       - name: Coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/.github/workflows/push-pull.yml
+++ b/.github/workflows/push-pull.yml
@@ -14,4 +14,30 @@ jobs:
       runner: 'ubuntu-22.04' # with ubuntu > 22.04, pip is broken
       python-version-alt3: 'exclude'  # No python 3.9
       runner-alt1: 'exclude'
+      # The upstream coverage job runs `unittest discover`, which silently
+      # skips every pytest-style test in this repo. We run our own pytest
+      # coverage job below instead.
+      do-coveralls: false
     secrets: inherit
+
+  pytest-coverage:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pyiron/actions/cached-miniforge@actions-4.1.0
+        with:
+          python-version: '3.12'
+          env-files: .ci_support/environment.yml
+      - name: Run pytest with coverage
+        shell: bash -l {0}
+        run: |
+          pytest tests/unit tests/integration/test_gb_code_pipeline.py \
+            --cov=pyiron_workflow_atomistics \
+            --cov-report=xml \
+            --cov-report=term \
+            -m "not slow"
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          file: coverage.xml

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -21,6 +21,7 @@ dependencies:
 - tqdm
 - pytest
 - pytest-cov
+- pyscal3
 - nbformat
 - nbclient
 - phonopy

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -20,6 +20,7 @@ dependencies:
 - pyiron_snippets
 - tqdm
 - pytest
+- pytest-cov
 - nbformat
 - nbclient
 - phonopy

--- a/pyiron_workflow_atomistics/physics/_grain_boundary_code/constructor.py
+++ b/pyiron_workflow_atomistics/physics/_grain_boundary_code/constructor.py
@@ -9,10 +9,14 @@ from pymatgen.io.ase import AseAtomsAdaptor
 
 
 def _axis_index_to_label(axis: int) -> str:
+    # bool is a subclass of int — reject it explicitly so True/False don't
+    # silently map to 1/0.
+    if isinstance(axis, bool) or not isinstance(axis, (int, np.integer)):
+        raise ValueError("grain_length_axis must be one of 0, 1, or 2")
     axis_labels = {0: "x", 1: "y", 2: "z"}
     try:
         return axis_labels[int(axis)]
-    except (KeyError, ValueError, TypeError) as exc:
+    except KeyError as exc:
         raise ValueError("grain_length_axis must be one of 0, 1, or 2") from exc
 
 

--- a/tests/integration/test_gb_code_pipeline.py
+++ b/tests/integration/test_gb_code_pipeline.py
@@ -1,0 +1,73 @@
+"""Integration tests for the gb_code → grain boundary pipeline.
+
+Exercises the public macros end-to-end with `gb_code` and the constructor
+helpers. Marked slow because each call runs a small workflow graph.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from ase import Atoms
+
+
+@pytest.mark.slow
+def test_construct_GB_from_GBCode_macro_builds_an_atoms_structure():
+    """End-to-end: feed a Σ5 [100] BCC GB through the public macro and
+    verify it yields a valid ASE Atoms object with the BCC element symbol."""
+    pytest.importorskip("gb_code")
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        construct_GB_from_GBCode,
+    )
+
+    fn = construct_GB_from_GBCode(
+        axis=[1, 0, 0],
+        basis="bcc",
+        lattice_param=2.828,
+        m=3,
+        n=1,
+        GB1=(0, 1, -2),
+        element="Fe",
+        req_length_grain=10.0,
+        grain_length_axis=0,
+        equil_volume=11.3,
+    )()  # invoke the macro
+
+    final = fn["final_structure"]
+    original = fn["original_GBcode_structure"]
+    assert isinstance(final, Atoms)
+    assert isinstance(original, Atoms)
+    assert all(s == "Fe" for s in final.get_chemical_symbols())
+    assert len(final) > 0
+    # ``wrap_and_sort_structure`` produces z-sorted output for the final cell.
+    z = final.get_positions()[:, 2]
+    assert np.all(np.diff(z) >= -1e-6)
+
+
+@pytest.mark.slow
+def test_construct_GB_from_GBCode_macro_grain_length_extension_in_original():
+    """The pre-realignment ``original_GBcode_structure`` is extended along
+    ``grain_length_axis`` to at least ``2 · req_length_grain`` (the rearrange
+    + align steps may permute axes after that)."""
+    pytest.importorskip("gb_code")
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        construct_GB_from_GBCode,
+    )
+
+    req = 8.0
+    fn = construct_GB_from_GBCode(
+        axis=[1, 0, 0],
+        basis="bcc",
+        lattice_param=2.828,
+        m=3,
+        n=1,
+        GB1=(0, 1, -2),
+        element="Fe",
+        req_length_grain=req,
+        grain_length_axis=0,
+        equil_volume=11.3,
+    )()
+    original = fn["original_GBcode_structure"]
+    cell_lengths = np.linalg.norm(original.cell.array, axis=1)
+    # At least one cell vector is long enough to host the requested grain.
+    assert cell_lengths.max() >= 2 * req - 1e-3

--- a/tests/unit/_internal/test_workdir.py
+++ b/tests/unit/_internal/test_workdir.py
@@ -1,0 +1,55 @@
+"""Tests for the workdir fan-out helpers."""
+
+from __future__ import annotations
+
+import os
+
+
+def test_get_subdirpaths_joins_parent_and_subdirs():
+    from pyiron_workflow_atomistics._internal.workdir import get_subdirpaths
+
+    out = get_subdirpaths.node_function(
+        parent_dir="/tmp/parent",
+        output_subdirs=["a", "b", "c"],
+    )
+    assert out == [
+        os.path.join("/tmp/parent", "a"),
+        os.path.join("/tmp/parent", "b"),
+        os.path.join("/tmp/parent", "c"),
+    ]
+
+
+def test_get_subdirpaths_empty_subdirs():
+    from pyiron_workflow_atomistics._internal.workdir import get_subdirpaths
+
+    assert get_subdirpaths.node_function(parent_dir="/tmp", output_subdirs=[]) == []
+
+
+def test_get_working_subdir_kwargs_overrides_working_directory():
+    from pyiron_workflow_atomistics._internal.workdir import get_working_subdir_kwargs
+
+    original = {"working_directory": "/old", "force_tol": 0.01}
+    out = get_working_subdir_kwargs.node_function(
+        calc_structure_fn_kwargs=original,
+        base_working_directory="/base",
+        new_working_directory="sub",
+    )
+    assert out["working_directory"] == os.path.join("/base", "sub")
+    assert out["force_tol"] == 0.01
+    # Original dict is not mutated.
+    assert original["working_directory"] == "/old"
+
+
+def test_get_working_subdir_kwargs_requires_working_directory_present():
+    """`modify_dict` rejects keys that are not already present, so the
+    caller must seed `working_directory` even if it will be overridden."""
+    import pytest
+
+    from pyiron_workflow_atomistics._internal.workdir import get_working_subdir_kwargs
+
+    with pytest.raises(KeyError, match="working_directory"):
+        get_working_subdir_kwargs.node_function(
+            calc_structure_fn_kwargs={},
+            base_working_directory="/base",
+            new_working_directory="run1",
+        )

--- a/tests/unit/physics/test_gb_constructor_helpers.py
+++ b/tests/unit/physics/test_gb_constructor_helpers.py
@@ -13,7 +13,6 @@ import pytest
 from ase.build import bulk
 from pymatgen.core import Lattice, Structure
 
-
 # ---------------------------------------------------------------------------
 # _axis_index_to_label
 # ---------------------------------------------------------------------------

--- a/tests/unit/physics/test_gb_constructor_helpers.py
+++ b/tests/unit/physics/test_gb_constructor_helpers.py
@@ -1,0 +1,315 @@
+"""Tier 1 helpers for `physics._grain_boundary_code.constructor`.
+
+The constructor's small pure helpers (axis-label, structure conversion,
+rearrange-by-axes) are tested directly; the macro `construct_GB_from_GBCode`
+is exercised once end-to-end as an integration test in
+``tests/integration/test_gb_code_pipeline.py``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from ase.build import bulk
+from pymatgen.core import Lattice, Structure
+
+
+# ---------------------------------------------------------------------------
+# _axis_index_to_label
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("axis, expected", [(0, "x"), (1, "y"), (2, "z")])
+def test_axis_index_to_label_valid(axis, expected):
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        _axis_index_to_label,
+    )
+
+    assert _axis_index_to_label(axis) == expected
+
+
+@pytest.mark.parametrize("bad", [3, -1, "x", None, 1.5, True, False])
+def test_axis_index_to_label_rejects_bad_input(bad):
+    """Floats (even integer-valued ones), bools, and non-integers must all
+    raise rather than silently truncate to a valid axis index."""
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        _axis_index_to_label,
+    )
+
+    with pytest.raises(ValueError, match="0, 1, or 2"):
+        _axis_index_to_label(bad)
+
+
+def test_axis_index_to_label_accepts_numpy_integers():
+    """The guard must still accept numpy integer scalars, which are used
+    throughout the codebase as axis indices."""
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        _axis_index_to_label,
+    )
+
+    assert _axis_index_to_label(np.int64(0)) == "x"
+    assert _axis_index_to_label(np.int32(2)) == "z"
+
+
+# ---------------------------------------------------------------------------
+# wrap_and_sort_structure
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_and_sort_structure_orders_by_axis():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        wrap_and_sort_structure,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True) * (2, 2, 2)
+    out = wrap_and_sort_structure.node_function(cu, axis=2)
+    z = out.get_positions()[:, 2]
+    assert np.all(np.diff(z) >= -1e-9)
+
+
+def test_wrap_and_sort_structure_with_axis_x():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        wrap_and_sort_structure,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True) * (2, 2, 2)
+    out = wrap_and_sort_structure.node_function(cu, axis=0)
+    x = out.get_positions()[:, 0]
+    assert np.all(np.diff(x) >= -1e-9)
+
+
+# ---------------------------------------------------------------------------
+# get_multiplier_to_extend_gb_to_min_length
+# ---------------------------------------------------------------------------
+
+
+def test_multiplier_extends_axis_to_at_least_2x_req_length():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        get_multiplier_to_extend_gb_to_min_length,
+    )
+
+    struct = Structure(
+        Lattice.cubic(3.5),
+        ["Fe"],
+        [[0, 0, 0]],
+    )
+    factors = get_multiplier_to_extend_gb_to_min_length(
+        struct, axis=0, req_length_grain=15
+    )
+    assert factors[0] * 3.5 >= 2 * 15
+    assert factors[1] == 1
+    assert factors[2] == 1
+
+
+def test_multiplier_returns_1_when_already_long_enough():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        get_multiplier_to_extend_gb_to_min_length,
+    )
+
+    struct = Structure(Lattice.cubic(40.0), ["Fe"], [[0, 0, 0]])
+    factors = get_multiplier_to_extend_gb_to_min_length(
+        struct, axis=2, req_length_grain=15
+    )
+    assert factors == [1, 1, 1]
+
+
+# ---------------------------------------------------------------------------
+# rearrange_structure_lattice_vectors
+# ---------------------------------------------------------------------------
+
+
+def test_rearrange_structure_lattice_vectors_swap_a_and_b():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        rearrange_structure_lattice_vectors,
+    )
+
+    s = Structure(
+        Lattice.from_parameters(2.0, 4.0, 6.0, 90, 90, 90),
+        ["Fe", "Fe"],
+        [[0.0, 0.0, 0.0], [0.5, 0.5, 0.5]],
+    )
+    out = rearrange_structure_lattice_vectors(s, order=("b", "a", "c"))
+    # The new 'a' length matches the original 'b' length and vice versa.
+    assert out.lattice.a == pytest.approx(4.0)
+    assert out.lattice.b == pytest.approx(2.0)
+    assert out.lattice.c == pytest.approx(6.0)
+
+
+def test_rearrange_structure_lattice_vectors_invalid_order_raises():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        rearrange_structure_lattice_vectors,
+    )
+
+    s = Structure(Lattice.cubic(3.5), ["Fe"], [[0, 0, 0]])
+    with pytest.raises(ValueError, match="permutation"):
+        rearrange_structure_lattice_vectors(s, order=("a", "a", "c"))
+
+
+# ---------------------------------------------------------------------------
+# align_lattice_to_axes
+# ---------------------------------------------------------------------------
+
+
+def test_align_lattice_to_axes_produces_diagonal_lattice():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        align_lattice_to_axes,
+    )
+
+    s = Structure(
+        Lattice.from_parameters(2.0, 4.0, 6.0, 90, 90, 90),
+        ["Fe", "Cu"],
+        [[0.0, 0.0, 0.0], [0.25, 0.25, 0.25]],
+    )
+    out = align_lattice_to_axes(s)
+    # Off-diagonal entries of the new lattice matrix must be zero.
+    M = np.asarray(out.lattice.matrix)
+    off_diag = M - np.diag(np.diag(M))
+    np.testing.assert_allclose(off_diag, 0.0, atol=1e-9)
+    # Diagonal entries match the original abc.
+    np.testing.assert_allclose(np.diag(M), [2.0, 4.0, 6.0])
+
+
+# ---------------------------------------------------------------------------
+# convert_structure
+# ---------------------------------------------------------------------------
+
+
+def test_convert_structure_ase_to_pymatgen_and_back():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        convert_structure,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True)
+    pmg = convert_structure.node_function(cu, target="pmg")
+    assert isinstance(pmg, Structure)
+    ase_again = convert_structure.node_function(pmg, target="ase")
+    np.testing.assert_allclose(ase_again.get_positions(), cu.get_positions(), atol=1e-9)
+
+
+def test_convert_structure_pymatgen_alias_works():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        convert_structure,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True)
+    pmg = convert_structure.node_function(cu, target="pymatgen")
+    assert isinstance(pmg, Structure)
+
+
+def test_convert_structure_invalid_target_raises():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        convert_structure,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True)
+    with pytest.raises(ValueError, match="Not a valid conversion target"):
+        convert_structure.node_function(cu, target="nope")
+
+
+# ---------------------------------------------------------------------------
+# get_expected_equilibrium_c_struct
+# ---------------------------------------------------------------------------
+
+
+def test_get_expected_equilibrium_c_struct_scales_chosen_axis():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        get_expected_equilibrium_c_struct,
+    )
+
+    s = Structure(Lattice.cubic(3.5), ["Fe", "Fe"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+    v0 = 11.5  # target volume per atom in Å³
+    new_struct, new_axis_length = get_expected_equilibrium_c_struct.node_function(
+        s, v0_per_atom=v0, axis=2
+    )
+    # V = V0 * N_atoms; orthogonal lattice with a*b=12.25 → c = N*v0 / (a*b)
+    expected = (v0 * 2) / (3.5 * 3.5)
+    assert new_axis_length == pytest.approx(expected)
+    assert new_struct.lattice.c == pytest.approx(expected)
+    # The two orthogonal axes stay unchanged.
+    assert new_struct.lattice.a == pytest.approx(3.5)
+    assert new_struct.lattice.b == pytest.approx(3.5)
+
+
+# ---------------------------------------------------------------------------
+# merge_structure_sites
+# ---------------------------------------------------------------------------
+
+
+def test_merge_structure_sites_collapses_near_duplicates():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        merge_structure_sites,
+    )
+
+    s = Structure(
+        Lattice.cubic(10.0),
+        ["Fe", "Fe"],
+        [[0.0, 0.0, 0.0], [0.001, 0.001, 0.001]],
+    )
+    merged = merge_structure_sites.node_function(
+        s, merge_dist_tolerance=0.5, merge_mode="average"
+    )
+    assert len(merged) == 1
+
+
+def test_merge_structure_sites_keeps_distinct_sites():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        merge_structure_sites,
+    )
+
+    s = Structure(
+        Lattice.cubic(10.0),
+        ["Fe", "Cu"],
+        [[0.0, 0.0, 0.0], [0.5, 0.5, 0.5]],
+    )
+    merged = merge_structure_sites.node_function(
+        s, merge_dist_tolerance=0.5, merge_mode="average"
+    )
+    assert len(merged) == 2
+
+
+# ---------------------------------------------------------------------------
+# get_realigned_structure
+# ---------------------------------------------------------------------------
+
+
+def test_get_realigned_structure_runs_with_default_options():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        get_realigned_structure,
+    )
+
+    s = Structure(
+        Lattice.from_parameters(3.5, 4.0, 5.0, 90, 90, 90),
+        ["Fe"],
+        [[0.0, 0.0, 0.0]],
+    )
+    out = get_realigned_structure.node_function(s)
+    assert isinstance(out, Structure)
+    M = np.asarray(out.lattice.matrix)
+    off_diag = M - np.diag(np.diag(M))
+    np.testing.assert_allclose(off_diag, 0.0, atol=1e-9)
+
+
+def test_get_realigned_structure_with_equivalence_check():
+    """The ``perform_equiv_check`` branch logs whether the structures match;
+    just verify it runs without raising."""
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        get_realigned_structure,
+    )
+
+    s = Structure(
+        Lattice.from_parameters(3.5, 4.0, 5.0, 90, 90, 90),
+        ["Fe", "Fe"],
+        [[0.0, 0.0, 0.0], [0.5, 0.5, 0.5]],
+    )
+    out = get_realigned_structure.node_function(s, perform_equiv_check=True)
+    assert isinstance(out, Structure)
+
+
+def test_get_realigned_structure_no_ab_reorder():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.constructor import (
+        get_realigned_structure,
+    )
+
+    s = Structure(Lattice.cubic(3.5), ["Fe"], [[0.0, 0.0, 0.0]])
+    out = get_realigned_structure.node_function(s, arrange_ab_by_length=False)
+    assert isinstance(out, Structure)

--- a/tests/unit/physics/test_gb_searcher.py
+++ b/tests/unit/physics/test_gb_searcher.py
@@ -1,0 +1,260 @@
+"""Tests for `physics._grain_boundary_code.searcher`.
+
+Tier 1 — synthetic DataFrame tests for the pure dedup / negation / structure
+duplicate-check helpers. These run fast and need only pandas + numpy + pymatgen.
+Tier 2 — gated on ``gb_code`` for the actual GB DataFrame generator and
+the parallel multi-axis driver. Marked slow.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — pure helpers
+# ---------------------------------------------------------------------------
+
+
+def test_deduplicate_miller_equivalent_collapses_orientation_variants():
+    """``canonical_gb`` should treat (1,1,1)/(1,-1,-1) and its permutations as
+    the same orbit under the cubic point group + plane-swap symmetry."""
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.searcher import (
+        _deduplicate_gbcode_df_miller_indices_equivalent,
+    )
+
+    df = pd.DataFrame(
+        {
+            "Sigma": [3, 3, 3],
+            # The second row is the first row with both planes negated (axis flip)
+            # — should be canonicalised to the same fingerprint.
+            "GB1": [(1, 1, 1), (-1, -1, -1), (2, 0, 0)],
+            "GB2": [(1, -1, -1), (-1, 1, 1), (0, 2, 0)],
+            "n_atoms": [4, 4, 8],
+        }
+    )
+
+    out = _deduplicate_gbcode_df_miller_indices_equivalent(df)
+    # The (2,0,0)/(0,2,0) row is a distinct orbit -> still present.
+    # One of the two (1,1,1)/(1,-1,-1) rows is dropped.
+    assert len(out) == 2
+    assert "canon" in out.columns
+    assert "dupe" in out.columns
+
+
+def test_deduplicate_keeps_all_rows_when_orbits_are_distinct():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.searcher import (
+        _deduplicate_gbcode_df_miller_indices_equivalent,
+    )
+
+    df = pd.DataFrame(
+        {
+            "Sigma": [3, 5],
+            "GB1": [(1, 1, 1), (3, 1, 0)],
+            "GB2": [(1, -1, 0), (1, -3, 0)],
+            "n_atoms": [4, 12],
+        }
+    )
+
+    out = _deduplicate_gbcode_df_miller_indices_equivalent(df)
+    assert len(out) == 2
+
+
+def test_rid_negative_duplicates_drops_one_per_negation_pair():
+    """Rows whose GB1+GB2 are component-wise negations and have identical
+    ``n_atoms`` should be collapsed within each Sigma group."""
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.searcher import (
+        _rid_negative_duplicates,
+    )
+
+    df = pd.DataFrame(
+        {
+            "Sigma": [5, 5, 5],
+            "GB1": [(1, 0, 0), (-1, 0, 0), (3, 1, 0)],
+            "GB2": [(0, 1, 0), (0, -1, 0), (1, -3, 0)],
+            "n_atoms": [10, 10, 20],
+        }
+    )
+
+    out = _rid_negative_duplicates(df)
+    assert len(out) == 2
+    # The two negation-pair rows collapse to one; the third (different) row stays.
+    assert (out["n_atoms"] == 20).sum() == 1
+
+
+def test_rid_negative_duplicates_does_not_cross_sigma_groups():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.searcher import (
+        _rid_negative_duplicates,
+    )
+
+    df = pd.DataFrame(
+        {
+            "Sigma": [3, 5],
+            "GB1": [(1, 0, 0), (-1, 0, 0)],
+            "GB2": [(0, 1, 0), (0, -1, 0)],
+            "n_atoms": [10, 10],
+        }
+    )
+
+    out = _rid_negative_duplicates(df)
+    assert len(out) == 2  # different Sigma → never collapsed
+
+
+def test_rid_negative_duplicates_requires_same_n_atoms():
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.searcher import (
+        _rid_negative_duplicates,
+    )
+
+    df = pd.DataFrame(
+        {
+            "Sigma": [5, 5],
+            "GB1": [(1, 0, 0), (-1, 0, 0)],
+            "GB2": [(0, 1, 0), (0, -1, 0)],
+            "n_atoms": [10, 12],  # mismatch breaks the negation rule
+        }
+    )
+
+    out = _rid_negative_duplicates(df)
+    assert len(out) == 2
+
+
+def test_check_duplicates_in_group_drops_identical_structures():
+    """``_check_duplicates_in_group`` uses pymatgen's StructureMatcher; two
+    identical FCC Cu cells should be reported as duplicates."""
+    from ase.build import bulk
+
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.searcher import (
+        _check_duplicates_in_group,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True)
+    group = pd.DataFrame({"structure": [cu, cu.copy(), cu.copy()]})
+    # Pandas index after construction is 0, 1, 2 — the helper drops by index.
+    drops = _check_duplicates_in_group(group)
+    assert sorted(drops) == [1, 2]
+
+
+def test_check_duplicates_in_group_keeps_distinct_structures():
+    from ase.build import bulk
+
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.searcher import (
+        _check_duplicates_in_group,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True)
+    ni = bulk("Ni", "fcc", a=3.6, cubic=True)
+    group = pd.DataFrame({"structure": [cu, ni]})
+    assert _check_duplicates_in_group(group) == []
+
+
+def test_remove_duplicate_structures_groups_by_n_atoms():
+    """The dedup step only compares structures with matching atom counts;
+    a 4-atom and an 8-atom cell are never considered duplicates."""
+    from ase.build import bulk
+
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.searcher import (
+        _remove_duplicate_structures,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True)
+    cu2 = cu * (2, 1, 1)
+    df = pd.DataFrame({"structure": [cu, cu.copy(), cu2]})
+    out = _remove_duplicate_structures(df, max_atoms=100, max_workers=1)
+    # 4-atom group had 2 identical Cu cells → one drop. 8-atom group → keep.
+    assert len(out) == 2
+
+
+def test_remove_duplicate_structures_skips_groups_above_max_atoms():
+    from ase.build import bulk
+
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.searcher import (
+        _remove_duplicate_structures,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True)
+    big = cu * (2, 2, 2)  # 32 atoms; above max_atoms
+    df = pd.DataFrame({"structure": [big, big.copy()]})
+    out = _remove_duplicate_structures(df, max_atoms=10, max_workers=1)
+    assert len(out) == 2  # neither group was actually compared
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — gated on gb_code (always present in the test env, but importorskip
+# makes this resilient to lean CI). Marked slow because each call spins up a
+# multiprocessing pool.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_get_gbcode_df_for_axis_returns_expected_schema():
+    pytest.importorskip("gb_code")
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.searcher import (
+        _get_gbcode_df,
+    )
+
+    df = _get_gbcode_df(
+        axis=np.array([1, 0, 0]),
+        basis="fcc",
+        sigma_limit=10,
+        lim_plane_index=1,
+        max_atoms=200,
+        max_workers=1,
+    )
+    assert {"Axis", "Sigma", "m", "n", "GB1", "GB2", "Theta (deg)", "Type", "n_atoms"} <= set(
+        df.columns
+    )
+    assert (df["n_atoms"] <= 200).all()
+    assert len(df) > 0
+
+
+@pytest.mark.slow
+def test_get_gb_code_df_macro_runs_and_deduplicates():
+    pytest.importorskip("gb_code")
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.searcher import (
+        get_gb_code_df,
+    )
+
+    out = get_gb_code_df.node_function(
+        axes_list=[np.array([1, 0, 0])],
+        basis="fcc",
+        sigma_limit=6,
+        lim_plane_index=1,
+        max_atoms=200,
+        max_workers=1,
+        deduplicate=True,
+    )
+    assert isinstance(out, pd.DataFrame)
+    assert "canon" in out.columns
+    assert len(out) >= 1
+
+
+@pytest.mark.slow
+def test_get_gb_code_df_macro_no_dedup_returns_more_rows():
+    """``deduplicate=False`` short-circuits the orientation collapsing step,
+    so the no-dedup output has ≥ the dedup output rows."""
+    pytest.importorskip("gb_code")
+    from pyiron_workflow_atomistics.physics._grain_boundary_code.searcher import (
+        get_gb_code_df,
+    )
+
+    raw = get_gb_code_df.node_function(
+        axes_list=[np.array([1, 0, 0])],
+        basis="fcc",
+        sigma_limit=6,
+        lim_plane_index=1,
+        max_atoms=200,
+        max_workers=1,
+        deduplicate=False,
+    )
+    dedup = get_gb_code_df.node_function(
+        axes_list=[np.array([1, 0, 0])],
+        basis="fcc",
+        sigma_limit=6,
+        lim_plane_index=1,
+        max_atoms=200,
+        max_workers=1,
+        deduplicate=True,
+    )
+    assert len(raw) >= len(dedup)

--- a/tests/unit/physics/test_gb_searcher.py
+++ b/tests/unit/physics/test_gb_searcher.py
@@ -12,7 +12,6 @@ import numpy as np
 import pandas as pd
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # Tier 1 — pure helpers
 # ---------------------------------------------------------------------------
@@ -202,9 +201,17 @@ def test_get_gbcode_df_for_axis_returns_expected_schema():
         max_atoms=200,
         max_workers=1,
     )
-    assert {"Axis", "Sigma", "m", "n", "GB1", "GB2", "Theta (deg)", "Type", "n_atoms"} <= set(
-        df.columns
-    )
+    assert {
+        "Axis",
+        "Sigma",
+        "m",
+        "n",
+        "GB1",
+        "GB2",
+        "Theta (deg)",
+        "Type",
+        "n_atoms",
+    } <= set(df.columns)
     assert (df["n_atoms"] <= 200).all()
     assert len(df) > 0
 

--- a/tests/unit/physics/test_phonons_helpers.py
+++ b/tests/unit/physics/test_phonons_helpers.py
@@ -15,7 +15,6 @@ import numpy as np
 import pytest
 from ase.build import bulk
 
-
 # ---------------------------------------------------------------------------
 # harmonic._normalise_supercell_matrix
 # ---------------------------------------------------------------------------
@@ -233,7 +232,9 @@ def _make_engine_output(converged: bool, wd: str = "/tmp/foo"):
 
     cu = bulk("Cu", "fcc", a=3.6)
     cu.info["working_directory"] = wd
-    return SimpleNamespace(converged=converged, final_structure=cu, final_forces=np.zeros((len(cu), 3)))
+    return SimpleNamespace(
+        converged=converged, final_structure=cu, final_forces=np.zeros((len(cu), 3))
+    )
 
 
 def test_check_all_converged_silent_when_all_pass():
@@ -272,9 +273,7 @@ def test_stack_forces_returns_3d_array():
     from pyiron_workflow_atomistics.physics.phonons.anharmonic import _stack_forces
 
     n_atoms = 4
-    outs = [
-        SimpleNamespace(final_forces=np.ones((n_atoms, 3)) * i) for i in range(3)
-    ]
+    outs = [SimpleNamespace(final_forces=np.ones((n_atoms, 3)) * i) for i in range(3)]
     out = _stack_forces(outs)
     assert out.shape == (3, n_atoms, 3)
     assert np.all(out[0] == 0)

--- a/tests/unit/physics/test_phonons_helpers.py
+++ b/tests/unit/physics/test_phonons_helpers.py
@@ -1,0 +1,593 @@
+"""Tier 1 helpers for the phonons subpackage.
+
+Covers the cheap pure-Python helpers in
+``physics.phonons.harmonic`` / ``anharmonic`` / ``md_renormalised`` that
+don't need phonopy or phono3py to be importable. Heavy paths live in the
+sibling ``test_phonons.py`` module behind ``pytest.importorskip``.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from ase.build import bulk
+
+
+# ---------------------------------------------------------------------------
+# harmonic._normalise_supercell_matrix
+# ---------------------------------------------------------------------------
+
+
+def test_normalise_supercell_matrix_scalar_returns_diag_identity():
+    from pyiron_workflow_atomistics.physics.phonons.harmonic import (
+        _normalise_supercell_matrix,
+    )
+
+    out = _normalise_supercell_matrix(3)
+    assert out.shape == (3, 3)
+    assert out.dtype.kind in "iu"
+    assert np.array_equal(out, 3 * np.eye(3, dtype=int))
+
+
+def test_normalise_supercell_matrix_1d_list_to_diag():
+    from pyiron_workflow_atomistics.physics.phonons.harmonic import (
+        _normalise_supercell_matrix,
+    )
+
+    out = _normalise_supercell_matrix([2, 3, 4])
+    assert np.array_equal(out, np.diag([2, 3, 4]))
+
+
+def test_normalise_supercell_matrix_2d_preserved():
+    from pyiron_workflow_atomistics.physics.phonons.harmonic import (
+        _normalise_supercell_matrix,
+    )
+
+    src = np.array([[1, 1, 0], [-1, 1, 0], [0, 0, 1]])
+    out = _normalise_supercell_matrix(src)
+    assert out.shape == (3, 3)
+    assert np.array_equal(out, src)
+
+
+def test_normalise_supercell_matrix_1d_wrong_shape_raises():
+    from pyiron_workflow_atomistics.physics.phonons.harmonic import (
+        _normalise_supercell_matrix,
+    )
+
+    with pytest.raises(ValueError, match=r"1d shape must be \(3,\)"):
+        _normalise_supercell_matrix([1, 2])
+
+
+def test_normalise_supercell_matrix_2d_wrong_shape_raises():
+    from pyiron_workflow_atomistics.physics.phonons.harmonic import (
+        _normalise_supercell_matrix,
+    )
+
+    with pytest.raises(ValueError, match=r"2d shape must be \(3,3\)"):
+        _normalise_supercell_matrix(np.zeros((2, 3)))
+
+
+def test_normalise_supercell_matrix_high_dim_raises():
+    from pyiron_workflow_atomistics.physics.phonons.harmonic import (
+        _normalise_supercell_matrix,
+    )
+
+    with pytest.raises(ValueError, match=r"must be int / \(3,\) / \(3,3\)"):
+        _normalise_supercell_matrix(np.zeros((3, 3, 3)))
+
+
+# ---------------------------------------------------------------------------
+# md_renormalised._normalise_supercell_matrix (local copy, must match)
+# ---------------------------------------------------------------------------
+
+
+def test_md_normalise_supercell_matrix_matches_harmonic_for_all_forms():
+    """The md_renormalised local copy must produce byte-identical results."""
+    from pyiron_workflow_atomistics.physics.phonons import harmonic, md_renormalised
+
+    for arg in [2, [2, 2, 2], np.diag([1, 2, 3])]:
+        a = harmonic._normalise_supercell_matrix(arg)
+        b = md_renormalised._normalise_supercell_matrix(arg)
+        assert np.array_equal(a, b)
+
+
+# ---------------------------------------------------------------------------
+# md_renormalised._auto_band_path
+# ---------------------------------------------------------------------------
+
+
+def test_auto_band_path_returns_npoints_by_3():
+    from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
+        _auto_band_path,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6)
+    pts = _auto_band_path(cell=np.asarray(cu.cell), npoints=15)
+    assert pts.ndim == 2
+    assert pts.shape[1] == 3
+    assert pts.shape[0] >= 5  # ASE returns at least a few high-symmetry points
+
+
+def test_auto_band_path_distinct_cells_give_different_paths():
+    from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
+        _auto_band_path,
+    )
+
+    fcc = bulk("Cu", "fcc", a=3.6)
+    bcc = bulk("Fe", "bcc", a=2.86)
+    a = _auto_band_path(cell=np.asarray(fcc.cell), npoints=20)
+    b = _auto_band_path(cell=np.asarray(bcc.cell), npoints=20)
+    # The two paths cover different reciprocal regions.
+    assert not np.allclose(a[: min(len(a), len(b))], b[: min(len(a), len(b))])
+
+
+# ---------------------------------------------------------------------------
+# md_renormalised._multiplier_to_cell_vectors
+# ---------------------------------------------------------------------------
+
+
+def test_multiplier_to_cell_vectors_scales_each_axis():
+    from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
+        _multiplier_to_cell_vectors,
+    )
+
+    cell = np.array([[3.0, 0, 0], [0, 4.0, 0], [0, 0, 5.0]])
+    out = _multiplier_to_cell_vectors(cell, multiplier=[2, 3, 4])
+    assert out.shape == (3, 3)
+    np.testing.assert_allclose(np.diag(out), [6.0, 12.0, 20.0])
+
+
+def test_multiplier_to_cell_vectors_with_3x3():
+    from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
+        _multiplier_to_cell_vectors,
+    )
+
+    cell = np.array([[1.0, 0, 0], [0, 1.0, 0], [0, 0, 1.0]])
+    P = np.array([[1, 1, 0], [-1, 1, 0], [0, 0, 1]])
+    out = _multiplier_to_cell_vectors(cell, multiplier=P)
+    np.testing.assert_allclose(out, P)
+
+
+# ---------------------------------------------------------------------------
+# anharmonic._check_polar_unsupported (extra coverage beyond test_phonons.py)
+# ---------------------------------------------------------------------------
+
+
+def test_check_polar_unsupported_both_kwargs_raises():
+    from pyiron_workflow_atomistics.physics.phonons.anharmonic import (
+        _check_polar_unsupported,
+    )
+
+    with pytest.raises(NotImplementedError, match="NAC"):
+        _check_polar_unsupported(
+            born_charges=np.zeros((4, 3, 3)),
+            epsilon_inf=np.eye(3),
+        )
+
+
+# ---------------------------------------------------------------------------
+# anharmonic._resolve_random_seed
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_random_seed_returns_user_value_when_set():
+    from pyiron_workflow_atomistics.physics.phonons.anharmonic import (
+        _resolve_random_seed,
+    )
+
+    assert _resolve_random_seed(number_of_snapshots=10, random_seed=42) == 42
+
+
+def test_resolve_random_seed_returns_none_when_no_snapshots():
+    """Without random mode, the seed isn't auto-generated — pass-through."""
+    from pyiron_workflow_atomistics.physics.phonons.anharmonic import (
+        _resolve_random_seed,
+    )
+
+    assert _resolve_random_seed(number_of_snapshots=None, random_seed=None) is None
+
+
+def test_resolve_random_seed_autofills_when_snapshots_set_and_seed_missing():
+    from pyiron_workflow_atomistics.physics.phonons.anharmonic import (
+        _resolve_random_seed,
+    )
+
+    seed = _resolve_random_seed(number_of_snapshots=10, random_seed=None)
+    assert isinstance(seed, int)
+    assert 0 <= seed < 2**32
+
+
+# ---------------------------------------------------------------------------
+# anharmonic._is_kappa_not_converged
+# ---------------------------------------------------------------------------
+
+
+def test_is_kappa_not_converged_detects_phrase():
+    from pyiron_workflow_atomistics.physics.phonons.anharmonic import (
+        _is_kappa_not_converged,
+    )
+
+    assert _is_kappa_not_converged(["Iteration is NOT CONVERGED in 30 steps."])
+    assert _is_kappa_not_converged(["foo", "NOT converged warning", "bar"])
+
+
+def test_is_kappa_not_converged_returns_false_for_unrelated_messages():
+    from pyiron_workflow_atomistics.physics.phonons.anharmonic import (
+        _is_kappa_not_converged,
+    )
+
+    assert not _is_kappa_not_converged([])
+    assert not _is_kappa_not_converged(["everything is fine", "kappa = 100"])
+
+
+# ---------------------------------------------------------------------------
+# anharmonic._check_all_converged
+# ---------------------------------------------------------------------------
+
+
+def _make_engine_output(converged: bool, wd: str = "/tmp/foo"):
+    from ase.build import bulk
+
+    cu = bulk("Cu", "fcc", a=3.6)
+    cu.info["working_directory"] = wd
+    return SimpleNamespace(converged=converged, final_structure=cu, final_forces=np.zeros((len(cu), 3)))
+
+
+def test_check_all_converged_silent_when_all_pass():
+    from pyiron_workflow_atomistics.physics.phonons.anharmonic import (
+        _check_all_converged,
+    )
+
+    outs = [_make_engine_output(True) for _ in range(3)]
+    _check_all_converged(outs, label="FC2")  # should not raise
+
+
+def test_check_all_converged_raises_with_failed_indices_and_wd():
+    from pyiron_workflow_atomistics.physics.phonons.anharmonic import (
+        _check_all_converged,
+    )
+
+    outs = [
+        _make_engine_output(True, "/tmp/a"),
+        _make_engine_output(False, "/tmp/b"),
+        _make_engine_output(False, "/tmp/c"),
+    ]
+    with pytest.raises(RuntimeError) as exc:
+        _check_all_converged(outs, label="FC3")
+    msg = str(exc.value)
+    assert "FC3" in msg
+    assert "1 (/tmp/b)" in msg
+    assert "2 (/tmp/c)" in msg
+
+
+# ---------------------------------------------------------------------------
+# anharmonic._stack_forces
+# ---------------------------------------------------------------------------
+
+
+def test_stack_forces_returns_3d_array():
+    from pyiron_workflow_atomistics.physics.phonons.anharmonic import _stack_forces
+
+    n_atoms = 4
+    outs = [
+        SimpleNamespace(final_forces=np.ones((n_atoms, 3)) * i) for i in range(3)
+    ]
+    out = _stack_forces(outs)
+    assert out.shape == (3, n_atoms, 3)
+    assert np.all(out[0] == 0)
+    assert np.all(out[2] == 2)
+
+
+# ---------------------------------------------------------------------------
+# anharmonic._kappa_voigt_to_tensor
+# ---------------------------------------------------------------------------
+
+
+def test_kappa_voigt_to_tensor_round_trip_for_isotropic_case():
+    from pyiron_workflow_atomistics.physics.phonons.anharmonic import (
+        _kappa_voigt_to_tensor,
+    )
+
+    voigt = np.array([[10.0, 10.0, 10.0, 0.0, 0.0, 0.0]])
+    tensor = _kappa_voigt_to_tensor(voigt)
+    assert tensor.shape == (1, 3, 3)
+    expected = 10.0 * np.eye(3)
+    np.testing.assert_allclose(tensor[0], expected)
+
+
+def test_kappa_voigt_to_tensor_general_shear_terms():
+    from pyiron_workflow_atomistics.physics.phonons.anharmonic import (
+        _kappa_voigt_to_tensor,
+    )
+
+    voigt = np.array([[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]])
+    out = _kappa_voigt_to_tensor(voigt)[0]
+    expected = np.array(
+        [
+            [1.0, 6.0, 5.0],
+            [6.0, 2.0, 4.0],
+            [5.0, 4.0, 3.0],
+        ]
+    )
+    np.testing.assert_allclose(out, expected)
+    # symmetry
+    np.testing.assert_allclose(out, out.T)
+
+
+def test_kappa_voigt_to_tensor_multiple_temperatures():
+    from pyiron_workflow_atomistics.physics.phonons.anharmonic import (
+        _kappa_voigt_to_tensor,
+    )
+
+    voigt = np.tile([10.0, 10.0, 10.0, 0.0, 0.0, 0.0], (5, 1))
+    out = _kappa_voigt_to_tensor(voigt)
+    assert out.shape == (5, 3, 3)
+    for t in range(5):
+        np.testing.assert_allclose(out[t], 10 * np.eye(3))
+
+
+# ---------------------------------------------------------------------------
+# md_renormalised._resolve_md_defaults — argument-coupling tests
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_md_defaults_raises_when_both_inputs_missing():
+    from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
+        _resolve_md_defaults,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6)
+    with pytest.raises(ValueError, match="Must supply"):
+        _resolve_md_defaults.node_function(
+            structure=cu,
+            fc2_supercell_matrix=None,
+            phono3py_output=None,
+            q_points=None,
+            band_npoints=10,
+            seed=None,
+        )
+
+
+def test_resolve_md_defaults_recompute_branch_returns_expected_tags():
+    from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
+        _resolve_md_defaults,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6)
+    sc, qpts, seed, tag, fc2 = _resolve_md_defaults.node_function(
+        structure=cu,
+        fc2_supercell_matrix=2,
+        phono3py_output=None,
+        q_points=None,
+        band_npoints=10,
+        seed=12345,
+    )
+    assert np.array_equal(sc, 2 * np.eye(3, dtype=int))
+    assert qpts.shape[1] == 3
+    assert seed == 12345
+    assert tag == "recompute"
+    assert fc2 is None
+
+
+def test_resolve_md_defaults_seed_autofill_when_missing():
+    from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
+        _resolve_md_defaults,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6)
+    *_, seed, _, _ = _resolve_md_defaults.node_function(
+        structure=cu,
+        fc2_supercell_matrix=2,
+        phono3py_output=None,
+        q_points=None,
+        band_npoints=10,
+        seed=None,
+    )
+    assert isinstance(seed, int)
+    assert 0 <= seed < 2**32
+
+
+def test_resolve_md_defaults_explicit_qpoints_pass_through():
+    from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
+        _resolve_md_defaults,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6)
+    explicit_q = np.array([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]])
+    _, qpts, *_ = _resolve_md_defaults.node_function(
+        structure=cu,
+        fc2_supercell_matrix=2,
+        phono3py_output=None,
+        q_points=explicit_q,
+        band_npoints=10,
+        seed=0,
+    )
+    np.testing.assert_allclose(qpts, explicit_q)
+
+
+def test_resolve_md_defaults_qpoints_wrong_shape_raises():
+    from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
+        _resolve_md_defaults,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6)
+    with pytest.raises(ValueError, match="must be"):
+        _resolve_md_defaults.node_function(
+            structure=cu,
+            fc2_supercell_matrix=2,
+            phono3py_output=None,
+            q_points=np.zeros((4, 4)),
+            band_npoints=10,
+            seed=0,
+        )
+
+
+def _fake_phonon_output(fc2_supercell, fc2=None):
+    """Construct just enough of a PhononOutput for the coupling guard."""
+    from pyiron_workflow_atomistics.physics.phonons.output import PhononOutput
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True)
+    return PhononOutput(
+        structure=cu,
+        fc2_supercell_matrix=fc2_supercell,
+        fc3_supercell_matrix=fc2_supercell,
+        temperatures=np.array([300.0]),
+        kappa=np.zeros((1, 3, 3)),
+        converged=True,
+        fc2=fc2,
+    )
+
+
+def test_resolve_md_defaults_reuse_requires_fc2():
+    from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
+        _resolve_md_defaults,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True)
+    upstream = _fake_phonon_output(fc2_supercell=2 * np.eye(3, dtype=int), fc2=None)
+    with pytest.raises(ValueError, match="phono3py_output.fc2 is None"):
+        _resolve_md_defaults.node_function(
+            structure=cu,
+            fc2_supercell_matrix=None,
+            phono3py_output=upstream,
+            q_points=None,
+            band_npoints=10,
+            seed=0,
+        )
+
+
+def test_resolve_md_defaults_reuse_succeeds_when_fc2_present():
+    from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
+        _resolve_md_defaults,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True)
+    n = 4 * len(cu)
+    fake_fc2 = np.zeros((n, n, 3, 3))
+    upstream = _fake_phonon_output(fc2_supercell=2 * np.eye(3, dtype=int), fc2=fake_fc2)
+    sc, _qpts, _seed, tag, fc2 = _resolve_md_defaults.node_function(
+        structure=cu,
+        fc2_supercell_matrix=None,
+        phono3py_output=upstream,
+        q_points=None,
+        band_npoints=10,
+        seed=0,
+    )
+    assert tag == "reuse"
+    assert np.array_equal(sc, 2 * np.eye(3, dtype=int))
+    assert fc2 is not None
+    assert fc2.shape == fake_fc2.shape
+
+
+def test_resolve_md_defaults_supercell_mismatch_raises():
+    from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
+        _resolve_md_defaults,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True)
+    upstream = _fake_phonon_output(
+        fc2_supercell=2 * np.eye(3, dtype=int),
+        fc2=np.zeros((4, 4, 3, 3)),
+    )
+    with pytest.raises(ValueError, match="disagrees with"):
+        _resolve_md_defaults.node_function(
+            structure=cu,
+            fc2_supercell_matrix=3 * np.eye(3, dtype=int),  # mismatch
+            phono3py_output=upstream,
+            q_points=None,
+            band_npoints=10,
+            seed=0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# md_renormalised._select_or_compute_fc2 — exercise the reuse and error paths
+# ---------------------------------------------------------------------------
+
+
+def test_select_or_compute_fc2_reuse_returns_array_as_ndarray():
+    from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
+        _select_or_compute_fc2,
+    )
+
+    fake = [[[1.0, 2.0]]]  # nested list to make sure asarray triggers
+    out = _select_or_compute_fc2.node_function(
+        structure=None,
+        engine=None,
+        resolved_fc2_supercell=np.eye(3, dtype=int),
+        fc2_source_tag="reuse",
+        fc2_array_reused=fake,
+    )
+    assert isinstance(out, np.ndarray)
+    np.testing.assert_allclose(out, np.asarray(fake))
+
+
+def test_select_or_compute_fc2_reuse_without_array_raises():
+    from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
+        _select_or_compute_fc2,
+    )
+
+    with pytest.raises(RuntimeError, match="Internal error"):
+        _select_or_compute_fc2.node_function(
+            structure=None,
+            engine=None,
+            resolved_fc2_supercell=np.eye(3, dtype=int),
+            fc2_source_tag="reuse",
+            fc2_array_reused=None,
+        )
+
+
+def test_select_or_compute_fc2_unknown_tag_raises():
+    from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
+        _select_or_compute_fc2,
+    )
+
+    with pytest.raises(ValueError, match="Unknown fc2_source_tag"):
+        _select_or_compute_fc2.node_function(
+            structure=None,
+            engine=None,
+            resolved_fc2_supercell=np.eye(3, dtype=int),
+            fc2_source_tag="bogus",
+            fc2_array_reused=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — gated on phonopy/phono3py for the round-trip atoms helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_ase_phonopy_round_trip_preserves_structure():
+    pytest.importorskip("phonopy")
+    from pyiron_workflow_atomistics.physics.phonons.harmonic import (
+        _ase_to_phonopy,
+        _phonopy_to_ase,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True)
+    p = _ase_to_phonopy(cu)
+    back = _phonopy_to_ase(p)
+    assert back.get_chemical_symbols() == cu.get_chemical_symbols()
+    np.testing.assert_allclose(back.get_positions(), cu.get_positions(), atol=1e-10)
+    np.testing.assert_allclose(np.asarray(back.cell), np.asarray(cu.cell), atol=1e-10)
+    assert all(back.pbc)
+
+
+@pytest.mark.slow
+def test_build_phono3py_round_trip_carries_supercell_matrices():
+    pytest.importorskip("phono3py")
+    from pyiron_workflow_atomistics.physics.phonons.harmonic import _build_phono3py
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True)
+    sc = 2 * np.eye(3, dtype=int)
+    ph3 = _build_phono3py(
+        structure=cu,
+        fc2_supercell_matrix=sc,
+        fc3_supercell_matrix=sc,
+    )
+    np.testing.assert_array_equal(ph3.supercell_matrix, sc)
+    np.testing.assert_array_equal(ph3.phonon_supercell_matrix, sc)

--- a/tests/unit/structure/test_defects.py
+++ b/tests/unit/structure/test_defects.py
@@ -1,0 +1,312 @@
+"""Tests for `structure.defects`.
+
+Tier 1 — pure helpers + the two as_function_node builders. Always runs.
+Tier 2 — gated on ``pyscal3``; covers the void analysis pipeline.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from ase.build import bulk
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — create_vacancy
+# ---------------------------------------------------------------------------
+
+
+def test_create_vacancy_removes_one_atom():
+    from pyiron_workflow_atomistics.structure.defects import create_vacancy
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True) * (2, 2, 2)
+    n0 = len(cu)
+    vac = create_vacancy.node_function(cu, remove_atom_index=0)
+    assert len(vac) == n0 - 1
+    # input not mutated
+    assert len(cu) == n0
+
+
+def test_create_vacancy_removes_specified_index():
+    from pyiron_workflow_atomistics.structure.defects import create_vacancy
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True) * (2, 2, 2)
+    target = cu.positions[5].copy()
+    vac = create_vacancy.node_function(cu, remove_atom_index=5)
+    # Position 5 from the original must no longer appear in the vacancy cell.
+    assert not np.any(np.all(np.isclose(vac.positions, target), axis=1))
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — substitutional_swap
+# ---------------------------------------------------------------------------
+
+
+def test_substitutional_swap_changes_one_symbol():
+    from pyiron_workflow_atomistics.structure.defects import substitutional_swap
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True) * (2, 2, 2)
+    out = substitutional_swap.node_function(cu, defect_site=0, new_symbol="Ni")
+    syms = out.get_chemical_symbols()
+    assert syms[0] == "Ni"
+    assert all(s == "Cu" for s in syms[1:])
+    # original unmutated
+    assert cu.get_chemical_symbols()[0] == "Cu"
+
+
+def test_substitutional_swap_with_explicit_index():
+    from pyiron_workflow_atomistics.structure.defects import substitutional_swap
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True) * (2, 2, 2)
+    out = substitutional_swap.node_function(cu, defect_site=7, new_symbol="Fe")
+    assert out.get_chemical_symbols()[7] == "Fe"
+    assert out.get_chemical_symbols()[0] == "Cu"
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — filter_condition pure-Python branches
+# ---------------------------------------------------------------------------
+
+
+def _mock_sys(boxdims):
+    return SimpleNamespace(boxdims=np.asarray(boxdims, dtype=float))
+
+
+def test_filter_condition_inside_band_and_rvv():
+    from pyiron_workflow_atomistics.structure.defects import filter_condition
+
+    sys = _mock_sys([10.0, 10.0, 10.0])
+    # pos lies inside [d_min, d_max] along axis=2, rvv inside (rvv_min, rvv_max).
+    assert filter_condition(
+        sys, pos=[0, 0, 4.0], rvv=0.5,
+        distance_min=2.0, distance_max=6.0,
+        axis=2, rvv_min=0.0, rvv_max=1.0,
+    ) is True
+
+
+def test_filter_condition_rvv_outside_returns_false():
+    from pyiron_workflow_atomistics.structure.defects import filter_condition
+
+    sys = _mock_sys([10.0, 10.0, 10.0])
+    assert filter_condition(
+        sys, pos=[0, 0, 4.0], rvv=5.0,
+        distance_min=2.0, distance_max=6.0,
+        axis=2, rvv_min=0.0, rvv_max=1.0,
+    ) is False
+
+
+def test_filter_condition_wrap_near_zero():
+    """When pos[axis] is outside [d_min, d_max] but lies in [0, width] (the
+    near-zero band wrap), the function should accept it."""
+    from pyiron_workflow_atomistics.structure.defects import filter_condition
+
+    sys = _mock_sys([10.0, 10.0, 10.0])
+    # band centred at (2+6)/2 = 4 with width 2; wrap window = [0, 2].
+    assert filter_condition(
+        sys, pos=[0, 0, 1.0], rvv=0.5,
+        distance_min=2.0, distance_max=6.0,
+        axis=2, rvv_min=0.0, rvv_max=1.0,
+    ) is True
+
+
+def test_filter_condition_wrap_near_boxdim():
+    """Pos in [boxdim - width, boxdim) is also accepted (top of the wrap)."""
+    from pyiron_workflow_atomistics.structure.defects import filter_condition
+
+    sys = _mock_sys([10.0, 10.0, 10.0])
+    # band centred at 4 with width 2 → top wrap window = [8, 10).
+    assert filter_condition(
+        sys, pos=[0, 0, 9.0], rvv=0.5,
+        distance_min=2.0, distance_max=6.0,
+        axis=2, rvv_min=0.0, rvv_max=1.0,
+    ) is True
+
+
+def test_filter_condition_outside_all_bands_returns_false():
+    from pyiron_workflow_atomistics.structure.defects import filter_condition
+
+    sys = _mock_sys([10.0, 10.0, 10.0])
+    # mid = 4, width = 2 → bands are [0,2], [2,6], [8,10). pos=7 lies outside.
+    assert filter_condition(
+        sys, pos=[0, 0, 7.0], rvv=0.5,
+        distance_min=2.0, distance_max=6.0,
+        axis=2, rvv_min=0.0, rvv_max=1.0,
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — tabulate_voids (matplotlib smoke; backend forced to Agg in conftest)
+# ---------------------------------------------------------------------------
+
+
+def test_tabulate_voids_runs_and_closes_figure():
+    import matplotlib.pyplot as plt
+
+    from pyiron_workflow_atomistics.structure.defects import tabulate_voids
+
+    void_ratios = [0.2, 0.5, 1.0]
+    void_count = [10, 20, 5]
+    n_before = len(plt.get_fignums())
+    tabulate_voids(void_ratios, void_count)
+    # A new figure was created.
+    assert len(plt.get_fignums()) == n_before + 1
+    plt.close("all")
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — pyscal3-gated void analysis pipeline
+# ---------------------------------------------------------------------------
+
+
+def _fcc_cu_pyscal_system():
+    """Build a fresh pyscal3 System for an 8x cubic-fcc Cu supercell."""
+    pyscal3 = pytest.importorskip("pyscal3")
+    System = pyscal3.System
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True) * (2, 2, 2)
+    sys = System()
+    sys.read.file(cu, format="ase")
+    return sys, cu
+
+
+@pytest.mark.slow
+def test_get_ra_matches_packing_factor_formula():
+    """``get_ra`` returns (pf · V_atom / (4π/3))^(1/3); for fcc Cu with pf=0.74
+    and 32 atoms in a 7.2³ box, the closed form is ≈ 1.272 Å."""
+    from pyiron_workflow_atomistics.structure.defects import get_ra
+
+    sys, _ = _fcc_cu_pyscal_system()
+    ra = get_ra(sys, sys.natoms, pf=0.74)
+    # Closed-form: volume = 7.2^3 = 373.248; v_atom = 11.664; ra = (0.74*11.664*3/(4π))**(1/3)
+    expected = ((0.74 * (7.2**3 / 32)) / ((4 / 3) * np.pi)) ** (1 / 3)
+    assert ra == pytest.approx(expected, rel=1e-9)
+
+
+@pytest.mark.slow
+def test_get_octahedral_positions_returns_finite_list():
+    """For an 8x fcc Cu supercell the octahedral-site finder should produce
+    a non-trivial number of candidate positions inside the box."""
+    pytest.importorskip("pyscal3")
+    from pyiron_workflow_atomistics.structure.defects import get_octahedral_positions
+
+    sys, _ = _fcc_cu_pyscal_system()
+    sys.find.neighbors(method="voronoi", cutoff=0.1)
+    positions = get_octahedral_positions(sys, alat=3.6)
+    assert len(positions) > 0
+    box = sys.box
+    for p in positions:
+        assert 0 <= p[0] <= box[0][0]
+        assert 0 <= p[1] <= box[1][1]
+        assert 0 <= p[2] <= box[2][2]
+
+
+@pytest.mark.slow
+def test_calculate_voids_returns_sys_and_ratios(tmp_path, monkeypatch):
+    """End-to-end: write a small Cu cell to a LAMMPS data file, run
+    ``calculate_voids``, and confirm it returns a populated sys + ratios."""
+    pytest.importorskip("pyscal3")
+    from ase.io.lammpsdata import write_lammps_data
+
+    from pyiron_workflow_atomistics.structure.defects import calculate_voids
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True) * (2, 2, 2)
+    monkeypatch.chdir(tmp_path)
+    write_lammps_data("cu.data", cu)
+
+    sys, void_ratios, void_count = calculate_voids(
+        "cu.data",
+        format="lammps-data",
+        alat=3.6,
+        pf=0.74,
+        tabulate=False,
+        write=False,
+    )
+    assert sys.natoms > 32  # original 32 + void sites
+    assert len(void_ratios) > 0
+    assert len(void_count) == len(void_ratios)
+    # Sanity: tabulate=True path is covered separately to keep this test fast.
+
+
+@pytest.mark.slow
+def test_calculate_voids_with_tabulate_runs(tmp_path, monkeypatch):
+    """Covers the ``tabulate=True`` branch (calls ``tabulate_voids`` which
+    needs the matplotlib backend already forced to Agg in conftest)."""
+    pytest.importorskip("pyscal3")
+    import matplotlib.pyplot as plt
+    from ase.io.lammpsdata import write_lammps_data
+
+    from pyiron_workflow_atomistics.structure.defects import calculate_voids
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True) * (2, 2, 2)
+    monkeypatch.chdir(tmp_path)
+    write_lammps_data("cu.data", cu)
+    plt.close("all")
+    calculate_voids(
+        "cu.data",
+        format="lammps-data",
+        alat=3.6,
+        pf=0.74,
+        tabulate=True,
+        write=False,
+    )
+    plt.close("all")
+
+
+@pytest.mark.slow
+def test_filter_and_cluster_atoms_runs_after_calculate_voids(tmp_path, monkeypatch):
+    pytest.importorskip("pyscal3")
+    from ase.io.lammpsdata import write_lammps_data
+
+    from pyiron_workflow_atomistics.structure.defects import (
+        calculate_voids,
+        filter_and_cluster_atoms,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True) * (2, 2, 2)
+    monkeypatch.chdir(tmp_path)
+    write_lammps_data("cu.data", cu)
+
+    sys, _vr, _vc = calculate_voids(
+        "cu.data",
+        format="lammps-data",
+        alat=3.6,
+        pf=0.74,
+        tabulate=False,
+        write=False,
+    )
+    out = filter_and_cluster_atoms(
+        sys, distance=[0.0, 14.4], axis=2, rvv=[0.0, 1.5], write=False
+    )
+    # Output is a fresh System; it should still hold a positive atom count.
+    assert out.natoms > 0
+
+
+@pytest.mark.slow
+def test_filter_and_cluster_atoms_writes_output_when_requested(tmp_path, monkeypatch):
+    pytest.importorskip("pyscal3")
+    from ase.io.lammpsdata import write_lammps_data
+
+    from pyiron_workflow_atomistics.structure.defects import (
+        calculate_voids,
+        filter_and_cluster_atoms,
+    )
+
+    cu = bulk("Cu", "fcc", a=3.6, cubic=True) * (2, 2, 2)
+    monkeypatch.chdir(tmp_path)
+    write_lammps_data("cu.data", cu)
+
+    sys, _, _ = calculate_voids(
+        "cu.data",
+        format="lammps-data",
+        alat=3.6,
+        pf=0.74,
+        tabulate=False,
+        write=False,
+    )
+    filter_and_cluster_atoms(
+        sys, distance=[0.0, 14.4], axis=2, rvv=[0.0, 1.5], write=True
+    )
+    assert os.path.exists(tmp_path / "output.data")

--- a/tests/unit/structure/test_defects.py
+++ b/tests/unit/structure/test_defects.py
@@ -13,7 +13,6 @@ import numpy as np
 import pytest
 from ase.build import bulk
 
-
 # ---------------------------------------------------------------------------
 # Tier 1 — create_vacancy
 # ---------------------------------------------------------------------------
@@ -80,22 +79,38 @@ def test_filter_condition_inside_band_and_rvv():
 
     sys = _mock_sys([10.0, 10.0, 10.0])
     # pos lies inside [d_min, d_max] along axis=2, rvv inside (rvv_min, rvv_max).
-    assert filter_condition(
-        sys, pos=[0, 0, 4.0], rvv=0.5,
-        distance_min=2.0, distance_max=6.0,
-        axis=2, rvv_min=0.0, rvv_max=1.0,
-    ) is True
+    assert (
+        filter_condition(
+            sys,
+            pos=[0, 0, 4.0],
+            rvv=0.5,
+            distance_min=2.0,
+            distance_max=6.0,
+            axis=2,
+            rvv_min=0.0,
+            rvv_max=1.0,
+        )
+        is True
+    )
 
 
 def test_filter_condition_rvv_outside_returns_false():
     from pyiron_workflow_atomistics.structure.defects import filter_condition
 
     sys = _mock_sys([10.0, 10.0, 10.0])
-    assert filter_condition(
-        sys, pos=[0, 0, 4.0], rvv=5.0,
-        distance_min=2.0, distance_max=6.0,
-        axis=2, rvv_min=0.0, rvv_max=1.0,
-    ) is False
+    assert (
+        filter_condition(
+            sys,
+            pos=[0, 0, 4.0],
+            rvv=5.0,
+            distance_min=2.0,
+            distance_max=6.0,
+            axis=2,
+            rvv_min=0.0,
+            rvv_max=1.0,
+        )
+        is False
+    )
 
 
 def test_filter_condition_wrap_near_zero():
@@ -105,11 +120,19 @@ def test_filter_condition_wrap_near_zero():
 
     sys = _mock_sys([10.0, 10.0, 10.0])
     # band centred at (2+6)/2 = 4 with width 2; wrap window = [0, 2].
-    assert filter_condition(
-        sys, pos=[0, 0, 1.0], rvv=0.5,
-        distance_min=2.0, distance_max=6.0,
-        axis=2, rvv_min=0.0, rvv_max=1.0,
-    ) is True
+    assert (
+        filter_condition(
+            sys,
+            pos=[0, 0, 1.0],
+            rvv=0.5,
+            distance_min=2.0,
+            distance_max=6.0,
+            axis=2,
+            rvv_min=0.0,
+            rvv_max=1.0,
+        )
+        is True
+    )
 
 
 def test_filter_condition_wrap_near_boxdim():
@@ -118,11 +141,19 @@ def test_filter_condition_wrap_near_boxdim():
 
     sys = _mock_sys([10.0, 10.0, 10.0])
     # band centred at 4 with width 2 → top wrap window = [8, 10).
-    assert filter_condition(
-        sys, pos=[0, 0, 9.0], rvv=0.5,
-        distance_min=2.0, distance_max=6.0,
-        axis=2, rvv_min=0.0, rvv_max=1.0,
-    ) is True
+    assert (
+        filter_condition(
+            sys,
+            pos=[0, 0, 9.0],
+            rvv=0.5,
+            distance_min=2.0,
+            distance_max=6.0,
+            axis=2,
+            rvv_min=0.0,
+            rvv_max=1.0,
+        )
+        is True
+    )
 
 
 def test_filter_condition_outside_all_bands_returns_false():
@@ -130,11 +161,19 @@ def test_filter_condition_outside_all_bands_returns_false():
 
     sys = _mock_sys([10.0, 10.0, 10.0])
     # mid = 4, width = 2 → bands are [0,2], [2,6], [8,10). pos=7 lies outside.
-    assert filter_condition(
-        sys, pos=[0, 0, 7.0], rvv=0.5,
-        distance_min=2.0, distance_max=6.0,
-        axis=2, rvv_min=0.0, rvv_max=1.0,
-    ) is False
+    assert (
+        filter_condition(
+            sys,
+            pos=[0, 0, 7.0],
+            rvv=0.5,
+            distance_min=2.0,
+            distance_max=6.0,
+            axis=2,
+            rvv_min=0.0,
+            rvv_max=1.0,
+        )
+        is False
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds 93 new tests across 6 files covering the largest gaps reported on coveralls (the project sat at 37.76% there, 66% locally).
- Tightens input validation on `_axis_index_to_label` so `1.5`, `True`, `False`, etc. no longer silently coerce to a valid axis index.

## Coverage impact (local, all extras installed)

| Module | Before | After |
| --- | --- | --- |
| `_internal/workdir.py` | 0% | 100% |
| `physics/_grain_boundary_code/searcher.py` | 0% | 74% |
| `physics/_grain_boundary_code/constructor.py` | 40% | 95% |
| `structure/defects.py` | 11% | 99% |
| `physics/phonons/harmonic.py` | 24% | 46% |
| `physics/phonons/anharmonic.py` | 32% | 41% |
| `physics/phonons/md_renormalised.py` | 43% | 48% |
| **TOTAL** | **66%** | **83%** |

Coveralls will report a smaller but still substantial bump (~38% → ~55-60%) since CI runs without the optional `[phonons]`/`[phonons-md]`/`[free-energy]` extras.

## What's new

Test files added (mirroring existing `tests/unit/` layout):

- `tests/unit/_internal/test_workdir.py`
- `tests/unit/physics/test_gb_searcher.py`
- `tests/unit/physics/test_gb_constructor_helpers.py`
- `tests/unit/physics/test_phonons_helpers.py`
- `tests/unit/structure/test_defects.py` (+ empty `__init__.py`)
- `tests/integration/test_gb_code_pipeline.py`

Tiering follows the convention already in `tests/unit/physics/test_phonons.py`:
- **Tier 1** — pure-Python helpers, dataclass shape, error-path tests with `monkeypatch.setitem(sys.modules, ..., None)`, and small ASE structures (Cu/Fe/Ti). Always runs.
- **Tier 2** — `pytest.importorskip("phonopy" / "phono3py" / "pyscal3" / "dynaphopy")` and `@pytest.mark.slow`. Skipped cleanly when extras are missing.
- **Tier 3** — `tests/integration/test_gb_code_pipeline.py`: end-to-end `construct_GB_from_GBCode` macro run against a Σ5 [100] BCC Fe GB.

## Bug fix

`_axis_index_to_label` in `physics/_grain_boundary_code/constructor.py` previously coerced its input via `int()`, so `1.5 → 1`, `True → 1`, `False → 0` all silently passed. Now rejects non-`int`/non-`np.integer` (and `bool` explicitly) with the existing actionable error message. Numpy integer scalars still pass.

## Test plan

- [x] `pytest tests/unit` — 297 → 322 passing tests, 44 skipped (all optional-extra gated)
- [x] `pytest tests/unit -m "not slow"` — 84 tests pass in 2.6 s for the cheap CI subset
- [x] `pytest tests/integration/test_gb_code_pipeline.py` — both pass
- [x] Verified bug-fix tests (`1.5`, `True`, `False` rejected; `np.int64(0)` accepted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)