### PR TITLE
Add 0.7 fs sibling of dynaphopy_grace_example notebook

### DIFF
--- a/.ci_support/exclude
+++ b/.ci_support/exclude
@@ -1,1 +1,2 @@
 dynaphopy_grace_example.ipynb
+dynaphopy_grace_example_long.ipynb

--- a/notebooks/dynaphopy_grace_example_long.ipynb
+++ b/notebooks/dynaphopy_grace_example_long.ipynb
@@ -1,0 +1,1670 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b870fff4",
+   "metadata": {},
+   "source": [
+    "# Anharmonic phonon renormalisation with dynaphopy + GRACE (0.7 fs timestep)\n",
+    "\n",
+    "Sibling notebook to `dynaphopy_grace_example.ipynb`, identical wiring but\n",
+    "with the MD timestep dropped from 1.0 fs to **0.7 fs** to match the\n",
+    "dynaphopy upstream Tersoff Si example exactly\n",
+    "(https://abelcarreras.github.io/DynaPhoPy/examples.html, which uses\n",
+    "`-ts 0.0007` ps). At a fixed `production_steps = 50 000` this gives\n",
+    "35 ps of trajectory (vs the 50 ps the 1.0 fs sibling produces); a finer\n",
+    "integrator step trades a bit of total simulation time for better\n",
+    "numerical accuracy and a higher Nyquist limit in the power spectrum.\n",
+    "\n",
+    "Walks through `calculate_phonon_md_renormalisation` (v0.0.8) end-to-end\n",
+    "on Si 2×2×2 with the **GRACE-1L-OAM** foundation model. Shows two equivalent paths:\n",
+    "\n",
+    "1. **ASE-driven** — Langevin NVT MD via ASE's built-in integrator + GRACE calculator,\n",
+    "   routed through `calculate_phonon_md_renormalisation` (the user-facing macro).\n",
+    "2. **LAMMPS-driven** — same FM via LAMMPS' `pair_style grace`, NVT MD via LAMMPS' own\n",
+    "   integrator, trajectory parsed by `dynaphopy.interface.iofile` and fed into the\n",
+    "   same `_project_with_dynaphopy` node.\n",
+    "\n",
+    "References:\n",
+    "- dynaphopy upstream examples: <https://abelcarreras.github.io/DynaPhoPy/examples.html>\n",
+    "- GRACE foundation models: <https://github.com/ICAMS/grace-tensorpotential>\n",
+    "\n",
+    "**Hardware notes:** GRACE runs on GPU here (RTX 5070 Ti, sm_120). On Blackwell\n",
+    "GPUs the nvidia-* CUDA wheels bundled with TF 2.20 must be upgraded\n",
+    "(`nvidia-cuda-nvcc-cu12>=12.8`, `nvidia-cudnn-cu12>=9.22`, etc.) to support\n",
+    "ptxas compilation for compute capability 12.0. The first XLA-compile step on\n",
+    "a fresh process takes ~10 s; subsequent evals are ~25 ms/step on this hardware."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0fc7b26f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T16:51:32.751691Z",
+     "iopub.status.busy": "2026-05-15T16:51:32.751263Z",
+     "iopub.status.idle": "2026-05-15T16:51:34.596568Z",
+     "shell.execute_reply": "2026-05-15T16:51:34.593898Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "# Make WSL CUDA driver libs visible to TensorFlow.\n",
+    "os.environ.setdefault(\"LD_LIBRARY_PATH\", \"/usr/lib/wsl/lib\")\n",
+    "os.environ.setdefault(\"CUDA_CACHE_PATH\", os.path.expanduser(\"~/.nv/ComputeCache\"))\n",
+    "os.environ[\"TF_CPP_MIN_LOG_LEVEL\"] = \"2\"\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\", category=RuntimeWarning)\n",
+    "warnings.filterwarnings(\"ignore\", category=DeprecationWarning)\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from ase.build import bulk, make_supercell\n",
+    "from ase.calculators.singlepoint import SinglePointCalculator"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "601be70e",
+   "metadata": {},
+   "source": [
+    "## 1. Structure + GRACE foundation model\n",
+    "\n",
+    "Si primitive (diamond, 2-atom basis, a=5.43 Å) → 2×2×2 supercell for MD (16 atoms).\n",
+    "Same supercell is used by both halves for apples-to-apples comparison."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "db5632c3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T16:51:34.601912Z",
+     "iopub.status.busy": "2026-05-15T16:51:34.601208Z",
+     "iopub.status.idle": "2026-05-15T16:51:34.631041Z",
+     "shell.execute_reply": "2026-05-15T16:51:34.629296Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Si primitive: 2 atoms, cell=[3.83958982 3.83958982 3.83958982]\n",
+      "2x2x2 supercell: 16 atoms\n"
+     ]
+    }
+   ],
+   "source": [
+    "si_prim = bulk(\"Si\", \"diamond\", a=5.43)\n",
+    "fc2_multiplier = 2 * np.eye(3, dtype=int)\n",
+    "si_supercell = make_supercell(si_prim, fc2_multiplier)\n",
+    "print(f\"Si primitive: {len(si_prim)} atoms, cell={si_prim.cell.lengths()}\")\n",
+    "print(f\"2x2x2 supercell: {len(si_supercell)} atoms\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6d40f81b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T16:51:34.637908Z",
+     "iopub.status.busy": "2026-05-15T16:51:34.636812Z",
+     "iopub.status.idle": "2026-05-15T16:51:57.394139Z",
+     "shell.execute_reply": "2026-05-15T16:51:57.391154Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[tensorpotential] Info: Environment variable TF_USE_LEGACY_KERAS is automatically set to '1'.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using cached GRACE model from /home/liger/.cache/grace/GRACE-1L-OAM\n",
+      "Model license: Academic Software License\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
+      "W0000 00:00:1778863906.129419  317976 gpu_device.cc:2431] TensorFlow was not built with CUDA kernel binaries compatible with compute capability 12.0. CUDA kernels will be jit-compiled from PTX, which could take 30 minutes or longer.\n",
+      "W0000 00:00:1778863906.140005  317976 gpu_device.cc:2431] TensorFlow was not built with CUDA kernel binaries compatible with compute capability 12.0. CUDA kernels will be jit-compiled from PTX, which could take 30 minutes or longer.\n",
+      "I0000 00:00:1778863907.606090  317976 gpu_device.cc:2020] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 9226 MB memory:  -> device: 0, name: NVIDIA GeForce RTX 5070 Ti Laptop GPU, pci bus id: 0000:63:00.0, compute capability: 12.0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "I0000 00:00:1778863917.133422  317976 device_compiler.h:196] Compiled cluster using XLA!  This line is logged at most once for the lifetime of the process.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GRACE-1L-OAM on Si primitive: E = -10.8372 eV  (-5.4186 eV/atom)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from tensorpotential.calculator.foundation_models import grace_fm\n",
+    "\n",
+    "grace_calc = grace_fm(\"GRACE-1L-OAM\")\n",
+    "si_prim_check = si_prim.copy()\n",
+    "si_prim_check.calc = grace_calc\n",
+    "e0 = si_prim_check.get_potential_energy()\n",
+    "print(f\"GRACE-1L-OAM on Si primitive: E = {e0:.4f} eV  ({e0/len(si_prim_check):.4f} eV/atom)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f11cdf7a",
+   "metadata": {},
+   "source": [
+    "## 2. Section A — ASE-driven workflow through `calculate_phonon_md_renormalisation`\n",
+    "\n",
+    "The macro is the single user-facing entry point. It internally:\n",
+    "1. resolves arguments (`_resolve_md_defaults`),\n",
+    "2. fits FC2 from displacement-force evals through `engine.calculate` (`_compute_fc2_from_scratch`),\n",
+    "3. runs ASE Langevin NVT MD borrowing the engine's calculator (`_run_nvt_trajectory`),\n",
+    "4. builds `dynaphopy.Quasiparticle` and fits Lorentzians (`_project_with_dynaphopy`).\n",
+    "\n",
+    "Returns a typed `MdPhononOutput` dataclass with harmonic and renormalised\n",
+    "frequencies, per-band power spectra, linewidths, MD diagnostics, and\n",
+    "optional handles to the underlying dynaphopy / phonopy objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "40be6b3f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T16:51:57.398198Z",
+     "iopub.status.busy": "2026-05-15T16:51:57.397775Z",
+     "iopub.status.idle": "2026-05-15T17:12:42.784680Z",
+     "shell.execute_reply": "2026-05-15T17:12:42.780744Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No velocity provided! calculating it from coordinates...\n",
+      "MD cell size relation: [2 2 2]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using 50000 steps\n",
+      "Calculating phonon projection power spectra\n",
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Harmonic frequencies (THz):\n",
+      "[2.52669885e-07 3.29447212e-07 4.08406407e-07 2.41045897e+01\n",
+      " 2.41045897e+01 2.41045897e+01]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Peak # 1\n",
+      "----------------------------------------------\n",
+      "Width                             1.960977 THz\n",
+      "Position                         12.336521 THz\n",
+      "Area (<K>)    (Lorentzian)        1.011224 eV\n",
+      "Area (<K>)    (Total)            13.482631 eV\n",
+      "<|dQ/dt|^2>                       2.022449 eV\n",
+      "Base line                         0.312558 eV * ps\n",
+      "Maximum height                    0.328288 eV * ps\n",
+      "Fitting global error              0.120241\n",
+      "Frequency shift                  12.336521 THz\n",
+      "\n",
+      "Peak # 2\n",
+      "----------------------------------------------\n",
+      "Width                             1.960977 THz\n",
+      "Position                         12.336521 THz\n",
+      "Area (<K>)    (Lorentzian)        1.011224 eV\n",
+      "Area (<K>)    (Total)            13.482631 eV\n",
+      "<|dQ/dt|^2>                       2.022449 eV\n",
+      "Base line                         0.312558 eV * ps\n",
+      "Maximum height                    0.328288 eV * ps\n",
+      "Fitting global error              0.120241\n",
+      "Frequency shift                  12.336521 THz\n",
+      "\n",
+      "Peak # 3\n",
+      "----------------------------------------------\n",
+      "Width                             1.960977 THz\n",
+      "Position                         12.336521 THz\n",
+      "Area (<K>)    (Lorentzian)        1.011224 eV\n",
+      "Area (<K>)    (Total)            13.482631 eV\n",
+      "<|dQ/dt|^2>                       2.022449 eV\n",
+      "Base line                         0.312558 eV * ps\n",
+      "Maximum height                    0.328288 eV * ps\n",
+      "Fitting global error              0.120241\n",
+      "Frequency shift                  12.336521 THz\n",
+      "\n",
+      "Peak # 4\n",
+      "----------------------------------------------\n",
+      "Width                             2.066022 THz\n",
+      "Position                         13.538997 THz\n",
+      "Area (<K>)    (Lorentzian)        1.840801 eV\n",
+      "Area (<K>)    (Total)            13.863428 eV\n",
+      "<|dQ/dt|^2>                       3.681602 eV\n",
+      "Base line                         0.302106 eV * ps\n",
+      "Maximum height                    0.567221 eV * ps\n",
+      "Fitting global error              0.048189\n",
+      "Frequency shift                 -10.565593 THz\n",
+      "\n",
+      "Peak # 5\n",
+      "----------------------------------------------\n",
+      "Width                             2.066022 THz\n",
+      "Position                         13.538997 THz\n",
+      "Area (<K>)    (Lorentzian)        1.840801 eV\n",
+      "Area (<K>)    (Total)            13.863428 eV\n",
+      "<|dQ/dt|^2>                       3.681602 eV\n",
+      "Base line                         0.302106 eV * ps\n",
+      "Maximum height                    0.567221 eV * ps\n",
+      "Fitting global error              0.048189\n",
+      "Frequency shift                 -10.565593 THz\n",
+      "\n",
+      "Peak # 6\n",
+      "----------------------------------------------\n",
+      "Width                             2.066022 THz\n",
+      "Position                         13.538997 THz\n",
+      "Area (<K>)    (Lorentzian)        1.840801 eV\n",
+      "Area (<K>)    (Total)            13.863428 eV\n",
+      "<|dQ/dt|^2>                       3.681602 eV\n",
+      "Base line                         0.302106 eV * ps\n",
+      "Maximum height                    0.567221 eV * ps\n",
+      "Fitting global error              0.048189\n",
+      "Frequency shift                 -10.565593 THz\n",
+      "Calculating phonon projection power spectra\n",
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Peak # 1\n",
+      "----------------------------------------------\n",
+      "Width                             2.314049 THz\n",
+      "Position                         13.095756 THz\n",
+      "Area (<K>)    (Lorentzian)        1.183044 eV\n",
+      "Area (<K>)    (Total)            13.428333 eV\n",
+      "<|dQ/dt|^2>                       2.366088 eV\n",
+      "Base line                         0.307202 eV * ps\n",
+      "Maximum height                    0.325468 eV * ps\n",
+      "Fitting global error              0.099967\n",
+      "Frequency shift                   6.391205 THz\n",
+      "\n",
+      "Peak # 2\n",
+      "----------------------------------------------\n",
+      "Width                             2.314049 THz\n",
+      "Position                         13.095756 THz\n",
+      "Area (<K>)    (Lorentzian)        1.183044 eV\n",
+      "Area (<K>)    (Total)            13.428333 eV\n",
+      "<|dQ/dt|^2>                       2.366088 eV\n",
+      "Base line                         0.307202 eV * ps\n",
+      "Maximum height                    0.325468 eV * ps\n",
+      "Fitting global error              0.099967\n",
+      "Frequency shift                   6.391205 THz\n",
+      "\n",
+      "Peak # 3\n",
+      "----------------------------------------------\n",
+      "Width                             3.149097 THz\n",
+      "Position                         13.206055 THz\n",
+      "Area (<K>)    (Lorentzian)        2.185645 eV\n",
+      "Area (<K>)    (Total)            13.704608 eV\n",
+      "<|dQ/dt|^2>                       4.371290 eV\n",
+      "Base line                         0.290934 eV * ps\n",
+      "Maximum height                    0.441849 eV * ps\n",
+      "Fitting global error              0.079543\n",
+      "Frequency shift                  -3.867679 THz\n",
+      "\n",
+      "Peak # 4\n",
+      "----------------------------------------------\n",
+      "Width                             2.207238 THz\n",
+      "Position                         11.082478 THz\n",
+      "Area (<K>)    (Lorentzian)        1.118892 eV\n",
+      "Area (<K>)    (Total)            13.398960 eV\n",
+      "<|dQ/dt|^2>                       2.237784 eV\n",
+      "Base line                         0.308063 eV * ps\n",
+      "Maximum height                    0.322715 eV * ps\n",
+      "Fitting global error              0.111510\n",
+      "Frequency shift                  -7.926440 THz\n",
+      "\n",
+      "Peak # 5\n",
+      "----------------------------------------------\n",
+      "Width                             2.594471 THz\n",
+      "Position                         13.203341 THz\n",
+      "Area (<K>)    (Lorentzian)        1.497081 eV\n",
+      "Area (<K>)    (Total)            13.548029 eV\n",
+      "<|dQ/dt|^2>                       2.994162 eV\n",
+      "Base line                         0.302882 eV * ps\n",
+      "Maximum height                    0.367347 eV * ps\n",
+      "Fitting global error              0.091173\n",
+      "Frequency shift                  -9.689549 THz\n",
+      "\n",
+      "Peak # 6\n",
+      "----------------------------------------------\n",
+      "Width                             2.594471 THz\n",
+      "Position                         13.203341 THz\n",
+      "Area (<K>)    (Lorentzian)        1.497081 eV\n",
+      "Area (<K>)    (Total)            13.548029 eV\n",
+      "<|dQ/dt|^2>                       2.994162 eV\n",
+      "Base line                         0.302882 eV * ps\n",
+      "Maximum height                    0.367347 eV * ps\n",
+      "Fitting global error              0.091173\n",
+      "Frequency shift                  -9.689549 THz\n",
+      "Calculating phonon projection power spectra\n",
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 9.0391301   9.0391301  18.66589077 18.66589077 21.78408021 21.78408021]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 9.0391301   9.0391301  18.66589077 18.66589077 21.78408021 21.78408021]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 9.0391301   9.0391301  18.66589077 18.66589077 21.78408021 21.78408021]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Harmonic frequencies (THz):\n",
+      "[ 9.0391301   9.0391301  18.66589077 18.66589077 21.78408021 21.78408021]\n",
+      "\n",
+      "Peak # 1\n",
+      "----------------------------------------------\n",
+      "Width                             2.634452 THz\n",
+      "Position                         13.367815 THz\n",
+      "Area (<K>)    (Lorentzian)        1.594925 eV\n",
+      "Area (<K>)    (Total)            13.598847 eV\n",
+      "<|dQ/dt|^2>                       3.189850 eV\n",
+      "Base line                         0.301836 eV * ps\n",
+      "Maximum height                    0.385416 eV * ps\n",
+      "Fitting global error              0.082342\n",
+      "Frequency shift                   4.328685 THz\n",
+      "\n",
+      "Peak # 2\n",
+      "----------------------------------------------\n",
+      "Width                             2.634452 THz\n",
+      "Position                         13.367815 THz\n",
+      "Area (<K>)    (Lorentzian)        1.594925 eV\n",
+      "Area (<K>)    (Total)            13.598847 eV\n",
+      "<|dQ/dt|^2>                       3.189850 eV\n",
+      "Base line                         0.301836 eV * ps\n",
+      "Maximum height                    0.385416 eV * ps\n",
+      "Fitting global error              0.082342\n",
+      "Frequency shift                   4.328685 THz\n",
+      "\n",
+      "Peak # 3\n",
+      "----------------------------------------------\n",
+      "Width                             3.868821 THz\n",
+      "Position                         12.583148 THz\n",
+      "Area (<K>)    (Lorentzian)        1.759154 eV\n",
+      "Area (<K>)    (Total)            13.550873 eV\n",
+      "<|dQ/dt|^2>                       3.518308 eV\n",
+      "Base line                         0.297771 eV * ps\n",
+      "Maximum height                    0.289471 eV * ps\n",
+      "Fitting global error              0.138069\n",
+      "Frequency shift                  -6.082743 THz\n",
+      "\n",
+      "Peak # 4\n",
+      "----------------------------------------------\n",
+      "Width                             3.868821 THz\n",
+      "Position                         12.583148 THz\n",
+      "Area (<K>)    (Lorentzian)        1.759154 eV\n",
+      "Area (<K>)    (Total)            13.550873 eV\n",
+      "<|dQ/dt|^2>                       3.518308 eV\n",
+      "Base line                         0.297771 eV * ps\n",
+      "Maximum height                    0.289471 eV * ps\n",
+      "Fitting global error              0.138069\n",
+      "Frequency shift                  -6.082743 THz\n",
+      "\n",
+      "Peak # 5\n",
+      "----------------------------------------------\n",
+      "Width                             2.355574 THz\n",
+      "Position                         12.774174 THz\n",
+      "Area (<K>)    (Lorentzian)        1.084584 eV\n",
+      "Area (<K>)    (Total)            13.292361 eV\n",
+      "<|dQ/dt|^2>                       2.169167 eV\n",
+      "Base line                         0.306196 eV * ps\n",
+      "Maximum height                    0.293121 eV * ps\n",
+      "Fitting global error              0.116376\n",
+      "Frequency shift                  -9.009907 THz\n",
+      "\n",
+      "Peak # 6\n",
+      "----------------------------------------------\n",
+      "Width                             2.355574 THz\n",
+      "Position                         12.774174 THz\n",
+      "Area (<K>)    (Lorentzian)        1.084584 eV\n",
+      "Area (<K>)    (Total)            13.292361 eV\n",
+      "<|dQ/dt|^2>                       2.169167 eV\n",
+      "Base line                         0.306196 eV * ps\n",
+      "Maximum height                    0.293121 eV * ps\n",
+      "Fitting global error              0.116376\n",
+      "Frequency shift                  -9.009907 THz\n",
+      "Calculating phonon projection power spectra\n",
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n",
+      "\n",
+      "Peak # 1\n",
+      "----------------------------------------------\n",
+      "Width                             2.314049 THz\n",
+      "Position                         13.095756 THz\n",
+      "Area (<K>)    (Lorentzian)        1.183044 eV\n",
+      "Area (<K>)    (Total)            13.428332 eV\n",
+      "<|dQ/dt|^2>                       2.366088 eV\n",
+      "Base line                         0.307202 eV * ps\n",
+      "Maximum height                    0.325468 eV * ps\n",
+      "Fitting global error              0.099967\n",
+      "Frequency shift                   6.391205 THz\n",
+      "\n",
+      "Peak # 2\n",
+      "----------------------------------------------\n",
+      "Width                             2.314049 THz\n",
+      "Position                         13.095756 THz\n",
+      "Area (<K>)    (Lorentzian)        1.183044 eV\n",
+      "Area (<K>)    (Total)            13.428332 eV\n",
+      "<|dQ/dt|^2>                       2.366088 eV\n",
+      "Base line                         0.307202 eV * ps\n",
+      "Maximum height                    0.325468 eV * ps\n",
+      "Fitting global error              0.099967\n",
+      "Frequency shift                   6.391205 THz\n",
+      "\n",
+      "Peak # 3\n",
+      "----------------------------------------------\n",
+      "Width                             3.149097 THz\n",
+      "Position                         13.206055 THz\n",
+      "Area (<K>)    (Lorentzian)        2.185645 eV\n",
+      "Area (<K>)    (Total)            13.704608 eV\n",
+      "<|dQ/dt|^2>                       4.371290 eV\n",
+      "Base line                         0.290934 eV * ps\n",
+      "Maximum height                    0.441849 eV * ps\n",
+      "Fitting global error              0.079543\n",
+      "Frequency shift                  -3.867679 THz\n",
+      "\n",
+      "Peak # 4\n",
+      "----------------------------------------------\n",
+      "Width                             2.207238 THz\n",
+      "Position                         11.082478 THz\n",
+      "Area (<K>)    (Lorentzian)        1.118892 eV\n",
+      "Area (<K>)    (Total)            13.398960 eV\n",
+      "<|dQ/dt|^2>                       2.237784 eV\n",
+      "Base line                         0.308063 eV * ps\n",
+      "Maximum height                    0.322715 eV * ps\n",
+      "Fitting global error              0.111510\n",
+      "Frequency shift                  -7.926440 THz\n",
+      "\n",
+      "Peak # 5\n",
+      "----------------------------------------------\n",
+      "Width                             2.594471 THz\n",
+      "Position                         13.203341 THz\n",
+      "Area (<K>)    (Lorentzian)        1.497081 eV\n",
+      "Area (<K>)    (Total)            13.548029 eV\n",
+      "<|dQ/dt|^2>                       2.994162 eV\n",
+      "Base line                         0.302882 eV * ps\n",
+      "Maximum height                    0.367347 eV * ps\n",
+      "Fitting global error              0.091173\n",
+      "Frequency shift                  -9.689549 THz\n",
+      "\n",
+      "Peak # 6\n",
+      "----------------------------------------------\n",
+      "Width                             2.594471 THz\n",
+      "Position                         13.203341 THz\n",
+      "Area (<K>)    (Lorentzian)        1.497081 eV\n",
+      "Area (<K>)    (Total)            13.548029 eV\n",
+      "<|dQ/dt|^2>                       2.994162 eV\n",
+      "Base line                         0.302882 eV * ps\n",
+      "Maximum height                    0.367347 eV * ps\n",
+      "Fitting global error              0.091173\n",
+      "Frequency shift                  -9.689549 THz\n",
+      "⟨T⟩ measured: 294.5 K  (target 300 K)\n",
+      "σ_T: 60.9 K\n",
+      "harmonic   freqs (THz): [2.85225322e-07 4.03488783e-07 4.94219497e-07 2.41048043e+01\n",
+      " 2.41048043e+01 2.41048043e+01]\n",
+      "renormalised freqs (THz): [ 0.          0.          0.         13.53899696 13.53899696 13.53899696]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic\n",
+    "from pyiron_workflow_atomistics.physics.phonons import (\n",
+    "    calculate_phonon_md_renormalisation,\n",
+    ")\n",
+    "\n",
+    "ase_engine = ASEEngine(\n",
+    "    EngineInput=CalcInputStatic(),\n",
+    "    calculator=grace_calc,\n",
+    "    working_directory=\"./_dynaphopy_grace_0p7fs/ase_run\",\n",
+    ")\n",
+    "\n",
+    "# Band-path of commensurate q-points for the 2×2×2 supercell — these\n",
+    "# are the only q's where dynaphopy's mode projection is well-defined.\n",
+    "# Γ → X → K/W-like → L is a standard FCC path through high-symmetry points.\n",
+    "wf_ase = calculate_phonon_md_renormalisation(\n",
+    "    structure=si_prim,\n",
+    "    engine=ase_engine,\n",
+    "    fc2_supercell_matrix=fc2_multiplier,\n",
+    "    temperature=300.0,\n",
+    "    equilibration_steps=5000,\n",
+    "    production_steps=50000,\n",
+    "    time_step=0.7,\n",
+    "    thermostat_time_constant=100.0,\n",
+    "    q_points=[[0.0, 0.0, 0.0], [0.5, 0.0, 0.0], [0.5, 0.5, 0.0], [0.5, 0.5, 0.5]],\n",
+    "    seed=42,\n",
+    "    keep_handles=True,\n",
+    "    power_spectra=True,\n",
+    ")\n",
+    "# GRACE's TF FuncGraph isn't pickleable; disable pyiron_workflow's recovery save.\n",
+    "wf_ase.recovery = None\n",
+    "wf_ase.run()\n",
+    "out_ase = wf_ase.outputs.md_phonon_output.value\n",
+    "\n",
+    "print(f\"⟨T⟩ measured: {out_ase.md_temperature_mean:.1f} K  (target {out_ase.temperature:.0f} K)\")\n",
+    "print(f\"σ_T: {out_ase.md_temperature_std:.1f} K\")\n",
+    "print(f\"harmonic   freqs (THz): {out_ase.harmonic_frequencies[0]}\")\n",
+    "print(f\"renormalised freqs (THz): {out_ase.renormalised_frequencies[0]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a1eb6ef",
+   "metadata": {},
+   "source": [
+    "### Section A plot — renormalised phonon dispersion (ASE) + power spectrum at X\n",
+    "\n",
+    "Left: harmonic dispersion (continuous lines from phonopy at each commensurate\n",
+    "q-point) vs MD-projected renormalised frequencies (markers, dynaphopy fit on\n",
+    "the Langevin trajectory). Right: per-band power spectra at q = X, with\n",
+    "vertical dotted lines marking the harmonic positions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e5114858",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T17:12:42.789581Z",
+     "iopub.status.busy": "2026-05-15T17:12:42.789045Z",
+     "iopub.status.idle": "2026-05-15T17:12:43.592706Z",
+     "shell.execute_reply": "2026-05-15T17:12:43.588923Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABEEAAAGGCAYAAACUtJ9/AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQABAABJREFUeJzsnQd4HNXZtp/tRatqSZZsy713Y8A0U43phF5SKCEkHwkJCakkgXykkUrIRwj8aZBACARCC8UUg6mmuPfebXWrba//9ZzRrFerlbSSJa2kfW9fxzuanZ1ypp3znLcYYrFYDIIgCIIgCIIgCIIgCEMcY6Z3QBAEQRAEQRAEQRAEoT8QEUQQBEEQBEEQBEEQhKxARBBBEARBEARBEARBELICEUEEQRAEQRAEQRAEQcgKRAQRBEEQBEEQBEEQBCErEBFEEARBEARBEARBEISsQEQQQRAEQRAEQRAEQRCyAhFBBEEQBEEQBEEQBEHICkQEEQRBEARBEARBEAQhKxARRBAEQRAEQRC6wZ49e2AwGPDII48Munr73//9X7XvgiAI2YqIIIIgCIIgCMJRQTGAHWuW9957r933sVgMFRUV6vsLL7ywzXf671jMZjOKioowf/583Hbbbdi0aVNWnplDhw4psWLNmjWZ3hUhA3zwwQfq/Dc2Ng7J+v/5z3+O5557Lq1l//KXv6hnw9///vd23y1fvhxGoxHf+ta3kGmuuuoqtZ/f/e53OxVPb7zxRkyYMAF2ux1lZWU49dRT8aMf/ajNcqeffnqb52JimTp1aj8czdDHEONbSRAEQRAEQRCOQgRh454Ne37+8Y9/bPP9smXLcMYZZ8Bms2HRokV48cUXjzRGDQacffbZuO6665RY0tTUhLVr1+Kpp56Cx+PBL3/5S9x+++0D6txwPwOBACwWC0wmU6+vf8WKFTjuuOPw8MMP44YbbujVdbNzfffdd6tjEAYmv/nNb/Dtb38bu3fvxtixYzHUcLlcuOKKK9KypOJ1SqFgy5YtqgwbNkzND4VCOOaYY9Dc3KzE0pycHGQK7sPw4cOVqBGJRLB379521lY7duxQ97TD4cDnP/95dV4rKyuxatUqvPLKK/D7/W1EkJ07d+Kee+5pt638/HxcdNFF/XJcQxlzpndAEARBEARBGBqcf/75Srz4v//7P2XVofP4448r6466urqUv5s8eTI++9nPtpn3i1/8QjX2v/nNb6rRT667r2BHi50QdlDSgR0cCj7CwIbn1Gq1KmuBoUo0GkUwGByy1yPvtf/3//4f5s6dqyw+KAyS3/72t9iwYQNeeOGFjAog5D//+Y8SP/72t7/hzDPPxDvvvIPTTjutzTK/+93v4Ha7lXXXmDFj2nxXU1OTUuxIfiYKvcfQfSIIgiAIgiAI/cq1116L+vp6vP766/F57KA9/fTT+PSnP92tdXHE94knnlBiys9+9rO0XXLYAfnSl76kfp+Xl6csTBoaGtosy1FYuuW8+uqrOPbYY5X4wY4W2bVrF6688krlluN0OnHCCSfgpZdeSismCEeqOcLN37JTynWzk5YM3Ry+8Y1vqP2gdcyoUaPUflIkotUMR4wJrWp0M/jEbX300Uc499xzVUeJ+8gO1/vvv99uO3RN4rq4LzTB148xHTgaPXPmTKxcuRInnXSSqqNx48bhoYcearcsO3E33XSTGg3ntubMmdPOfYGj9pdddlmbebNmzVLHtm7duvi8J598Us3bvHlzfN7BgwfV6DnXz/qaMWOG6nAmwnrj73jN/PCHP8TIkSNV3XCUviO4LMW53Nxcda1wf37/+9/36JoiHNFfuHCh6pRznRdccAE2btzYbjleJ3SfKCkpUfU6ZcoU/OAHP4hb6tAKhLC+9fPPa45w+tZbb8U///lPVQ+sjyVLlsSPn59dXau0LqI1xr59+9R9wGnW1wMPPKC+X79+verM8zjYYaeIma4FC68V1hOPi3XLez8R7gstvHh96MfWlbXT9OnTVZ3wGN5++21lIfPjH/9YXU8DwSqC54LWbLR2mzZtmvo7GVp28D5PFkBIaWlpP+2poCOWIIIgCIIgCEKvwE79iSeeiH/9618477zz4h1Durhcc801ykKkO4wePVp18N966y3VmWUHtCvYQSwoKFCdya1bt+LBBx9U5ul6J1GH31G0Yef25ptvVh3R6upq1Ynzer342te+pjpz7KxdfPHFqjN36aWXdrhddnZPPvlk1Zn83ve+pzqQ//73v3HJJZeokWL9txwNZkeZnXx27CkOUPygWHLgwAHViWIH76677sIXv/hFtSzhfpE333xT1S07mIwlQCsHjo6z0/ruu+/i+OOPj3dkFy9erDrarItwOKyWp5CQLuzo0wKHHXbWFY/nlltuUdYV3Hfi8/mUYEJzf9Y9O+60BmLHlmIPY7sQHgevC53Dhw+rOuP+c79nz56t5nOa+8x6IDwnFKL0zj+/4zVF0YXXxNe//vU2+/yTn/xE7R+tBuiyxOlUUKjjMZ111lnK5YrwnFBM0ve5O9fUo48+iuuvvx7nnHOOWh+vIS53yimnYPXq1XG3Fgo+rAu6UvH8cj47yP/973+V2MeO/bZt21Rd0XqguLhY/Y7HrcNrgOeC+8XvuY7uxg+h5QKvI7qa/OpXv1Idd66P1y0Fmc985jNqXyh6UfThfc1z2xkUkHiv8LcUPykyUVCk+xsFIb2evvCFL6jrlMdPKNB1BYUtro/3K4UEiqPdfZ70VfwePp900Y/XFM/bH/7whzbXHvf5jTfeUOeO92o65yeV5RzFpUxbvgwJGBNEEARBEARBEHrKww8/zAATsU8++ST2hz/8IZabmxvzer3quyuvvDJ2xhlnqOkxY8bELrjggja/5e++8pWvdLju2267TS2zdu3atPZh/vz5sWAwGJ//q1/9Ss1//vnn4/O4H5y3ZMmSNuv4+te/rua/++678XktLS2xcePGxcaOHRuLRCJq3u7du9Vy3KbOWWedFZs1a1bM7/fH50Wj0dhJJ50UmzRpUnzeXXfdpX77zDPPtDsGLk9Yj8nr17/nus4555z4soR1zX08++yz4/MuueSSmN1uj+3duzc+b9OmTTGTyaTW3RWnnXaaWu63v/1tfF4gEIjNnTs3VlpaGq/j++67Ty332GOPxZfjdyeeeGLM5XLFmpub1bynnnpKLcd9IC+88ELMZrPFLr744tjVV18d/+3s2bNjl156afzvm266KVZeXh6rq6trs3/XXHNNLD8/P36dvfXWW2r948ePj8/rDF5XeXl5sXA4fNTXFK+RgoKC2M0339zm91VVVWofE+efeuqp6v5IPC8k8Xz++te/VuvndZYM5xuNxtjGjRvbzNePn5+JpLpWr7/+ejXv5z//eXxeQ0NDzOFwxAwGQ+yJJ56Iz9+yZYta9kc/+lGsK5LrnXU2c+bM2Jlnntlmfk5OjtqH7vLqq6+qfWHhdTcQ+M1vfqPqTb/Ot23bpvbv2WefbbPchg0b1HL8jvcQr7/nnnsu5vF4Orz3UpUvfelL/XZsQxlxhxEEQRAEQRB6DVoN0DqAo78tLS3qs7uuMInQVJ9wXenA0WWOsuvQcoGjxi+//HKb5TiqzVH7RLgMR6g5ep+4fa6TbgUdZauhVQNHeHns3E+O4LLQNYjb2L59u3LpILQKobtIKquSrlLXMp4A18X65Lr17dC9gBYNdNtgjAiOItPVh1YotKbRoXVF8jF3BuuNI+86HNnm33R/oZuMXmcMCMkRcB3WPy1paPVC9wWiW7RwH3WLD7rq0I2A04TWDIzzoC/LPj/riy4PnNaPl4XHQQsjBpZMhNYY6cR2oWUH6y3Rdaun1xTXwX1nHSTuI4PmLliwQFkKkNraWnX8tKJJPC+kO2mLaR1FF5GjhRYZifVBayhaGfA61uE8fkc3sa5IrHdaEfH88Fwmn6OeQjczPb4LrZwGArSgoZUL3Z/IpEmTlJVWsksMXZd4/zLOB58ltJrh/UnLrD//+c/t1kvrHl5XySXZ8knoGeIOIwiCIAiCIPQaNNtnBhjGEaBLADvkjJPRU9iRJnono6qqqs33jIuR2PliJyQRihjl5eXxmAo6qUz76eLATmsyumsGv2ecjGToCsJO+p133qlKKigc0FWGrg+XX345egIFEL2j3xHseNINhEJUcl3ondpkQagjRowY0c70nkFsCeuTbiqsE24nOfhoYp0Rdva4HAUPCin8ZAwFumN89atfVZ1suqNQxNFFEIoGFBf+9Kc/qZKK5KCSXbls6Hz5y19WLiV0CeF5YaeanX/GWkmmq2tKPy8duTnobly6kJDqGuoO6R5jZzB2S6KLjX4vMW5FsiDD+alioCRDwfOnP/2p6uzzGuyJwNMRfI5QjOI1yWcCRbZ0BCzeB7wnegKfKzz2juD1SlcnugvxGaBD9zDGV0l24eO9Q3cgHgsFVdYXXZF4XDynfG7q8L5L/FvoXUQEEQRBEARBEHoVWiowzgYFC3YyOZLcU2gZwBF1vePHzmciPU0jm24mmHRgx50wDkVHlhYTJ07ste38+te/VtkyUsEOemIHdCBBC5ulS5eqjiktSRj3hIIArw+KIuxUcv/nzZvX5ng5et6R8KPHEunueWUwSnbWaTHDGCMsvJbYoU0O6toV+n6yg0urmGQSMyX1BqmOsSOhgR3uVHSU2rmj+V2lVOb5YzwQilpMkc37lNYzrNN0A6t2Bi0nKDg899xzyqrqK1/5ilpvV1ZmDLTLAMM9gddcZ2l8H3vsMfXJIMcsydCKKdW2WccMwsvCWCsUA2k5IqJH/yEiiCAIgiAIgtCr0NWDo/0ffvih6oT0FGavoDsFOwq6JUjy6C/NzBPhqDw7FTocNa6srEwrxS6DFzLwZapsHvr3qRg/frz6ZKevq44Mg0BS2OmMjjq0egBJji53th0964huoZBIquPrLOgjXUYSrUEYtJPogT5ZJwz2SSEg0RokVZ3RwoOdYga4ZOecwV75G4ojugjCeXpHnMfB885l+6KDSPceutqwcP9pHcIMOrTmSRSturqm9PNCYaWz/dSvk56e/84oLCxUn8kBUnVLnL6GHX5al1BUYsYaHT2l7dEc3/79+1VQ30996lOq8FxRqLr99tuVK0pn1hoUJdOxGEkFrU46gqIQRRheF7xukmGAXgobXQkwzCBFeD0J/YfEBBEEQRAEQRB6FY7mMzMGs2n0NIUl42wwxgI7wHr6UMJOZmJJtgyh20QoFIr/zf1gZhQ9W01nsFP78ccfY/ny5fF5FAG4Tnb6O4rDwM4vTeDZgU7VmaFbhw5dYdauXYtnn322w9F2XXRI7tAy1gA73ExFqrsJpdoORQR2/jhqTiFJhyIDO6npwnpLTKvLjB/8m+IE90WvM1r8JIpd/N3999+vrgPGr9DR3VyYPYUWHHrnlfNpIbJixYr4MvpxsL7YwU4lHCTWa3dhTJVEKMboViXJljRdXVOsawpTP//5z9ssl7yfrDdaSjC9b+J5Sba06Oj8dwbFJtaXHnNFh1YZ/QG3TXEj0fKE7kK8BpPh8XXn2OguxfrhNaWfK2atYdyV73//+53+ls+H5GdGuqWzuCvMIsTjo8hBd7/kcvXVV6tYMBQSCUW+VNeG7ppGNzWh/xBLEEEQBEEQBKHX6SxuRTK0LqBpOTs69KOnSMA0q+zo33vvvSnjNHQEO+oMEsr4DrR6YCeQlgY01e8KprbV0/sy5gADMXLEeffu3aojnhz3IhHGAOB2aOJOVyCO+jO9KwUVpr7lMZFvf/vbKt0uU4cyQCbFBAo+TJHLjh2DplLooIsI/6YlBDuNjFVCl6C//OUvav9oAcMOGONZ0D2AHS52xJlqldx9991YsmSJEhU4Uq0LE/wdLTfSHQmnYMHOHuMZUOigCwlFAT1QKOMZUBihSxJdXCgW8fjYSbzvvvviFjyE1hV0F+F5YcdWh8LAd7/7XTWdKIKQX/ziF+rYePysV3ZMWV8MtsmUo5zuaVBQ/pZxPBgHgxYTrB+6GenxTNK9pljvFEY+97nPqZTHTAdNwYNCx0svvaRSJzNlKmFaV/6Wy+mxIFi/XI51S3SBieIf18W6ppjYWWpUCkq8pngMFCN4DTHmRHLMlL6CFhn6vUoXFW6X9wTPefL1xuPjuePyvMZYB6li8RCKhc8//zx++9vfoqKiIj6fLlN0iWG98tpjkN3+hFYeFH701L/J8Nrg+aPVEy1WeB/x/mDaYV1s4zX8j3/8Qz1nkgOeMo6J7m6TDN3DhKMk0+lpBEEQBEEQhKGTIrczOkqRqxem/mSq0Xnz5qkUkslpQNPZh7fffjv2xS9+MVZYWKhStH7mM5+J1dfXd7kfOjt37oxdccUVaj+YYvb444+Pvfjii12mHdV/e91118XKyspiFoslNnLkyNiFF14Ye/rpp9ssx/259dZb1fdWqzU2atQolTI0MQ0s069Onz49Zjab221r9erVscsuuyw2bNgwlWaWx3PVVVfFli5d2mY7rAumd+U2mDr2oYceUqlO002RO2PGjNiKFStUulvWBbfDFMjJVFdXx2688cZYcXGx2hZTBSfXjQ5TJnP7Tz75ZJtUqk6nU/3W5/OlXD/TKFdUVKh6Zf0yJfGf/vSndilimYo3HXhOFi9erNL9crujR49W6UcrKyt7dE3p+8D0xUyLy/qaMGFC7IYbblB1mJwulWmA9WtsypQpsTvvvLPNMj/5yU/U9cF7IjFdbmcppWtra2OXX365qkvuK4+H20qVIpdpajs658l0dr8k8te//lWlcOY1OXXqVLXNVNcb0+4yVbCeMrajdLlMPcx7gyllU6UyZlraESNGxI455phOUx33Nrxeee8tXLiw0+WYtprPMvL++++r88aUwbw+eB3zmuP1wedGuilypfveOxj439EKKYIgCIIgCIKQSRjAkJYRn3zySdzPvq9ghheOcDMQ5lAdlaV7D90NuopfMZTpz2tKEIT+Q2KCCIIgCIIgCEI30ON+FBcXS70JgiAMMiQmiCAIgiAIgiCkCYNasjidTpxwwglSb4IgCIMMsQQRBEEQBEEQhDRhMEsG1GTgVgYvFQRBEAYXEhNEEARBEARBEARBEISsQCxBBEEQBEEQBEEQBEHICkQEEQRBEARBEARBEAQhKxARZIBzww03YOzYsW3mGQwG/O///m+/7ge3x+32FsuWLVPre/rppzFUGYjHuGfPHrVPTPk22BlKx9Jf/OpXv8LUqVMRjUYzvSuCkDahUAgVFRX44x//KLUmDNnn7mB7p+ltHH52Bo+Hy/H4ElPvsgx19GNfsWIFspGeXtMPPfQQRo8ejUAg0Gf7JgjGTD4U9GI2mzFy5EjV4T948KCcFUHIcv773//itNNOQ2lpqYq+P378eFx11VVYsmRJt9e1ZcsWfOc738HcuXORm5uL8vJyXHDBBb3WKGHDls+0iy++WHXUcnJyMHPmTPz0pz+F3+/vlW30xjE0Nzfjl7/8Jb773e/CaGz76GdD4/7778cpp5yCwsJCWK1WjBgxQh3Tv/71L0QikXaNGr1wXUVFRTjvvPOwfPnyDre/efNmtbzdbkdjY2OHy7HOfve732HBggXIz89Xy0+ePBm33nortm3b1k6Y7ahUVVV1WSc/+9nP1DEOHz68U3GZ7yaXy4WjYd++ffif//kfJWrbbDZ1bV9yySV4//33O/0dzzv37eqrr075feL54DWXis985jPq+6M9hnTPI++Jf/zjH+oc8trgNctzeN111+HDDz9s14nqqDzxxBNqOYvFgttvv12dr966pwShP+jsudubfPDBB+r5leqe/PnPf47nnnuuz7YtCL0N37nBYBD/7//9P6lcYWimyP3xj3+McePGqUYNG0bsSLz33nvYsGGDamAJqfH5fEo4EoShyG9+8xt8+9vfViLIHXfcoUSQHTt24I033lCdonPPPVctN2bMGHUvsIPUGX/5y1/w17/+FZdffjm+/OUvo6mpSb1YmdaQosqiRYuOan+9Xi9uvPFGtT52ctm5pRjwox/9CEuXLsWbb7551FZUvXEMTOcYDodx7bXXtplfW1urBIyVK1finHPOwQ9/+EPVcaWIwDr/9Kc/rer/zjvvbPM7ruf8889XAgnFCY7Sn3HGGfjkk08wa9asdtt/7LHHUFZWhoaGBmUd9YUvfKHdMnV1der8cl8uvPBCtW123Ldu3arO/Z/+9CfVMErkwQcfTNm5TydjA4+V+zRv3jy8+uqr6CsodLCuCI97+vTpqn75zlu4cCF+//vf46tf/Wq738ViMSVCUTihMNjS0qIEhVTwnclleUyJeDwePP/88732Tk3nPH7ta1/DAw88gE996lNKgOH7iufwlVdeUYJmckpRLn/ccce1W8+JJ54Yn+Y99r3vfQ+PP/44Pv/5z/fKsQhCX9PRc7cvRJC7775bdR6Tn30UQa644golug4UXnvttUzvgtAPpNtOS4bvq+uvvx733nuvejf2piW6IMSJZYCHH344xk1/8sknbeZ/97vfVfOffPLJ2EDF4/H06/auv/762JgxY2KZ5kc/+pE6N73FW2+9pdb31FNPxYYqA/EYd+/erfaJ9+BAJBQKxfLy8mJnn312yu+rq6u7vc4VK1bEWlpa2syrq6uLlZSUxE4++eR2y/O5tHr16g73L7nuAoFA7P3332+37N13363q+vXXX28zPxqNxv72t7+pz1S88847sc2bNx/VMaRi9uzZsc9+9rPt5p9zzjkxo9EY+89//pPyd6yPxx57rN019Otf/7rNcq+88oqaf8stt7RbB4917Nixsdtvvz126aWXxk4//fSU27rgggvUvjz99NPtvvP7/bFvfvOb7Z5JtbW1sZ7CYyFcB9fFdXb0HM7JyenRNg4fPhwrKyuLDR8+PLZjx44233m93tjChQvVMae6ht588021X/y0WCyxRx55JOUxcJnLLrtMfa5Zs6bN9//85z/Vby+66KIeH0N3zmNVVVXMYDDEbr755pS/T7yHu/uMvPDCC1V9CcJgoaPnbm+/n/k85m/1Z1oivO/5DOtt9PuXn+m0+VPt21Cno/7OYO+b9Ads97Duli5dmuldEYYoAyomCEfEyM6dO9uZglPF5ugk1cFjjz0WL7zwQkoXG4640Wy2pKREmaVfeumlaqQzGY5azpgxQ5kl0+z7K1/5SjszQvor0qydo5KnnnqqGpH+/ve/Hzc/5og1R7s4ssXvFi9ejP3796vRu5/85CcYNWoUHA6HGg1jPvlEODJHc3Zum/swYcIE9ZtEs/OOSDbb5ujg17/+9TZm1meffTZWrVrV5ncfffSRGmWliTn3lyPtqUyxaY3DUTnWNferO+ZoiXV20kknqeOntQ/9+zoym6aJM+uK2zvrrLPUqHMyTz31FObPn6/WV1xcjM9+9rPtXKd0k3XO54gHp3kdfOtb32pXrxwd/eY3v6ncF1hnU6ZMUeeT5y65rmmGT1NSHheX5XXTHbcMbpvXDUdPeU3S/J7XSSLvvvsurrzySuUDyW1wv77xjW8oBb2nx8jrmcvzfHNkiKp6KlNZjkhzlJXngNumqwWv2UT/3f6ClgA0Hz755JNTfs9ru7u+prxuki0Fhg0bpp43NO1PhtYntIjYvn17m/m8Nm666SZV1q9fH59P1xFe68nw2UOSt8F7jiPZvP6SWb16tbKAuOuuu47qGJLZvXs31q1b185ihBYrtID44he/iMsuuyzlb/m85Wh+T5/f+jHzfF1zzTWqvPPOOzhw4EC759NLL72k6pcWL8nw2uQ92pskx1vqC/j85D3261//Wj1PE+Hz7O9//7u6jmkZmcw///lPZTVCCxueO/7dEbSa4LOWlhLJ6+Bzn+/PoyWd88hrjfdKqnuYx5l4D3cXvtf4fkp+nwrCQKSj52533s+E1oR8vrL9wGX5fk587rM9SOtJwmeA7k6mvyPZ3tGfMyzcrg7bEnwf0SVQb9/QeiUZ3udsc3AfeA+zfXI08RqSY4LornH//ve/02oTptOeTbdt3B+wrrrqm6TbL+jLvkl3+0ebNm1S7yduh2ENGP8mkY7aaezX0cWZ9cF9YRv8Bz/4Qbt2D99brBdB6AsGlE+F3umiT7rOxo0bVWOKNxdNYfnw4EOSD+P//Oc/8Y6GDs2m+HuaonN99913n+rEPvnkk21eGDQb5IvplltuUWa6NKmmGTcfoolmW/X19cpUnA0+drz5okhsXNI0m9vkg4Q3P2/qM888Uz3Q6QPKhzd97dlJTXyx8IHATg0fivzkS44dH3YA2VjuDjTBp1kyj5MNZu4zG4p8SR5zzDFqGa6fx8GHCuuGvqkPP/yw2ld2wI8//ni1HDt3fGDywcR6ohknl0887q6gmTRNv1kXNAHl+WI9s7OYbMb8i1/8Qu0L64cm/qxDdrj4gkusK3bSKczcc889qK6uVubjPFfsNCaafvJlwQ4sfdH5IqA5/29/+1v1MuE+EL4IKES89dZbqsPFOAvsCLIRwQYB4xEkwrp85plnlBsCTdH/7//+T3XS6OPPjmhX8IXOlwCvh5qaGnVN8tpbs2aNevjrIg/dKriPXOfHH3+srhs2PPhdIukeI19w3HdeH9OmTcOzzz6rGlrJ8Fh4n/E6ZmOB+/j666+r4+uPTmIibKSwTmj6z/3pjY5bR7BjSkEtmUcffVTFxtA7XGwwEN6rjHNAl4xU7h6p1k+St8F18zpnrAc+q3Q3E4oubNRRCEtXeOzoGFKZShP9eaDDeiZ8tvXF8zvxWcnrk/cwG05sMNF1Q2+4E13Y/tznPtet7aZqxNH9Ih13mP6AdczGPJ+HqWCnhdcEn9EUPfVnAhvNfMfpYhmfpXwO8pxTUE0Fl6G7Cp+rfOZQVKTZOa/pnsTT6cl5pPkz4XOLwi6X6Qp2VrivyfBZmGgGzfcXn228nikWCsJApqPnbnfez3y/s+3GDi3bZHxGsG3AdjE783xHU8CmSyLvRbZf9HcC23G89+myxjYexW6ii7FsS9E1TR/s4fJ0WWO7iG1RCgiE26QYwTYBXdfYMeZ6+czqbdJpE6bbnk2nbdxRIGZuOx3YRkkn1ks6fZPu9Av6qm/Snf4R2/pss/D64/pZ11w320fct46gMEhRj+viNclrmIMnfFeyvZwIz1NXcbMEocdk0jzsjTfeUGbI+/fvV+bPNO222Wzqb52zzjorNmvWLGUKnWhSe9JJJ8UmTZrUbp2LFi1qY2b+jW98I2YymWKNjY3q75qampjVao0tXrw4FolE4sv94Q9/UL+nmbrOaaedpuY99NBDKU0Wub/6eskdd9yh5s+ZM0eZzetce+21apuJx0Az6GS+9KUvxZxOZ5vlUrnDJJtt5+fnx77yla90WN+sD9YVzd4T64b7MG7cuDauB5dccknMbrfH9u7dG5+3adMmVYfpXC56nf32t79t4y4wd+7cWGlpaSwYDLYxo5w2bZr6Xuf3v/+9mr9+/Xr1N5fn72bOnBnz+Xzx5V588UW13F133dWmrjjvxz/+cZt9mjdvXmz+/Pnxv5977jm13E9/+tM2y11xxRXKjDvRZJ3L8dwlzlu7dq2af//993daF/oxjhw5Mtbc3Byf/+9//1vN57F2dj3cc889an8Sz0V3j/FXv/pVfF44HFam5Inmtg0NDSldGzIJzyn3iSa85513XuxnP/tZbOXKlb1qOkyXE9btnXfemfL7nTt3xsrLy9X1yWfUT37yE7WtX/ziF2lvg88iuvawjlOhu//x2XPgwAF1n/N+PHToUK8cQyI//OEP1baSXWro0sD5ic8xwnuNx62XxGPQ653uPvyO7g/vvvtu7Ljjjkvp2sB7eNiwYbEf/OAH8Xmf/vSn1XMy1b50VF/J6O4wqcqUKVNi3aEv3WEKCgraHWsyX/va19T2161bF5/HdyLnbd++Xf3NZwifzb/73e/a/DbRPWnDhg1qmueDPPDAAzGXy6VMpY/mGLpzHsl1112n9qOwsFCd19/85jftXLwSn5EdlcrKyjbL897g/F/+8pc9Pg5B6C86eu6m+34metupvr6+TRuELnS8z47GHeamm25S7zm6ViZyzTXXqHal3i6577771LrZdtHhM2XixIk9dodhW5FFJ902YXfas121jTuiq+dSYunKxSfdvol+DOn0C/qqb9KT/tE//vGP+DyeN7p+Xn755e32KfGaPvXUU2O5ublt2rYklYvwF7/4xZjD4UhZt4IwqN1hqDRSeabpP91daOXB0UB95JUKJpVQKoz6SBELFVDdXD3ZJYKqYuLIEdVGjpzv3bs3rqpTIaXCnaje3nzzzcjLy1Pm2InQHIyjb6ngKBdN8XQ4Mk+oyiYGLuV8bjNxX/XRPqIfG/eV1gA0E+sOHPGkSn7o0KGU39PigHXFIIOsO70eaSJJdZ8mzXRLYT3RIoJWNhyN1uEoBes7XXjsX/rSl+J/0wKEf9PCgOZ7ibBu+X2ySf2uXbvUJ7Nf8He0wkgM7EeTQaacSz5fuvqfCNepr4+8/PLLMJlMakQjEY64UvfgSEjydZpoxj579mx1rSSuszOYESExmCGvdbqccD9SXQ88Lzw/dLHg/tDapSfHyPOgW4YQHnNy8EVul/XP0QGq+gMBjkLQpF8PVkkTSY74cEQgHdePruD1xHuBI/C0xkgFR924bY66c9u01uBoN0c50oGB6Pis4ahWRxYJ/I4jdDwnHI3jyD8tcHht9MYxJML7ntdDsksNR5hI8ny6r/HZrBdaKiTDES1+R6sE3S2HFkm8vhPh/cTtJwYG5PTatWuVBVLyvnQU+LMjaC3BekssHBUcKHQWzFRH/16vA300j65IEydOjC/D515nLjE0YebziSPChPcRR5zTscboinTPI2H9/+EPf1DXJ0e4OdrI9wjfN6kywHG0M/kcsiRbgulWRqmsRgRhoNHRczfd93NlZaVqv9F9JfFe4D1OS8XENkR3YduCz86LLrpITevtQha292gJobuNcDt8LyU+2/lM0S1LepOu2oTptmfTaRt3xJw5c1I+j1KVjqzykumqb9LdfkFf9E262z/idZ1oRcrzRiucztrGdAHiOaJVeGI/g6QKfspnPi2RWAeCMKTcYeizxrR5fNjSHIs3Bm9sHZpr8eHMDkhyZoLEzgBdZXSSbyq90aR38PQHDv3PEuHNy45P4gOJcN2JD+REkrelP3Qo6qSan9jJZKORUfwp8iQ2fEm6Zng6NHWjGSW3yw4bXVHY8ebxED22QSpTy8RtshPGh82kSZPafc/6SveFS1NJClqJ8DwTmgEmZgbo6fkiFEFo2pgIhRJ2zJLXmVj3XCf3MbljwkZ64jY72sdU6+yM5Prkg54dm8SYGzQzZUeAImDyepOvh3SPkY2W5MZXcj3yfmP6PgpANKfkuaGZOa+fzl7uvE66e50mvugTX9CpYOeKhfcGGzE0E2WHjg22o8kexYYSj48NDF47naUMpUknG6WM1cC6oDiTDjRv5b1Nk+LERm4qaOJKtwG6PTEKenLMiKM9hq7Q7wG3293mnNBFiu4OhNdGqlhFbNSxscXsXnyO0U0s1XJ0z2BnmNea7tvN42Qjmh16CkaEjSzC4+qOKwt9ojtzCUpOlcvjTGxs9gasP5bEDo1+j7KOeUydoX+vnw/6X/N5S3PpRH94msCz40LTd/2Zmgw7BxSj6LNPc3z6ivcG6Z5HwgY0/chZ2FGhOTOFNQopNN+myXryvZZOhiM9ZpNkChAGM+m+nztr/7C9QqGe74Pk9lY6sDPK5wzdO1k6al/r+8E2S/J9l2q/jpau2oTptmf5u67axh3B3x5t1rjuHld3+wV90Tfpbv+IA9bJ1wSPi+4uHaELJHr7oivkmS8MWRGEiiFHugitDzjayAYcfdD4ctDVXI4idWSJoI+SJTY+U5Ec8DJdOmssd7StrvaBLx4GcWKjnx0sNiTZqaPqzpFm/bjThZYyVIs54kb/b3as2LFlHAv65enr43zGv0gF6/toglz1lN4+Xx2tbyDtYzLsOHJUh5ZPPP8Ud9iooTrPEaDk66G3j5GqP8UFBn9lo4qCI2Ov8EVMa4yOOvodjUJ0BRslXQUz1eE9wrphof8og7tRFOH90104wkHfVb6geZxdvYTpn8qOHQOAMYAo7zPeY52lp+bIEBtZHLHvKBiwDsUDPvcYd4edW3ZWWd+JweKO9hgSYytwO8lWCbzWCIWlxECWbCzpDSY2alKNvFPc0xuKFGV4XTJuE4Ok6c91NuRYjzzWVOIqhS09Zo6+L4xLpI/+9QbJljW0UkgMDNgbMDZPokjGuBi6yMnOCq25+HxNFPkT4fnk9a3XEYUxLk8xgyUZig4diXIUDxncl6N3PO+M8XS0dOc8JsN9YAwmFl7bb7/9tmpM67FDuoPeWE8nDo4gZJqOnrsDAb1dwZH8jgQFWpz0N121t9Jtz6bTNu7sPZtu8GWK3em0yXq7X9AXfZOB1jbWn/kU2nt74EIQBlRgVN5M7HixAU0zWjamdbWWjcPeUmX1hheFlkQ1mA89RvLubfU3FXQ94OgYH8QcxdTh9o+moU+XERaq93QdYKOUD3p9dJkP186OT4/SnJwVQ6+vdKHpYfLoBEcuSXcDbSaeLwZ1St6nnjSk+Rua/SU3THRzw56sszNSZRnhSKrewGCnj/XDDj470Ikd6p7CY1i6dKkanU4cberoPPIa4Yg/C/eXjQt2vjj6mwqKkj3dP1rh9AR2rFlHNBHuLmxAsG5ZJwzU25WIwo4aG1C8X2idww4g/2bnmQHhUnX2KM4wUDP3k9voTCxhw5jr+/DDD/Hiiy8q1yd2VvWAvRy1OtpjSEQXGPiMSWzYUrygWw471R1l5EkXui39+c9/ViNZehBOPuPYcWZgteSOK69FLksrAQrgFOL4DuA115siSPJ1SpeR3obnJdFlKLHBxjqmiEZhI1UAWooltIzgtab/jueDAhddjpJh0FyKDh2JIBwF5Lnke4aWSJ1dh+nSnfPYGbw3eG/xHu7Jc1Z/R+pWe4IwkOnouZvu+zmx/ZMM2yu8F/V2VmfWUam+Y3uP7R8OwnTV7uV+UChn2yVxXd1pF/YW6bZn02kbdwQt6NgXSQee294IIN8X/YKB2D/S18vrKR24XXneC33FgEqRy1EiWocwajIbXMwUwXls9KXq+KRKfdsVvIlp2kXT7US18q9//asyN+MIbl+jq6eJ2+dDhmmpugtfYMlmcqw3djR1yw52qPji4Ghlosl2cj1yv9i5pUUA3TN06OvPUed0YQcvMbsFj41/86WbqnPXVaOZx8NR9URLFZpVc796cr5oEsl6o9iWCKOq8wXf2cuxJzCjSKI5PCNo83rWt5PqeuA0M+D0FB4jzwM7LTo8ZkYDT4R+lrzXEuG1wsZRZ5ZBbFjwXupJYZT2juD+sMOYCj1WS09McOnWQusV3mMdpYLV4cgLxQheq3Q9oAjL39BkmJ3T5FgyRL8W2RiiqNHZqAXPLa1o6O7AzizrhCMd/B0bCIy2niouUHeOIVX6VD3GTiLsLNPKhsfWURq6dEd16MLC2D98VtBvm1DQ4DExhg39yRMLLfzYAdBjXHAfeex/+ctf1DMoGT5H+Jvuknz9pRNzpbvwGBO3kSgosU74DGNMmWRfad57vBZYx3paZKYypGsoRbLkOmPh8hRRE7MlJPPTn/5UCSjJMQZ6SnfOI92PmDYx1fljx4+uMskWnOnCmFJ8RuvXsyAMZDp67qb7fuazigMSFP8TU5SyA0nLBq5HRxdDUqXZ5XfJ89nuoNsj33GpOqSJ7Wtuh4NbbLskvqs7cqPpS9Jtz6bTNu7PmCD92S/oKf3RP2I/gCIPQyAk9jM6amuwPcZBIkEY0pYgOmwo0s+c5vJscDFuCEeX6DNM8142xJjWix0l+tEzKFt3b0CaCnMUjQ1udnaoevJBw7R/vZEqsit4Q9PEnCaI7FCxUcfR5Z6YkLFzTb88Nkb54GZjlFYOTGelm1Gz0cmOBTvdHAVlI5r+hHS34KgzFXU9VSbrhaO4HImlcs4XNV/M/F1nfn6J8CVDk0OOcNJvnR03dor4wkxMr5UOXJ7r4j5z5Jum3nqKXHY46ffeXTjiTJWfI9fcR9YbGxTsBNI1JJ24DN2BAc14DfMYuO8U+dgJ4PWsjxZxm+xM8JzwfLBhcjSBSnmM7IjRoorHSOGBIwzJjQJaoDCYGDtcXIajxjQd5X7Sd7+/YcOK9wdjk/D+pEsGG2/sFHO0nO4jHbnodATrm/c3G6QUG5KtW2i9kWi1RNNTPmcYBCwxoCQDefGc8HvGw9DT5PIepHjI7/j8Sg4exnOb2GnjiDk7jGxYJIoZFBEoIPBaYYeY1h49PYZkeDy0LOCzITlNNdfFumbd8hnBhhCfT+zMcnl2yNMVBm+77Ta1r7QuYYwTPl9SiUaEriGsN1pIsNHFe52CIS1iWC+8hnlt8rhonfTEE08o8ZCN30TYME8VF4XiTlepvfncpWuGHnSNx0oBQU/Vm2itwLSJ+nfJ9zeflZ2ZxHMf2YDkKCSD4fJeY/3yPUdBg88zvaFHYUxP450Kdkh4n/Ia0gPeJcNnZTqWQnr68c5chNj56c555HuZgxm03OP5YyeBI7AM1sr3NZ+xydYkvLeTxVjC0fPEEXR2OvhcSyc1uSBkmo6eu+m+nwldOPj85bOfcab0FLmM58B0pjr6ABPbNXx383nK7fD5ye+4D3wms33G2D58dvA5zXub02yPcD/oBsKOJ5fXXUL4HQeNaPFGIZLiDJ+dvRFwubuk255Np23cnzFB+rNf0FP6q3/E9wTbOXwfsi3F65H3AdtO+gAK4bXGa5DBvQWhT4hlAD1l1CeffNLuO6ZlmjBhgipMGaanq2QqMKZeslgsKuXohRdeqFIIdrVOPdVVcgovpnyaOnWqWt/w4cNjt9xyS7vUjEwBNWPGjHb7mJiSMNW2klNEptq3999/P3bCCSeo1E8jRoyIfec734m9+uqr7fa1qxS5TEn17W9/W6W+YsoppkLj9B//+Md2+7169erYZZddptIcMhUx13vVVVfFli5d2ma5t99+W6VbZaqs8ePHqzRcejrKrtDrbMWKFbETTzxRpXTkdljf6dRVR2lPn3zySZUGlvtdVFQU+8xnPqPSiibSUQrIVPvOlHVMUca65zXAlGs8n8kpuvi7VCnWeEypUs6lOsZ//etfKkUZ09zxfF9wwQXtUoMxDTFTqDGdZXFxcezmm2+Op+JNrIvuHCNT6n3uc59TaVqZKo7TvAYS18nUeDw+3gtcL5dbsGBBm1R4/QnTt/35z39WqZpZxzzfTA/Hc8/zk5g6L90UuXpa4XRT3DENZ3V1dYfrYx0mou9HRyXVdZK8jkT27NkTO3z48FEdQyruvfdedX2lSsPHlLhMg8h7lteL2WxWz1s+Z//5z3/Gn8WJx9tRWuUbbrhBpf5jWlQul/x8SeSRRx5Ryzz//PPxedw//pYpd7m/fA7x/vzqV7/aJlV1Zyly00nbmJjmr6vfd1b/fFelA+uN9/Xo0aPVM4f3+cUXXxxPZ6vDlPBcpjNOP/109Tzh/dLV+ejs2cE03/ztkiVLOvwd05135zwylS/TWjKF5ahRo9Sx8t3Ea4v3duIztqtUlIkpi5nykdfCX/7yl06PUxAGEh09d9N5P+u88cYbsZNPPlm1H7j8RRddpNoMyTCVO9vHTJ+b+F7YsmWLSkvK3ye/k/iuYxugoqJC3at87p911lmxP/3pT23WzTYLn1d8H/PZddttt6nnRm+nyE23TdhVe7Y7beO+pDt9k3T7BX3ZNzna/lFyn6Wj88d07kyfzhTy7Ccwrf2dd97ZZpnvfve76l2YKnWuIPQGBv7XN/KKkI3QfYlBFNP19xMEoX/gKCNHJhkxnyOKgkALMI7AffzxxwO+MmhhxGt3586dEiRPGDTIc1cQug9dlmjtTWspWpgKwpCPCSIIgiD0DTSf/s53vqPMq7ubgUoYenD8g8H4Urn4DDToikRTfgZglSwBwmBCnruC0H3ookmXLoZFEIS+QixBhF5FLEEEQRAEQRAEQRCEgYpYggiCIAiCIAiCIAiCkBWIJYggCIIgCIIgCIIgCFmBWIIIgiAIgiAIgiAIgpAViAgiCIIgCIIgCIIgCEJWYM7kxu+55x4888wz2LJli4r4ftJJJ+GXv/wlpkyZ0ibQ5ttvv93md1/60pfw0EMPpbUNZkE4dOgQcnNzYTAYev0YBEEQBCHbM820tLRgxIgRMBqzd2xF2huCIAiCMDjaGxmNCXLuuefimmuuwXHHHYdwOIzvf//72LBhAzZt2oScnJy4CDJ58mT8+Mc/jv/O6XQiLy8vrW0cOHAAFRUVfXYMgiAIgiAA+/fvx6hRo7K2KqS9IQiCIAiDo72RUUuQJUuWtPn7kUceQWlpKVauXIlTTz21jehRVlbWo23QAkSvrHSFk3RGe2pra1FSUpLVo15Cz5DrRzga5PoRBtq109zcrAYb9PdttqIf/969e1FQUJDp3RlU9NdzLRwKYs2L/09Nz73wSzBbrBjsyDth8NZdOBrGf3f9V01fNP4imI391y2LhcNofP4FNV3wqYthMJsHVd31hHAwhLf+8ZyaPuO6S2C2WjKyH4Ox7gYKjY2NGDNmTK+0NzIqgiTT1NSkPouKitrM/+c//4nHHntMCSEXXXQR7rzzTiWMpCIQCKiiQ5MZ4nK5VOmti9fn86n1ycUryPUj9Cfy/BEG2rXD9ZJsdznVj58DLr016JIt8Bry+/2q3vqyXRWNRDDu2EVquqCgEEaTCYOd/qq7oUim6y4ai+LEcSeq6YL8AhgN/bcPsWgUtpNOUtO2ggIYunn8ma67nhANRzBnYWt9FxTAaM7M/T8Y626g0JvtDfNAOqivf/3rOPnkkzFz5sz4/E9/+tNK8aHvz7p16/Dd734XW7duVbFEOoozcvfdd7ebT8WNF1xv7SsFG3oSycUryPUj9Cfy/BEG2rWjDzYIwkCHose4GQsyvRuCoKDoMblwckZqg6KHfUpmtp0pKHpMPG56pndDGCAMGBHkK1/5iooH8t5777WZ/8UvfjE+PWvWLJSXl+Oss87Czp07MWHChHbrueOOO3D77be3M9OlyVFvusNQgRIzJkGuH6G/keePMNCuHbvdLidFEARBEIRBw4AQQW699Va8+OKLeOedd7oMcrJggabg79ixI6UIYrPZVEmGDb7ebPSxIdnb6xSyB7l+BLl+hKHy7JH3oDBYoAuAx625Xue48rvtAiAIvXo9xmLwhr1q2ml29qtLIbcd9WjbNub077YzORDgbfKoaWd+jry7spyMPv15A1IAefbZZ/Hmm29i3LhxXf5mzZo16pMWIYIgCIIgCIKQDpFIGBtf/ZsqnBaETBKJRfDy7pdV4XT/bjyC5pdeUoXT2QBjgrz3xIuqcFrIbsyZdoF5/PHH8fzzz6sor1VVVWp+fn4+HA6Hcnnh9+effz6GDRumYoJ84xvfUJljZs+encldFwRBEARBEAYZRtOAMIIWBIXZkLnr0ZChwKCZxDAEgiELvUNG3wQPPvig+jz99NPbzH/44Ydxww03wGq14o033sB9990Hj8ejYntcfvnl+OEPf5ihPRYEQRAEQRAGI0yJe9xlt2V6NwRBwZS4l066NCO1wZS4BZdfnlVngilxz/niVZneDWGAYM60O0xnUPR4++23+21/BEEQBEEQBEEQBEEYukhEKEEQBEEQBEEQBEEQsgJxjOwBqx59Dp6mJjQfMxe5ZSXIKcyFK9+l8k8LgiAIgiAIA49IOIytn7yupqccdzZMZmkGCxm8HqMRrK5Zrabnlc6Dydh//YhYJALfqlVq2nHMMVkRKyMcDmPDm5+o6ZlnHgez3P9ZjTz9e+DCs/H9DxEM+LBj9RoYrFYY7HYYbTaYbXZY7Q7YnE6t5OTAkcvigjPPhZwCllw4C1xy4wmCIAiCIPQjsVgULQc2adPHniV1n0H8Hjde+cNvVZyWUz97I/JLy7LufMQQw+7m3Wp6buncft54DIFd2rYd8+YhK4jGULVzj5qcefqxmd4bIcOICNJNglVVCIcC8b9jwaAqUaMRUZsNIbsd3qauq9VstSnBxOqgWOKE3ZWjijPXBXtujhJLWFwUTKyW7p9ZQRAEQRAEIY7RaMKwySfEp4XMsXv1CjRUHlLTHz37byz+0tey7nQYDUbMHDYzPt2/GzfCMWtmfDobMBqNGDt3RnxayG5EBOkmlpJSHH/VFahZuw6R2joEfAEEIzGEohEEAyGEfX7EzCYYW61DOnqwhIMBVbzNjV2fJIsVlgQLE4olNlcOHBRN8l3Iyc9FTr4LzsJcWG3W7h6SIAiCIAjCkMdoMmHinJMzvRsCgG0rP0SVpwqRWASezT4sikayTpii8DFt2LSMbNtgNMI+fTqyCYYtmHri7EzvhjBAEBGkBzfQjHNORsm8SSgpLkZo1y74Vq9BYOsWxMIRRKMxhGOAN2IA7UUiw0sRKSlD2GaHz+NFwONBwOtFkMXvQzQS7nKb4VBQFV9LU5fLmswWZV1idVA0oXWJE3bdLSfPBScFkwIXXBRM7LbuHr4gCIIgCIIg9JhwKITd29YpAYQ0ug9j2/Y1mDplvtSqIAj9goggR6uiTp6sStTrhW/devhWr4KxsgpWJWZHgIaDqpjy8+CYOxeOeafCXFQUX0fAG4CnsRmexhZ4mtzwt3jgY3F7lGDi93gR9FEw8SIa7lowiYRDSixJRzAxms2w2imYUChxwup0KusSXTChdYnmlpMHm1MEE0EQBEEQBjd+n0d92h05md6VrKWh+hDcwRaELUBLEVBYDSxb8UJWiiCBiOZibzP1fzs7GtC2rSzXswS/x6c+7TmOTO+KkGFEBOkljE4nck5YoEqoqgq+1avhW7MWUZ92s0WamuF++x1VrGPGqCBE9pkzlLhgc5agaERJl9sI+gNwN7TA0+iGr8UNb5P26Xd74Hd7EfB6EPT5lGhCMaQrKKr43c2qNNd2cXwmCiYOJZTQyoTWJXTL0YO+0i2HRVmYOGziaycIgiAIwoCCVrVrX3xITc+/5KvK3Vjof3bsXq8SDQRzTThh+qnYWv0W9uzfouYZDIasOSXhaBgv7HxBTV868VKYjf3XLYuFw2h67nk1XXD5ZTBkQaaUcDCEZf94Tk0vuukKibmY5Qz9Kz4DWMrKYDnvPOSefTYC27bBu3o1Atu3q6jEJLh3ryrNL7+shBDnvHmwjB7d5YOf7itF5SzFXe5DMBCEl4JJk1sVX7Mb3hY3Akow0VxyWEJ+n2oUdAXddvyeFlW6gj6dFofjiEsOY5nEBZMcOPNyVVphiib2HLsIJoIgCIIgCFnC7r1ahh5nSRGmjzsG2956C+FGD/Y078G4/HGZ3j1BELIAEUH6EKqqDDrEEmlpUZYhtBAJ19Wp75lVxrdqtSqmYUVKDHHMmQNTfv5Rb5sBUq1lw1BQNiwtZdTd6FYuOb4mN7ytgolmYUK3HN0lx6eCuXZFNBpBwONWpQW1XboU0cLE4mgN+qoy5bhULJOcPE0ooWsOLUzsLocIJoIgCIIg9Ahafiy48ptSexmm+pCWprRkxBgUDx8Fq8kGuyeAdbXrskoEoeXHlZOvzFgfpfDqq5BNMNvmubdcm+ndEAYIIoL0E6bcXLgWnoKcU05G6MABzV1m/QbEWv3xIvWH0fLGUrQsfRO2CRM0d5mpU2CwWPrloVBQWqhKOoKJt9mjxTBp1AQTuuQwjoke9FUFfqVgEvB3ub5YNKrceFjc9Z0vazAYYbHbtbTCSjDJUemFVRyT/FxlZcJMOc4CzeJE0l8JgiBkLw888AB+/etfo6qqCnPmzMH999+P448/vsPl77vvPjz44IPYt28fiouLccUVV+Cee+6B3W7v1/0WhKGOp05r8I0ZNQV5JaUqHobVH8CG6nX41MRPZXr3BEHIAkQE6Wfo8mKtqFAl79xz4d+8WbnLBHft1haIxRDYsUMVo8MO+6zZcM6bC/OIEQPCT5KCSV5xgSpdEQ1H4KY7jnLLaYGv2aPcchj01e/xqAw5SjDxeRFKRzCJRTWLFJ8X7sNdLMx6tmkuOdaE1MIOFy1L6JLTmlqYbjm5TpX1RxAEQRgaPPnkk7j99tvx0EMPYcGCBUrgOOecc7B161aUlpa2W/7xxx/H9773Pfztb3/DSSedhG3btuGGG25Q79177703I8cgCEOViNsHI4CK8glw5ObB4chBc7AZ2w9sRDQWValjBUEQ+hIRQTKIwWpV7i8s4YYG+NasUel2I42N6vuozw/vxx+rYh5eqtxl7LPnwOQaHBHNKSzkDctXpSsomNDCxN3YAq+yMGlpdcnxxl1yAq0CCOOYdAkDbvm1rDpoqO86jguDvtLCpFU0oVhiz3XCqeKYaNYlrgLN2kQEE0EQhIENhYubb74ZN954o/qbYshLL72kRA6KHcl88MEHOPnkk/HpT39a/T127Fhce+21+Oijj/p934W+IxIOY/uqt9T0pGPOgCkLgkEONBq9DTAGo2q6YvgEJTQOKxmB6qZKhJvcqPZUo9xVjmwgEo1gfd16NT2reBZMxv4bkItFIvCtXaemHXNmw2Aa+oOB4XAYm95ZraannzoPZrn/sxp5+g8QzIWFyD3jDLhOPx3B3XuUu4x/40YVvZmEq2vQvORVNL/2GuxTpih3GdukSUPmoUVhwVWUp0pXRKNReJs8cQsTuuSo1MKtMUx0KxO65LBQEOkKCissnoau99VisyvRhNYlNmbJyaGFiZZWmFYmysKELjkFLnnACoIg9DPBYBArV67EHXfcEZ9H98hFixZh+fLlKX9D64/HHnsMH3/8sXKZ2bVrF15++WV87nOf63A7gUBAFZ3m5ub4O4pFSB/WFzOD9HW9RSJhNO1dq03PWajikg12+qvueos9h7apT4PJCJerQO13Tn4hLEYLzP4Qtjdsx3Dn8KyoO4og2w5r9TG9aDoMMPSrCOLftlVN22bO6La1eabrridwwPXg1h1qeupJsxHN0P0/GOtuoNCbdSYiyACDDyHb+HGqRC+8AP4NG+BdtQqh/Qe0BaIx+DdvUcVI1w5aksybC0sK896hChuzDJTKks7N4nf74D7c3CqYeLS0ws2aWMIS8PkQUlYmPuVy0xV03WHxNnWtmJitNhX4lVlyGL9EiSYuJ0KxKJrLy+DId2mCSV6OpBYWBKFX0S3sVPwmplVvdqO2sgb15aWYsfCYIVvbdXV1iEQiGD68bUeKf2/ZsiXlb2gBwt+dcsopqnHKEcP/+Z//wfe///0Ot8N4IXfffXe7+bW1tUqIEdKH7+qmpiZV930Zz4uB243Fk9V0XX29ymY32Omvuusttu7S0uMaHFZ1r5CY2QKzwQyzL4C1B9ZiskU7R0O97uj6M9ygPafqauv61Q2IMfkiZWVqOlBX121BMNN119N3Yn6FZmXE532mLLsHY90NFFhvvYWIIAMYo80G5/z5qoRra1XsEN/atYi2uNX3UbcbnvffV8UyciScx8yDfeZMGB2OTO/6gIEPFy0tL12IytMTTBoYv8QNb2umHM3CxI2A16cCuAa9tDDxqhdIVzCbDou3WXNxUrCBHYlgF614EpT3eKYcmxb81ep0tAZ/dbRamtDixKksTiS9sCBkH3pgalWY+jxuAedtzeLFZ5T2mTL9eeuzp2nU6CEtgvSEZcuW4ec//zn++Mc/qhgiO3bswG233Yaf/OQnuPPOO1P+hpYmjDuSaAlSUVGBkpISFBR0HTdLaPv+5SAQ666vOwVlZRcOqarvz7rrDXz+JrW/joK8eHye4rJy2Mw22II+VEeqU8btGap1VzZcEyIys/GyQV13PaFsROZdrQZr3Q0ErFZrr61LRJBBgrmkBHmLFyN30SIVNJVpdf1bt9CWTn0fOngQTQcPovmVJbBNmwrnMcfAOn78gAimOjgFE3QtmHhoDaIFflUxTFqtTNgZURYmetBXn0+NPnUnU046cUz0bDnKNYexTByOVmsTJxxMNZyrBYClYMJjkhTDgjCwCAaCyrWPoqunqTUGUosHfgquFDfigoZfCa+RUKh3tutLI67SIIaZXUwmE6qrq9vM599lHTT6KXTQ9eULX/iC+nvWrFnweDz44he/iB/84AcpG6o2m02VZLisNGy7D9srUndDv+6aGjTrD2d+YXx/cwoKYTFZYA0AOxt3quPpr/brYKq7gYbUndRdf9Ob96mIIIMMWgvYJ09WJer1wrduPXyrVyFUWaW+ZwwR//oNqpjy81TsEBbGHBF6WTBRgVOdKB5V2qVgEvQFlIUJRRN3YzNqK6thhgEhnx9+juCy09OaJUdlykkjjklitpx0YpnQ6kTFM7HZVTwTiib2HD1zjhOOXBccubqliSYGSaNAENIn6A+owM4elQlLi1FEN5SAx9ca3Fmz1KAwyvs8Eu4dUSMZk9mi3euO1thFukDqdCAUi6Bs9MghP1I0f/58LF26FJdcckn8Ocy/b7311pS/8Xq97Z53FFIITZaFoYNuIWW29N6IopA+3ibNMtZVUBSf58zNUzFBrAED3CE3an21KHVmh5t3OKrF/jMb+79LpscdNGRRgFBaVOrZLoXsJnuu+iGI0elEzgkLVAlVVqpgqoz0HG0d5Ys0NcO97G1VrGPHqtgh9hkzYOxFUyIhjfNE4SqHgoMDGFWqGuNFNTXK3DOVyKC75egm7/HAr+xEeRLM3ltN3jlKnE4sEworegDYdOKZEF00Ue45FE1ciemGKZzkxC1NJHOOMJTgfRjyh7RYQuo+9CRYarTei3oA5lZrjWhEa1D2NiaLBVa7U1l+qfuQwoYrB3a6zOVqcYZy8l1xAdNqs3Z4TDWtz56hDt1Urr/+ehx77LEq0ClT5NKyQ88Wc91112HkyJEqrge56KKLVEaZefPmxd1haB3C+boYIgwNAWTlc/er6fmXfFWEkAwQaGkB76iCwpL4PEd+gQoKmhemZVUAOxp3ZIUIQgHk2R3PqulLJ17ar0IIBZDG/zyjpgsuvywrhBAKIG/89Wk1veimK0QIyXKG/hWfJVjKy1XJXbwY/q1bVardwPbtcYuC4J49qjS/9DLsM2eodLuW0aPFXWagu+V0YWWS7JpDs3qf26tGoeOxAthRYxyTVksTdtrSiWfSJghsYkyTLgLBJrrnMN0wR58Z00Rzz8k5Ipzk50j2HKHfUBZZXj/cjYyl4dUCJPOz9T5RWaV8uqDRKmqk4cbWE9R9osRFzVJDd2VTFlkUGJPERRmx6j5XX321Crp41113oaqqCnPnzsWSJUviwVL37dvXRoT+4Q9/qN6H/Dx48KDy1aYA8rOf/awXz7wgCKEWnxJBioqOuKY58/PVpz1oUu1WusScNOIkqSxBEPoMEUGGGFRyHTNmqBJpaYFvzVrlLhOu02JMxIJBFU+ExTSsSIkhzDBjan0BCYPbNQdITzShe46eNYLBFdXotuoIHukMallztA5hup1BPRCsL13RxGJVoomWclhPO6x1Bumq48xtTTvcmkFHOoNCR+KfFpNHE/+U+4kS/zSrKQp/FPPSFf+6i5mCRquooQc1ppjBa9lJSw11f2qZoOx5ThH/+gm6vnTk/sJAqImYzWb86Ec/UkUYuvCdQwsQfVro/5SwBq/mjlRacsQtz5mntUEtMMMUAnY17cqKU0PLD1qA6NP93V+gBYg+nQ2wDUkLEH1ayG6y46rPUky5uXAtPAU5p5yM0IEDmrvM+g2IBQLq+0j9YbS8sRQtS9+EbcIEFTvEPm1q1jwMs5VE95yi8uK0fhPwBuLBG7VRdHY2tUCOtDLRAjgy1oEfwYAP0VY/03RMk1l8LU3pxzqwt1qZqFF0ugZo7gCq5Gqj6HQNcBa4OnQLEAYeuhuYp5HuJ5qgwZgamqhBi6YjmU90USOd2Dk9QbmBKYsmTdCwxTM10QXMqQIOK9cTWmrkOjOWZk8QhO4j4kfmaPA3wOLXpkuKR7Z5t3MQJNASUMFRdzftRraQiVggOtnY3hfxQ9DJvqs/C6GJr7WiQpW8c8+Ff/NmlW43uKv1JROLqYwzLEaHHfZZs+GcNxfmESPEXUZQ2Jw2VQrKhqWf9YIBIpuSLE1YVAYcXxvXg3QDRHK5iDsEv7s5reWNZjOsNgcsDi2uCWMpqNTDyu2AgWApmhyJp8BjFHqHaDgCb4s3nspVpZtu8R7JntQqbChBgyUY6BtRg88/dQ04YLVrQYGV1REFjVY3LX7SPSunIFeyKAmCIPQRNY2HYIwCJoMRroK27QlnfgF8HrcSSep99WgJtiDXmivnQhCEPkFEkCzDYLUq9xeWcEMDfGvWqPghkUbNfSHq88P78ceqmIeXqlS7FEVMrq7TxgqCDi0wrMOLUDD8SPT3roJVxd1zGBCW8RrYWXYfCUDJDrMe2FWP7t8VtEjxh1vg97SktbzRaNLcc2hl0mptQgsAuuboliZq9L81XoPVYcuaDDpK1Gg9R+r8UOBotdbQMxxp2Yp8CAb8CNNSo48yZKl4GrpFkBI1jrhQOfTYM63poe059qw5R4IgdE40EsGOte+p6YlzToFRgt72KzW1B9SnwW6B2dLWHcGRlw9j5SGUxPLRjGbsadqDWSWzMJSJxqLYVL9JTU8fNh1GQ/+9q+ge6t+4UU0zaQLfrdnQjtm8fJ2annbibLHizHJEBMlimDY394wz4Dr9dAR371buMv6Nm+Ips8LVNWh+ZQmaX30V9qlTlbuMbdKkrHhQCv1vnphXXKBKOoTDYeUyccTKQLM0YbBLZV3gbZtBh3FK0oGxTwJersMNdxrL815gZzyeQSfuNqHFhGA8E5VFZwB2yNsITy1H4mnowhPrj+JGd4Wn7pIoPB2x1DgSJPSIi5MmPmWT8CQIQu/CZ3zDzhXa9KwTRQTpZ+oPV6lPo8vR7jtagpDhhiLsRDN2N+/OChFk8+HNanpq0dR+FUFAEWSTtm37tGl8GSMb3G73b9iipqcsmAmjCtErZCsiggjK5cU2frwq0QsugH/DBuUuE9qvKfaIxtSDksVIFwJaksybC0sWpFkUBiYMYpg3LF+V7lgx6GmHtQ4/LU3omqNbmxzJoKPiTaQ5khJQ7j0eoEELPtwZBoNRpTlNzKBDt4y4a4ZLizehW5rYXY60O/zKBYmxNFpjt8TTuSa5IDHrSdDvRSSUngtSd6ELkp75hAJR22C3jKHRKg4x4G1+Lix2i4gagiD0C3wG54+ZHZ8W+pfmw3Xq0+JiIPe2OHPz1GdR1KU+syEuCNMCTyqYFJ/u340b1MCmPp0VGA0YMWVifFrIbkQEEdpgtNvhPPZYVcK1tUoMYYaZqFsbF+en5/33VbGMHAnnMfNgnzVL/U4QBioMXOkqylMlbdHE7W0VFVqtJOgC0ppyWLl/tMY06U6QzliMmXm0ILKehjR2xGBo6/qhih3u5hY1fqFn8OlOMNruooLRch/0VK6tWXwoaDCeir3V4kWC0QqCMNAxmc2YevzZmd6NrMXTpL347K2CRypLEFfImjUiiMlowtzSuRnZtsFkUm34bBtAm33mcZneDWGAICKI0PHFUVKCvMWLkbtoEQLbd2juMlu3MMeZ+j508CCaDh5ULjP26dOUu4x1/HgJpioMDdGkIFeV7mQ20S1NGARUuefomU08bd1zaI1BQaRLYrG4O4pHzzociyEcicBMX/YejN4kpiWmoMJgsTZaodCVh/E0WtMSszBYqGTYEQRBEHoDf7MW1NxZ0N71VU+Taw1o77W9zXtVSl0KBYIgCL2NiCBCWnEP7FMmqxL1eOBbv14JIqFKzbeTMUR869arYsrPV64yFEQYc0QQsgG6rKiAqXk5wKjStESToNcPtwoE61auOcriRIkmjMXh0axMvJp7Dq1N6HqTCrPVFnc/oYWGFijUkZD5xBl3r2GR9HCCIAhCJgi2aFbFuUmZYfTAqCTmDcJmsiEQCeCQ+xAq8ir6fT8FQRj6iAgidAtjTg5yTjhBlVBlJbyrVsG/bj2iPp/6PtLUBPeyt1Wxjh2rBBFGnTZaNfNGQRA00UTFyFB+0WmKJr6AFsi0qQUtbjdGja1Qliq0WhEEQRC6hgGeVz53v5qef8lXlWWc0H+E3T4V+SK/qKTdd448zUXG727B2Lwx2NqwTQVHHcoiSDgaxrM7nlXTl068FGZj/3XLOIDZ+J9n1HTB5ZfBYB76XUIGhH/jr0+r6UU3XSGDQlnO0L/ihT7DUl6O/AsuQN4558C/dSt8q1YjsGNHPDZCcM8eVZpfehn2mTNUul1LRYW4ywhCT0STHGaecai0wzU1NSq+iWRJEQRBEAYNHi3LWFFhWbuvHK1xQsLBIMY6J2oiSNNunDrq1H7fTUEQhj4igghHDdVjx4wZqkSam+Fbuw6+1asQrtOyZcSCQSWQsJiLh8Exd64qplbVXxAEQRAEoa+h5cecC/8nPi30H5FwGAa/FsC7pGRku+/p1mm22RAOBFBhKsuK4Ki0/Lh4wsXx6f5uu+df8qn4dDZAd+DTr7skPi1kN9lx1Qv9BoUN18JTkHPKyQjt369ih/g2bEQsEFDfUxhpeWMpWpa+CduECSp2iH3a1Kx5AAuCIAiCkDnsjhyp/gxQV39IfcYMQGlhecplGBy1ubYGpYbCrBBBCOOfZAqjLXPbzhS0qBUEIj1PoU8wGAywjh6tSu555yGwaRO8q9cguLv1hRaLKdcZFqPDAfvsWXAymGp5ubjLCIIgCIIgDCFq6zQRJOwwwmaxp1yGLjEUQQqjLvX3Yf9hNAebkWcVy2FBEHoXEUGEPodBUXUXmHBDA3yr18C3Zg0ijVrOTwZV9X70sSrmsuFKDLHPmg2TS0ZrBEEQBEHoHaKRCHZt+FBNj595AoxMNS70Cw0N1dqEs2M3BD0uSNTrx/Cc4aj2VCtrkDklc4bkWYrGoth6eKuanlI0BUaDsd+2zYxzgS1b1LRt6lSVCXKoEw1HsO2TjWp68nEzJLB8liMiiNC/F1xhIXLPPAOuM05XViF0l/Fv3KSiVJNwVTWaX1mC5tdeg33KFOUuY5s0KSsezoIgCIIg9B3RaAT12zQRZOz040QE6UeaDteqT2NOaiuQxAwxvpZmjBs2Tokge5r2DGkRZEP9BjU9qXBSv4ogiEbhW69t2zZ5MiOwY6jDTHt71mgiyMT502CEiKDZjIggQsbcZWzjx6sSveAC+DdsgHf1aoT2H9AWiETh37RZFaPLBcecOSrdrqW063SigiAIgiAI7dseRuSOmh6fFvoPd+Nh9Wl2dRyTwZGbrz69zU0YO34sPqz8cEjHBTHAgHF54+LT/btxtsPHxaezAqMBZRPGxqeF7EZEECHjGO12OI89VpVQTY1ylfGtWYuo262+56fn/fdVsYwaBee8ubDPmqV+JwiCIAiCkA4msxnTTzxPKisDeJo0F2hrbm6HyzgTLUHy56vpoSyCmIwmHFt2bEa2bTCZ4DzuOGQTZrMZcxefmOndEAYIIoIIAwpaelgWL0buokUIbN+uucts3aosQ0jowAE0HTigXGbs06cpdxnr+PESTFUQBEEQBKGVjyo/Qq41F9OHaZYvmcbf3Kw+Hfl5XcYE8TU3Y3b+eDW9r2UfItGIEgwEQRB6CxFBhAEJY4AwJghL1OOBb9065S7DmCGEMUR869arYioo0AKvzpurYo4IgiAIgiBkswDy0w9/qqZvmXMLzh9/fqZ3CcEWzbo3p6DjdpojT3OH8bU0odRZCofZAV/YhwPuAxiTN6bf9lUQhKGPiCDCgMeYk4OcE09UJVRZCe+qVfCvW6+yyhBmmXEvW6aKdexYOI+ZB9v06SorjSAIgiAIAgmHglj93wfV9LyLboHZMjTbCUv2LIlPv7DrBZw37ryMWszGYjFE3FqbLbdgWNeWIC0tMMSghI8th7col5ihKIKEo2H8d+d/1fRFEy6C2dh/3TIOJjY9/7yazv/Up2AwD/0uYTgYwtJHnlXTZ91wKczWjjMVCUMfiQolDCos5eXIv+AClH77Wyi46iqVOSYxoFNwzx40PvMsan79GzQ+9xyC+/apl68gCIIgCEI0ElZlqOIOurGyemX874MtB5VLSSYJ+X2IhrQ6Lygs7VIEYfpWv9eDcfnjhnxckHAsrEomiIUjqmQTsUhEFUHIqOx3zz334JlnnsGWLVvgcDhw0kkn4Ze//CWmTJkSX8bv9+Ob3/wmnnjiCQQCAZxzzjn44x//iOHDh8vZy2KoWDtmzlAl0twM39q1Kn5IuK5efR8LBOBbtVoVc/EwFTuEGWZMrUG3BEEQBEHILkwmM2ac8/n49FBkV9MuNfhDd5KK3AoliKyuWZ1RSwoGRWU62LAFyMsp6HA5o8kEe44Lfo9bxQVh2thXdr+irEGGIiaDCeePOz8+3b8bNyHvggvi09mA0WzCKddcGJ8WspuMWoK8/fbb+MpXvoIPP/wQr7/+OkKhEBYvXgyPxxNf5hvf+Ab++9//4qmnnlLLHzp0CJdddlkmd1sYYFDYcC1ciOKvfhXDvnATnPOPgSHBFYbCSMvrb6Dmt/fi8KOPwbdhozIDFARBEAQhu+KNufIKVeH0UES3mqAVxdSiqWp6R8OOjO6Tt7ERUUQRsgN51s4HoxwJGWKmFU1T09sbtyMUDWGoQRelHEuOKv3trsTtmVw5qmTSVao/MfL+L8xVhdNCdpNRGXzJkiM+i+SRRx5BaWkpVq5ciVNPPRVNTU3461//iscffxxnnnmmWubhhx/GtGnTlHBywgknZGjPhYEIH+LW0aNVyT3vPAQ2bYJ31WrlIqOIxVTGGRajwwH77FlwHnOMcrERBEEQBEEYCpYgZHz+eEwomKCmdzRlWARptQQJ2gCX1dXpso7cfDRUHlIiyATXVJXhpiXYgl2NuzCl6IiluCAIwtEwoGwBKXqQoqIi9UkxhNYhixYtii8zdepUjB49GsuXLxcRROgQBkVVGWPmzkW4oQG+1WuUu0yk9RpjUFXvRx+rYi4bDifdZWbPVkFYBUEQBEEYekQjEezdskJNj5l6rHK/GMqWIBMLJsbjgnhDXjgtzozsk7vxsHLRCXbHEqS5SQ1u0Rrk46qPsal+05ATQSgM7WjUBCqeK6Oh/6wTGHclsF3btm3SxCFrGZVINBzBrtVb1fT4eVPEJSbLGTAiSDQaxde//nWcfPLJmDlzpppXVVUFq9WKgoK2/oOMB8LvUsG4ISw6za15ybl+lt7aVz7Me2t9Qt9izM9HzumnwXnaqQju3q3EkMDmzYi1BukKVVahqfIVNL/6KmyTp8A+b64KuNpXLwS5fgS5foRM0FfPHnkXCoOFaDSCmk3vqemKyfOGnAjC+/uQ+5CaZjyQQnshiuxFOOw/jL3NezFtmOZe0t80NtSoT7rDuCxdWYIccYch3GeKIJsPb8aluBRDTQRZW7s2brnTnyIIolH41qxRk7YJ4+krgqEO31U7Vmj1PXbOJBgxtO5/YZCKIIwNsmHDBrz3nvZyOppgq3fffXe7+bW1tSrIam/dRLRa4ctGfMoGGS4XsHAhcNxxiGzdisiGjYhUVca/9q5eBaxeBYMzB+bp02CeORPGYR2nc+sJcv0Icv0ImaCvnj0tLS29ti5B6EsMBiNyyifFp4cajYFGBCLaQOBwp5ZAgAFRKYIwQ0ymRJCmhjptwmmFyWhKyxLE26xZ7upxQTbXb1bPrqEUv8IAA0bnjo5P9+/GDbCO0badmGVxSGM0oGRMRXxayG4GhAhy66234sUXX8Q777yDUaNGxeeXlZUhGAyisbGxjTVIdXW1+i4Vd9xxB26//fY2liAVFRUoKSlBXi9lBmFDkg9hrlNEkEHM6NHA2WcjXFurrEN8a9ch6nZr33GkdMNGVUwVo+CYOw/2mTNgtNuPerNy/Qhy/QiZoK+ePfZeeC4KQn9gMpsx85SLh2xlV3k0K+kSZwksJkvcIoTZYfY1Zy5NrrvhsPq05HbtcuzMy1ef/lZLkImFE1XmFAo8lZ5KjHCNwFCBgtCC8gUZ2bbBZEJOlsVWNJvNmH/+KZneDWGAkFERhIruV7/6VTz77LNYtmwZxo3T8oHrzJ8/HxaLBUuXLsXll1+u5m3duhX79u3DiSeemHKdNptNlWTY4OvNRh8bkr29TiEzWIcPh/Xcc5F39tkI7NihBBH/li20U1Tfhw8cRMuBg3AvWQL7jOkq3a513LijGo2Q60c4GuT6EQbStSPvQUEYGFR7q9tYgZDRedpo//6W/RkNjEqs+bldLpvsDmMz2ZQFy4a6DSrd71ASQQRByFIRhC4wzPzy/PPPIzc3Nx7nIz8/Hw6HQ33edNNNyrKDwVJpyUHRhAKIZIYR+kIVt0+ZokrE7YF//Tp4V69GuEprVDCtLq1FWEwFBVrg1XlzYS4slJMhCIIgCEJGoaUEKcs5Yi2tu1swJkgmCAeDCHo8atqRFOOvMxFEd4chxw4/VokgK6pX4KIJF/Xh3gqCkC1kVAR58MEH1efpp5/eZj7T4N5www1q+ne/+50aZaIlCAOennPOOfjjH/+Ykf0VsgfmTc858UQ4TzgB4cpKJYb4161D1KfFlYk0NsK9bJkq1rFj4TxmHuzTp8NgtWZ61wVBEARBSEE4FMTql/6spuddcDPMFuuQdIdJtAShOwxhXBBPyIMcS05G0uNGTUCuS3N16QxHqztMwONBJBxWLkzHlR2HRzY+gnW16+AP+2E3Dw0XvHA0jJd3v6ymzx93PszG/uuWcWCv6cUX1XT+hRfCYB4QERL6lHAwhGWPvaCmT//sxTBbNZcxITvJuDtMOr7GDzzwgCqCkAnTccuIEcgfMQJ5ixfDv2Wrll1m505ewGqZ4J49qhheehmOmTOUu4ylomJIBe8SBEEQhKFANNQ7QfIHInW+unYiiMvqimeIYVyQ/g6OynggFEECDqC0i/S4xOZwqqw9TGfsd7cgp6BQCTmMc1LrrVVCyPHlx2OooAeyzQSxQBDZRjgLj1lIzdCX/QShlzBYLHDMmqlKpLlZpRajhUikXgv4FQsE4F25ShVz8TAlhjjmzIGplwLyCoIgCILQc0wmM6aedV18eqiKIMMcbbPaMS4IRRDGBelvEcTTKoIE7UCuNVcNgO7fdBh+TwgTjx0OY1KWDoPRqFxiPI0NyoqEIggHlegS88ruV5RLzFARQRjwdfGYxfHp/t24CXnnnhOfzgaMZhNOuPzc+LSQ3Qy9N4Ag9AMUNlynnoqchQsR2r8f3lWr4N+wEbGgpjCH6+rR8vobaHljKWwTJ8JBd5kpU7LC3FAQBEEQBiLsYOcXlWAoQnGh3levposdxW2+oyXFmpo1Kk1uf0MxQ4kgDk0EWffmAWx456D6LuiPYOapI9v9hsIHf0cBpWSMljTh+LLjlQjy/qH38cXZX+xX15G+guJOvi0/Y9s25Wdm25mC4RUKSiWOn6Ax+J8ggpBB+BKxjh6tSvT88+HfuBG+1WuUe4wiFkNg+3ZVjA4H7LNnwT53btao7oIgCIIg9D2M96G7VtD9JRE9Q0wm0uQmusM4oi5sXq4FbyUUQyYfPxxWe9vuSE5hEbBnVzy1LplbOlcJBk2BJpXyl3FCBEEQeoqIIILQSxitVjjnzVMlfPiwcpehIBJp0iKcR30+eD/6GJ4PP4LfbEZdYSGMFjNgMqvMNAaa5hlNMHCe0QgD56vp1u+4DOclTyf+xsx5CdMUW1qXU9PxeVynWY2KCYLQTzGwIhHEIhEgHFafbabDESDKz3B8OTUvon/fOj/M745M679R60r8Xn22/r51nspw1dyMxomTUHTtNXLahayDcSb271ivpismzlKxJ4YK9X7NCoSBT5MDh+oZYjJjCXLEHSay24FIKIrCMidCgQjcDQHU7GnGqKltRRsXRZBWAUWHlh+njToNL+x8AW/ue3NIiCCslz3N2qDZ2LyxMBr6r00Wi0bjA3YM8J8N7cFoOIK9G3eq6TEzJohLTJYjIogg9MWNVVSE3DPPhOuMMxDctUsFU/Vv2qx1ZPjycbcgHA5nPniqwdAqjiSJKhRSTK1CTGcCTPw3FF0sMJiMbUWXxN+kEmDiv6GQY2md17oc15np+hEGn9BAQSAaRSxEoUCfDgH87EBUOLJc628iXDbVb9qKClDLhdtMa6JEWyFC/34g1E/U70OkpTnTuyIIGSEajaBq3VI1PXL89CEnghgjMSzcEET1xl8h54QFcJ12WhsRhO4y3pAXTouz/2OCOAD/fu2dPnZWMdwNfmxfUYOqXSlEkKJh7UQQcuboM5UI8mHlh3AH3Sroa6rn3GBpO7BeVlavjJ+j/hRB+H7zfrJCTdKamW2uoU40GsXWD7T6rpg2DkYMnftf6D4igghCH8IXsW3CBFVoCeLfsAGeNWvg37dPS6cbjWS2cxSLaR03duSQuQjlHQs0xraWMq3TbUSbVlFGiTaJQktKASZJoOH6W7/r0mpGn8eGAucNkkZWnwkNHVkqpLR0iLYXEjqybtAFCH4mWDy0m060dIiLFl1nHMtKjLyXtOud16/R7sj0HglCRjAYjHCWjotPDyUocJzzWj3mb43A7XgL7rfeQujQIRRee60SCwrthWjwNyhrkKlFU/vtfeHWY4LYTHDvjsAIM0ZMKkBznU+JINW7NWvZRHIKNFHE06BZt+iMzx+vXHvo1vPOgXdw/vjz49+FggEsf+px7N+0HgsuvRoTj12AgY4BBozMGRmf7t+NG2AZ2RqPJVvaM0YDikaVx6eF7EZEEEHoJxgTxHnccbDPn49ITQ1KS0tVkKYOzeRbO4ndMZNvbxqfhpl8NKmjGtJGxfXvMyvQcN8iGIhd27goQ4uVuFtTq6hi7Fq0OTLdanmT6PbUgWgTQAgtYS/cDc3I83pgiuHoXCbaWTd0cl3ovxGhoXOhoavzniC8dWxhlXQNtAp8+vXSRrhLJdYl/6Z1hI+jYDU1NSgsLe3Xe0UQBgomsxmzTrsMQxHf2rWYuckDozUHjmPnw7diJQ7/41HYZ85SWe1oaUARhBli+ksECfp8CAX8iCEGW6gYsYgBdpcF+aUOWOzaKHxTrQ+RcBQms7FLSxAOPjCbyl/W/wWv7HkF5407Lz4gsfqV/2LHJx+q6Xf++TCKRoxC0Yj2QVcHEiajCSeNPCkj2+a7wnXKycgmzGYzjr/o9EzvhjBAEBFEEDKMeoHrsTxsNgwk4gINRZFwOiP+3Rj9j4/468JOq0tBlyP+Cdvn/mWqbhIFGl8vrA8xhCIhBKNBBCOtJRpUge70+REKE4ghHI5gu9kMq8kCq8kKq9Gmfarp1k+Ttf9T7vU1uotWQqf/iNtWZy5cSW5b3XHh0t229N/oblvJVkPZMpImCMKAxLn0Y/XZsnA2Rtz9U9Tc+zu0vPYa6v/0/zDy//5PWVCsrV2LPU2tgdv7KR4I2xFhK+DylsAII0oqXOp56cyzwmIzqdggLfV+FAw/4qLjKtQyeAQ8HmXhYbHa2rjEPLLxEXUc2xq2YUrRFPg9bmx5/+0jG47FsO3D93DCZVf327EKgjC4EBFEEISuBRr+QfedgSbQMGaDLrp0FfshVRyIVHEcUsV+aI0X0WHsh1SiTZJAE41FlLARaBU3EoUOflLooBDSjRpAkOJIJMSmZoejTImiCKdtJhsscfHEooxwE4nHhenUgiXB0iEemNeUWkhIZd2QHMy3A1ekdpYOIjQIgiC0I9rUhLwN+xHkH+ecquYN+/yNcL/7LgLbd8Dz3vuYMHqCmr+jcUe/1aD7MOOBRBCwA0WecvUMHzbKdSQ9bKkDdfvd2Le3CTWIYEKJCyajAVaHE1aHQ1mSuA/Xo7BsRHydTLO7cORCvLX/LSzZs0SJILvXrEQ4GETRyFE49oJL8dqf7sfOlR/h+EuugNE4xAYDBEHoFUQEEQRhUKI6xHpHOcMCjfJ7DrlV6r548Teg2duIZl+DKsFgCIaoCYaIHYaoVQWwM0RZokemI1EYW+cZIjFtOhKFOWpAjsmBHIMdDoMNLX43AlYDvFE/vAgiZjQgZjIgZjQi2vrJv6NqvlF9H5+vprVPtg1djjzkOgqQ68hHvqMQ+fYCFNgKVCrCfGu+EkwEQRCGAuFQEGuWPKym5557I8yWgSXu95Tw2rWIRsKoGm7FhAmaq4upoAAFl16Chsf/hcOP/gMTfvk9NX9X0y5lVUiRvK9xH65DNBZDwAkMd5eCcSiHjTwSzLSg1Ind2xvwhxe2YEeBAeOKc/DLK2aj2GVDTkGhEkEYWDVRBCHnjjtXiSCMC3LTzJuwd+1qNX/8McdjxNRpsNjsyoqkofIQho2swEAlHA3j1T2vqulzxp6jMuD0FxzMaX5liZrOO+9czZpyiBMOhvDOv15W06deez7MVmnfZDND/4oXBEE4SkLRkBI2mgPNaApqIkdjoDEueDQHmxGJdRI/he3sBHPeZBxmhyY8WPM18SGxWPNVykPdCkKP66DHlKEFib5PeuG+cZ/S2Tc/3KjzuwH/AaCh/fdOszO+H/n21s8O9k0QBGGgE+HzbogR3rBBPed3jcvFAkdxfH7+ZZej6YX/IrRvP4pX71aWgP6wH4fch1CR1/fiQEs9RZAoQnYTbE05gBMoKs+Jf19viKLRG0KO8oQxYHedB3c8sx5//MwxKi4IRQxagiQzrWhaPEDq0h2v4vCOrWr+2NnzlOVHydhxOLR1M2p27xzQIgjxhr0Z23bUm7ltZ4pgFh6zkBoRQQRByGpoxcFGSFxESBIUWDzh1O4m6UAf6DxbnhI58qx5bQSEArs2j64pPYWWGsWOYlVSwQaobqWiRJzWY0wUcfwRf4frZ92wVHoqU37PuCOJx6OLJDxmTvPTotxuBEEQMovJZMak066JTw8F6AoaWr9BPev3jrZjmF0LKkpMrhzkX3YpGv7xKJqffArjrx2HzQ1bsKVhSz+JILVqv2Imp0r/6nBZYHVo9R6JxvDqrlowV8f4HDu+c/M8/M9jq7Czxo0nP9mP8XqGmMb26jyFd1pO/Hndn7F89euYHI0hr6RUFTJ8/EQlglTv2oFppwzcQJh8f541+qz4dP9u3ITcsxfFp7MBo9mE4z+1KD4tZDdD4w0gCILQiblpS7Al3umnZUSiAMASjoV7XH92k72NsNFm2p4Pl8WlGn+Zgtum0MKC3NTLMPhqG+EnSQhi/UWROpUzRx8P+w+rgubU62cdKGHEqolBeh3pwhAtYcSaRBCEvoZBjYtKB3bGkO4SrqxEpLkREbMB9RV5yjovkfyLL0bT0/9BcO9enHRwATY7gfW163H2mLP7xxIEURgN+dq7qORIeu6PdtVjt8ePkQag1GxBeb4Dt54xEfe8vBmPf7QPd03O19aRwhKEMC4Is8S07DmAcHQ4yidNiX9XOma8+qzbvxcDGb73iuxFGdu2uSgz284UtJ4tGlGS6d0QBggiggiCMKitOGjF0FkHnlYQ3Qs4egQDDCoIW9zSgZ12WjgkdODtZjsGOzSRLnWWqpIKjuRRCGnjBtRaz7Qu4TwGeO0IngOWgziY8nsGbNWFkXbWMrYCdQ76w39dEARhsBHYulWJ0dWlVhS6itsJyiaXC/mXfErFBpm4bCdwXgzr6tap92dfis9cv+4OY44VKqvI/AQR5L/rKuE3Azk2M8KBCELBCM6aWopnVh3A1qoWLK8MgTJIKncYUmgvxIxhM4D69fBHfG1EkMLW1LjNdbXtsssIgiAQEUEEQRiw6J3vNpYb3eh8d0Vy5zvRSoEdcOl8a3AET6+X0RjdfTEq2AR3sGMxiuew1lerSkdilMvqahc3JfGcDQUxShCEviUaieDQ7s1qesS4aTAOATeAwLZtiMSiqCyzxt0io9EI9q1bg6JRo5FXXIL8Sy5B47PPwb6/FpP3RLFtXD32tezDmLwxfbZffneLytjC97g1VKK9R1pFkEZvEB/vrlcBugvybEA4Bk9DQKXJ/dJpE3D7k2vw9qEIzo9E0VxX0+E2Tio6Dmua18Nr9KFswuT4fEduHuw5LpU6t6m6CsUVfXecRwPr5kDLATU9KndUv1qNKjeq/fvVtKWiQkv9PsSJhiM4sFWzDho1ZYy4xGQ5IoIIgpAx2rlhJHSeKXBQAOmpFQfJteS2sdxI7kCLG0bvwNFE1iVLWU5Zp25JyYFbEwWujtySeA3wtyz7oTXaUlmzJLokJWa44TVAQSuTbkmCIGQeigMHV2vZOMrGTB4aIsjWbSoNbWWZDeX2YUqUXvb3v2DP2lUq1eyFt30HBWXlyL/wQjQ+9RTO+ySK7WNiePfAuxgzve/EAVqBkIjTBKe/qFUEURFQsXxnvcoiP2m4C4VuKxqqvPA0aiLI3IoCnDBhGD7eFkKjLwSzqQUBrwc2Z1s3HzLWOwxraPGRE0KLyQ+nsh3R3kmF5SNQuWMbGioPDmgR5KOqj9T0CNeI/n1HRaPwfKhtu2DkSJWyfqjDwPKb3mmt70kVMDJdkZC1iAgiCELfmcKGWtoE5FQd3gQLgc4CcnaF2WBul0Ul8W+KHP2Zbk7oHJ4Lmi+z9EWAWgpqNd4aVToLUJsYuDVZGDuaALWCIAwO7MOGTkwQjuYH9+xRliDVw62Y6RiGmj27lABCgj4vVr78HM76/C0ouPIKNL/0EobX1mHKtiiWuZbh2qnX9pmrIYOikpDTBLvXBaONMUE0i713d2gCySkTi5GzO6CJIE2B+G9vXjhexQxphB254Qgaq6swfNyE9tvYc1A9t6uLglhVswrnjTsv/l1h+chWEeQQBjLDncMztm3z8NQusEOZ/OESE0TQkB6CIAg9Ijk1a2Lg0bTSxnZBjjnniKCR0HnVR/iZulWCaQ4deC4Z0I+FI2LppipOvvY6uuYYnI/LsaAl9T7QkqWjNMW87iQdsCAMbswWK+acqWWHGQqEq6sRDQQQMsXQUGBW7jA7V3yovisaWYHDB/dj/8b1CHi9sOXlIf+KyxH5xz9w2vLD+POkKry1/y0sGtOaIaSXaanXYnkETWY4Y4DFboT9498gsv9jTDtUhjXmT+GUSSWob9DEEnfjERFkXHEOzptZjgO78tHorUJjdWVKEaRy+xZlBdhcHMTa2rVtRJD84ZpVYnNtx+40A2Fw4NRRp2Zk2wazGbmnD9zMOX2B2WrBiZf1zfUuDD5EBBEEocNR+eRYHHocDv59NLntmQouOQBmPNhoq+DB1K+CkAhT7XaWDpjXrZ4OuKPYJL6wr8NK5XcsVd6qTq/bNrFjElxuOC3pgAcODzzwAH7961+jqqoKc+bMwf3334/jjz++w+UbGxvxgx/8AM888wwOHz6MMWPG4L777sP555/fr/stCOnCjC+kociq4msw08ie9W+recdedCk+ef5pZQmxb8MaTDr+JBRccgman38Bo+o8mLnRjb/Y/4KpRVNVPIo+swQxaBZ2udgHw8b/IBCM4PTgVowyN2Js0WL4C7SgpYwJksgNJ4/Fna8XIug+hNUbdmLKCae0+Z6pc5tqqmE3O9A8rAXratcp9xLdpSS3uKTNfgiCICQiIoggZCGMz5AobCTH4uC83kobm+hyoHcUGatDrDiE3obXFGN/sHTUqKfbTLJ7VuI9wOnO0gE3BBpUSceCKZWrllgw9Q9PPvkkbr/9djz00ENYsGCBEjPOOeccbN26FaWl7U3Ag8Egzj77bPXd008/jZEjR2Lv3r0oKCjopz0WhO5DVxhSVaRleXH5LfA1N6kgl2XjJ2HU9FlKBKnauV2JIEanEwXXXoPwQw/hrE+asWlaC7799rfx/QXfx6ySWX0TEyTKYKgxFIS2AAYTPipYjNGelzAvugmGLS/CVbBQLZfoDkOKXTbMmTEJ1cs2YuXazTi+1o3xJa7495Xbt6rPsjHjYXFoMaP2NO3B+AItPW7esFYRpK5WuQ1lQ+BPQRDSR0QQQRhicDSco9m6W0qqWBwcLe8pjK2gp41NtNxI7PTRPFUQBiK8NkucJap0lpFId7nRLZ90cZDzKKR0BOOWsBzyHOoylk1yNiIlEFpzJZZNL3Dvvffi5ptvxo033qj+phjy0ksv4W9/+xu+973vtVue82n98cEHH8Bi0azQxo4d2xu7IgwgwqEg1r7+TzU95+zPKPeYwUxw7z4lMBws1ITbWI3m6zdsZAXMVivKxk/E+qWvonrXjvhv8s8/H03/eQajamI4Z7sTL013487378TX538dp1f0nnuEu75OBbWOxfIYvARF5gbEJp+LP+46FwssBtxqeRn46E9wLjpNLc/AqMlccuZ8PPzuC7C7a/H1J1bjy2dMxNnTy2AyGnBo+xa1zMjJ0zFjWBgrq1cqlxhdBHEVDVPCRzgUgre5CTkFqeNRZXpAaum+pWr6rNFn9euzPxYOo+WNN9R07qJFyj1mqBMOhvD+U6+p6ZOvXKzcY4TsZehf8YIwxIhEI1qWjWDqWBwsR5s2Ni5uJMRD0DtrkmVDyJZ0wBWoSLkMRUb9XkslNnaWDpgWVvX+elU6SwfcRlhMEhlpaSWWVB1Dq46VK1fijjvuOHJejUYsWrQIy5cvT/mbF154ASeeeCK+8pWv4Pnnn0dJSQk+/elP47vf/S5MQyCDiHCEsOfwkKmO0IEDKihqXaFZuet5DlWr+aVjNSGgdNxEmsipuBgUApx5+TBYrSj87GdR+7vfYfEaoGXh8Xin/mP8ftXvMSF/AiryUj/3ukMkHIa7sUGJypZoIUdnUGBpxqFxX0L9ukYss52F2/M+AdxVcDWtoGQBvyeMcCgCs+XI/VYychSGFzhR3ehFuLkBv1qyFf9ecQA3nTwWlds0EaR80hTMMRniIsilky5V85n5x1VYpCxSaA0yEEUQwndIpog0ZW7bmcLXnH3HLKRGRBBBGGBwlLnR39ZyI9Fd5WjSxkoHSxCOnu6kA051H/P+Ticd8AH3gY7TASfEIUkOGpztQmVdXR0ikQiGD2+bdYF/b9midZyS2bVrF95880185jOfwcsvv4wdO3bgy1/+MkKhEH70ox+l/E0gEFBFp7m1cc00jCxC+rC+aMXY1/VmMBgx9sRL49OD+TyxvoIHD6qBEQZFLbQV4vB2LYV40ajR6tgsdjsKSstUYNG6fXsxavpM9X3OmWeodLnBAwdw4+7RcE8MY2XNSvx1/V9x14l3HfW+1a9cgXB9PQxmI2y2PPBplFOYg/eaihBDI6aMGgZUXIrYir/Csu1pmC2fRygYgbvBj7xius9o0JJj2MhRiEX24srxJjxTZ8buOg9+9u/3cer+SpTmO5XgM9NrVc/OTfWbEI6Ej8QFGVasRJCm2hqUjp+YseuuIwwxAxaOWBif7s/9iDEY+WlaUNaowQBDN7ed6brrEUYD5p7TGojW2L/1PejrboDQm3UmIogg9DPMcHHIewg1dTXxFLK62T3N7XsjbWyqwI1iai8IAycdcNyaJMHlJtGypDOXNZUO2FejSndc1hiLJ+QPIT+SD4fxSEdD0BpWjAfypz/9SVl+zJ8/HwcPHlSBVTsSQe655x7cfffd7ebX1tYqaxShe/Xf1NSk7g1a7fQpZqf6qK3TYlYMVqKNTQi1tKhMbXW5NoyHE7UH9ikRIGq1oaZGez7YCgoRPrQfe7duhrX4SDwcw8UXIXL/H3D4qadx2c+/h08qP8FHhz7C2j1rUe4s7/F+xUIh7L3vd4iGvHCEI8izOxCxxIBRU/DetipEImFMLDChrvRkFEX+BOxdDov10/D7jDiwuxrFUe386OSUlqN6zy6M9O7DfRdfjOc21GHD22sQCEWx11CIuoZGOOGEKWpCi78F6/euj++/0eFU9XFozy7k0yomk9ddF9S6MxjAtbb72x5IddctnKa4WJ4pBm3dDQBYb72FiCCC0I/Uemvx6KZHUdNUA7uj+ybtDLpYYC/oMLMKR6fFTF4QBja8R50WpyrlKO9QLE1OBZxsFdZZOmC1TLAJ+1oYM0CDDS6/z4+y+jLl/z9UKS4uVkJGdbXmGqDDv8vKUlvvlJeXq1ggia4v06ZNU5llKGhYre1jR9DdhsFXEy1BKioqlCuNBFTtfqeA9wXrTjoF6eGvqYHXZEKoMBewRjHCXoposBJmsxnjp02H2arF5ho1cTKqt25CqKWpTVDg2AUX4NCrryGwcydGb6vCghEL8En1J1jjXYM5Y+egpzS/+CL87hbAZoAFZjj8BnitURTOXohtzwdgMplx2szRKC7LhWHcQmDfByiI8FhGwmZytgtcPHn+cdi38iM07d+LsaPK8I2KcvxrzXPYWQ1st47Gx1URXDxnBKblzMIm93rUGeswp1Tb/7LRY3Fg7SrEAv6UAZHluus5UndSd5kg1bs4IyIIzUBtNgmAKAhp3S+RAJ7c+mSH/p+SflMQBB2m2h3mGKZKKihoeEKedlmdEmOTdJQOmMLpUG8k0ZJj6dKluOSSS+INdv596623pvzNySefjMcff1wtp3fCt23bpsSRjhpdbP+kagPx99KR7z4UQfq67qKRCKr2a0FCyyomqrgRg5VwZRU4jOIZlsMcKCj02dX83KJiWO1HLL2GjdJifDRUHmxXt3nnnou6Bx6Ae9lbOO27V2BF9Qp8XPUxbpypBRTuCZ5334PfAJjy82FsDMIQBSyxZmw3joc3uAG5djOmlOXBaDQAMy5RIkiObysMGAlvU6jdPpZPnAyT2axS4jYc3K9inARqD6Egx4b6/DH450f7MLo+itHLToHNMgbbx+7E2WPPVr/NL9Fc4hgTpKPrqj+uu45gzJRKT6WaLs8p71c3RmbMCR3Stm0ZUd6j7DmZrLueEA1HULlTczMtnzAKRnPm7v/BVncDhd6sr26JIK+88gqeeOIJvPvuu9i/f79qLOTk5GDevHlYvHixisI+YsSIXts5QRgqsMPy/I7n48EQi2xFOHn0yShwaOljacWRY8kRKw5BENJuQDGAKstI18iUywQjwXaxSPbX7Y9nTxjK0ELj+uuvx7HHHovjjz9epcj1eDzxbDHXXXedSoNLlxZyyy234A9/+ANuu+02fPWrX8X27dvx85//HF/72tcyfCRCbxKNRrD/kxfVdOnIrw5uEaTV0qkxXzsGp9ugknsXlrdthxeN1ESQ5ppqhINBlTVGx3Xaqah76CEEd+zEHH+p6oQfaDmAQ+5DGOHqfns+3NAA/4YN8NkAo9OBSMxG0zQ4wx6sPOhRy8ytKFDZXRRjTgbMDuREDwGRILzN7TPEWKw2jJlzDHat/Bgb3l6KaFiLpzRzwQK85yuAr8GPFW/sg8VoRY6nEDWfVALHar/NK2lNk1tfq9phA81SliLIB4c+UNOXTry0f2M5RaPwvP++miy4/DL2Lvtv2xmC/db1b2r1PXzcFTBi8N7/Qj+JIM8++6yKkN7S0oLzzz9fTVPscDgcKqXchg0b8MYbb+AnP/kJbrjhBvVJk0ZBEDT4ktt8eLOadpgcuHjUxZg8YrIowIIg9BlWk7VNOmA2AGtsNSnNwocaV199tYrNcddddymXlrlz52LJkiXxYKn79u1r8/ylG8urr76Kb3zjG5g9e7YSSCiIsL0jDC2s+W0D5g5Wwq0xDQ47tUCBVncUjCiW12r9oOPIzYPd5YLf7UZD1SGUjD6S+tmUlwfnccfC++FHiL73MaZNnIaNdRuxvm59j0QQ3+rVKhOMPzcXBpMZvhwLjVTg8njwwd4Gtcz8MQmxkix2YOwpcB4+BHi88DSljqUz87SzlAjCQmi1MOesc3DJQeCdF3bCEwijyKWJO6b9eQiEA7CZbXANK1bzgj4fAl4P7DkuDDSG2VNb+/UH5uLMbTtTuIYVZXoXhMEkgvzqV7/C7373O5x33nkpO21XXXWV+mQQsfvvvx+PPfaYakgIggDsatwVzwPP7CyXTLwE+aGhbY4uCIKQaej60pH7y7Jly9rNY4rcDz/8sB/2TMgUZosV8xZ/dkicgHBr4NNqZ0h9Gt2agJBb3HYQktYPRSNG4dC2LTh88EAbEUQtf9YiJYK4334bM44/Q4kgzLJyzthzur1PvnXrVO46n5Xdixj8NgdsLUCOuxGbDlAEMeCY0UkBoycuQs66PwBBL7xN7S1BSPHosZh37oVYveRF5Q5z/KeuwLBRo7Eo34+tT+xAIBzDrPPGofrZKtj8OVi/YxuOnTpLWZE48vLha25SWWIGmgjCINpnjj4zI9s2mM3IPessZBNmqwWnXNX961rIYhFk+fLlaa2MIye/+MUvjnafBGHIQPPzp7c/HU9pe9qo0zCpcFI8arsgCIIgCEJ3Cbdm9Kiyaxnlok3eeFrYZAp1EeSQlkI3EVqCGCwWhKuqMCOoCSgUQXqCf916BAxA1GKGKRZGwFLE+Kiw+FuQ11QHw8hRGFWYlJlqzEnIsf8WiIbgqW/p0G1l3rkXYczsebA6nHAVaqP5OVEDCmCEH1HsNEZgKg8gcsCGbZv3KxFE1UfRMCWCuOvr2glAgiBkL912AHvnnXdSduBCoZD6ThCE1nsiGsJT256KByecVDAJp45qzU8uCIIgCILQAygU0B2GMSXqciI0ukCgqUV9l5dkCUKKRo5Snw2HDrb7zmi3wz5bEwxGbm9Un1WeKhVLqLvxQEKHDsFrMsBotSHPYUA0XICwCTAFWlDeWKVcYdoJHFYnHBO07Uf9HgQ8WsyPVNCiRRdASO3eFjisJrRYgU8ONKBwlJZet+6gVhdEd4lpOTy4UyILgpBhEeT000/HnDlz2pmMMjbIGWec0Zv7JgiDuoHyyu5XcMhzSP1daCvEpZMuHXBBuQRBEAQhWwiHglj16qOqcHqwEm1uRiwQUGmyW1xm5EcciIUjKlaGq7B9nIeick0EOXzooGqfJOM87jj1GVm1TmUpIbubdndrnwLbtmufxUUqyGaeyQNDKA8RkwGGQAvKGisxP9kVphXTpDPgMHuUS4ynUbNsSYeafS2wW0xosBmwZn8jykdpApC/VouTQvJ0EaReC0w/kAhHw1i6d6kqnO5PYuEwml9/XRVOZwPhYAjvPbFEFU4L2U2PQgFfc801OOuss/DII4+0mZ/qwSoI2ciqmlVYXbNaTZsNZlw15So4zEkmoIIgCIIg9Cuh5hpVhoIrTDjPiYjZgOJQrvrbVViYMuNN/vAyJZAEfYy7oVl7JJLTKoL4NqzHJIeWTWZn485u7VNg61bts4hCRwyOUBNiMCFiBmKBFgxrqce80QWpfzx2IZwWt3KJ8R7Yk/Y2G6s8sDDTTL4F4UgM1rzWoM8tVrjd3jaWIO4BaglyOHBYlUwQOdygSjbhbmhQRRC6LYJwJPuOO+7Ao48+qgKOMQ2dLn7IKLcgQKWXoxWIzsUTLkZZTplUjSAIgiBkEKPRhDELLlaF04NdBAnka+4fBQG7+swdljrzk9liQV6J9l1DZXuXGMvIkbCMKAfCEUw/pIUL3NW0q1v7FNi+TX36HXYOucNsNGlBUi1eGGHAqEAjhrlsqX9sc8FZmKMmPTvWpbU99j0aa3wqUOrI0Xlq3sFmC8IOWpLEsGWXtv+5RbolyMATQZgS95QRp6jSr+lx1caNcC08RZVsSI9LmNxjztmnqJIq0YeQXXT7CtAFj8suuwzvvvsunn76aZU1prGxvbIsCNmGJ+TBv7f9W5mokgXlCzCrRPN1FQRBEAQhc9BKomz0JFVSWUwMNhHEm6+lhXX5LSkzwyRSWK6lvG2o1Nx0k3Ece6z6HLWrpdvuMOwb+LdqIoiH7Z+wDyGTSwkUzQ6uz4BSXwNiEa1tlIqckaO1Y9q/W6XZ7QpvcxChQISbwLRJmpvNxkMtsLQam+xpjX/iGqa5B7kP1yMWPeImMxCg8FHuKlelv0UQWgZZRoxQhdPZgNFsQvnEClU4LWQ3R3XVz5s3Dx9//LESQOgeIwjZDAOUPb3tabQEtQbEmNwxOHv02ZneLUEQBEEQhhC6CNKcq3XkHD5Dh5lhkuOCpLIEIc5jjlGfOVu1DDKH3IcQiUbS25/qahWnJGo2wePzAiE/AqZ8JX402AMImSxwGKEy0HREzthJanlPSwSo39HlNhurNXeXvBIHZldoysfGyibkFWuux9VVmstDTkGh6uRHIxF4m7sX7FUQhKFLt0WQ66+/Hg7HkdgGZWVlePvtt5UIMnq0puIKQjbyxt43sKdZ82XNteTiislXwDSIzW0FQRAEYShBS4DqAztVGWhWAd0hXKOJIIedmsWE2R3uMDOMTmH5yE5FEMesWQCtY6rqUOw2KovWam91WvsT2KZZgURHVyAWjcAc88MTK0DMYITbFESDaxhsZhOCB1JvmziH5QEWBzzhPGDHG2mLIAUlTowvcaksMd5ABPY8LT5KU52WmY9uT4yVMhBdYmhBw0w8LP0dV5HbC1VVqZItMR2j0Siqdh1UhdNCdtNtEeThhx9Gbq72gNGx2Wz4+9//jt27uxdJWhCGChvrNmJ55XI1bTKYcOXkK+GyujK9W4IgCIIgtBKJhLFn+XOqcHqwW4LUOFszXLQE1EfusK7dYRqrKhFNYeFhzMmBfcpk0KZkXpUWY2R/i2YV0hX+1qCowfIy5QqTZ4vAbShXXi1eSxgYXgbGLw1XVXa4jpx8m0qX6w3nAttf69IlJi6CDHfAZDRgerkWFyRkoQUKEGpC3JLFpccFGWDBUSk0vXvwXVV0N+r+23gE7rffUYXT2UA0HMGaV99RhdNDHYpbe9asxJYP3hnUom9foUU/SoN169ILVDR79uyj2R9BGHTUeGvwws4X4n+fM/YcVORp0dUFQRCEruGoHK1KGWts79698Hq9KCkpUW63ixYtQkWFPFOF3sGS2z6F7GAjXKd15g/Z/TBRBwmGAYsFucUdu8PQVcZstSIcDKK5thYFw9sHbHfMOwb+TZsx4UAYr0/UAr0ztlna6XEL84H9PuQ5I6hDiRYrxBRDwZiRQO02hKo7zsrjZHwTixM+by4iDQdgqtsOlEzucHkVFFWJIFpw2Jkj87FybwNqgg5YDEbYvC7sb96PsQVj1bFXbt8K9wCzBCEFtg4y5vQDpoLMbTtTOAs0kSwbWP3KC1jz2stquqWuFsddfHmmd2lwiiBz585V2V+SM8Hwb30+PyNZoiYKAvGH/Xhy65MIRoPq79nFs3HscC24mCAIgtA5Pp8Pv/3tb/Hggw/i8OHDqq0xYsQI5Xa7Y8cOPPfcc7j55puxePFi3HXXXTjhhBOkSoUeY7ZYccy5NwzqGmRw0XB9vcq8csjmhdVnUhaoNmcOrPYj7urJMC5GQVk56vbtVS4xKUWQY+ah4Z//RMnORrQsMOOlzRsw3n4m5lYUdJgBkvsT2K6JID6rRcUDybeHEQzmIooAfGYjRk4cDazoPCaI3WlRwSqjZgd8YRdcm18ASr6VctloJIqm2rYiyJQyzUp9e7MPs80mxEJRbDuwS4kgRyxB6jGQMBvNOHtMZmLHGcxm5J2zGNmE2WrBqdeej2wg4PViw7IjbmWcnnH6IjjzskcE6jV3GLq67Nq1K/7JBspbb73Vbr4gZAsU/p7b8RwO+7X87mXOMlw44UJJFS0IgpAmkydPVpamf/7zn9Hc3Izly5fjP//5Dx577DG8/PLL2LdvH3bu3ImFCxfimmuuUcsJQjYTOXxYuS9EDTF4ckxw+ozgP1dRUZe/7SouiH3KFAQtNnjrfXDt92Fd1S58899rcfd/N8EfSj3IGdq/HzG/HwaHA+6mKqoicNidCEUYEy2GqNWG0VPGasvWdBxjxGA0IIfWILZcLS7I5v8CIU3oSKa53o9YNAaz1ai50QCYVKq5IO9r8MGarwk2ew5qmXBy9QwxA9ASRBD6gh2fLFdWX4UjRqJ49BjlDrN79Qqp7J5YgowZM6bN31SER40a1W6+IGQL9OHc2qD5wdpNdlw15SpYjFqaOkEQBKFrXnvtNUybNq3TZdjOuOOOO/Ctb31LiSKCkM3o8UAiBbmIGf0oCucwqUrc2qEzikZ0niHGGwE+sZejIlqHaZUhtIxqhNEDvLOtFu5AGL+4bBbMprbjp3pqXNukiWg+pMUGNJfPQ2hrBH6zF+OKS2BjrBDue1XngVadeTa01NvhtYwDgu8CW18BZl7WcTyQUqcST8gwlw2FOVY0eIIw5VqBuiCqq7RBKr1umCZXELKBA5s3qM9Jx5+k+uy0ANu7bjVmnCbZXHWyIzG0IPQyOxp2YNn+ZWraAAMun3Q5Cu1a9HFBEAQhPboSQBKxWCyYMGGCVK3QY8KhINa88S9VOD2YRZBAoeYGkhfQLCFcRV3HOiko04KjNlRqFhLJ/OvjfdhUNBYWoxmzaiLIc0bx40vHwWYxYdXeBvxj+d52v/Fv3Kg+zRMmwNOopaU1jDoN4WgEHmsLZpWXwzx8uJofdbsRcbs73L+cAitHWeEpWajNWPfvlAFSm1rjgeSXtnX/0a1B4HAesRiJxeKpg7l/TJU7UAhHw6otycLp/iQWDqPlzbdU4XQ2EA6G8MHTr6vC6aFKJBxC9U7NRW3klGkYOXWGmq7dtweRLDnXA14Eeeedd3DRRRcp/1+qVPT9TeSGG25Q8xPLueeem7H9FQTS4G/AMzueQUx55AKnV5yOiYUTpXIEQRAEYYATaDikymBFF0G8rW4gOQFz2iKIniGmua4WoaCWUUbHGwzjmVUHsXP4eBQ4rRhbGYE5FEWuqxnfOXdKXCTZW+9JKYIELU3KFcZuNcDtmIZILAqPpQXHjx4No8MBU74WiyBcXd2pJQjx5EwHzA6gfjuwc2m75RrimWE0sUNnYqsI4jHQOsYAi9uh0vw6cvNgtliUIOJuGFjWILW+WlUydS3p11O20Fxbp8pQpmbPLoRDIXXdU/jMLx0OW04OIqEQ6g+INWWviCAdBUlKF4/Hgzlz5uCBBx7ocBmKHpWVlfHyr3/966i2KQhHQygawr+3/hu+sDYKMaVwChaObB2xEARBEPrEWsRkYnwBQTg6jEYTRs0/XxVOD+bMMM0ubf+tvljaIgiDIrJjROuKwwfapr99fVO1ivvhHDMarvLhsEVNGHUwoNLknj65BCdOGIZINIbfvb4tniQh3NCA0EHNtcZbt1J9Fo4YjS17mwFDFH6bG1NLNVcY3RqkMxHEVaiJIO4W5un9jDbzvfuAQFvrkcbKFsDXiIKN9wKv/gBo1I5l0nAtOOr+QFi5J9v9udjZuFP1V/T6aakfOCKI0WDECeUnqMLp/t24ETknnagKp7MBo9GIGaefqAqnhyq1ezW3tOHjJ8aNCIaP06woa3bvzPDeDcKYIExTlyh6MKI7rTisVmub5VatWpX2xs877zxVOsNms6GsrH0Ea0Hob/jSf3Hni6jyatHNi+xFuGTiJRIIVRAEoQ+555570NTUJHUsHDVGkwkjx6fvgjUQCddoaWYP52hChMlN83YzXIXppf4tGTMW+zasUx0ldpISRRBy0dyRcDYdA8vBnRiz149DnkOqnfO1syZh1b5GrDvQhPd31OOUScXwb9qkfmMtcaG+vpJ2KSicugDrdzZq++r0It+mWYCYy4YjsG0bQp3EBckdZlefLfV+4JjrgC0vAS2VwGs/BM79BWC2IbTpNXj2NzNFDApalgPbfMCBT4CrH8OkUk0E2enxYaLRAlsgBzsbduHkkSfDNawYjdVVcB8eOFYAFD4qcjOT/pvZgqxZlnqc2YcqpmlBeocyjP9BikcfOdbi0ePUfV9/sK34mc2kLYJccsklbf7+1Kc+hf5g2bJlKC0tRWFhIc4880z89Kc/xbDWKM+pCAQCqugw2jyJRqOq9AZcDzvEvbU+YXDwSdUnWFu7Vk1zhOHKSVfCarR2+zqQ60c4GuT6EQbatdPX78Lk9ocgZDO6+0KtMwxTKAZDMKrsuvUMKF1RMma86gzV7D2S0bG2JYBNh7T28ulTSmBrngvTS89i7F4vNrspbgDD8+y4Yv4o/PPDvfjb+7uVZYh/4yYgFoXdsh8NPqfK7JIzcgJaVnhBOcOSF40HjLfoliCdZIjJLdJEEG9TABGTA6ZzfgY8ewuw513g7xcpEaSxxghEPw2HPQT7mV/T4oY07AY+fBDlZ92FHJsZHn9ICV6GkAF7Dh0AZnLdrWly67LL/UPIPur27VGfJQkiSNGIzjNDZSNpiyA33nijygbTn+ZDdIW57LLLMG7cOJUi7/vf/76yHGEKvY5MYzlidPfdd7ebX1tbC7/f32sNPo5KsTE5lM2phCNUeivx/J7nEY1pjf0zRp0BuIEatzYi0x3k+hGOBrl+hIF27bS00Ha996ipqcHWrVrmrSlTpqiBEEHoDZgmsr7mgJoeVjpKjYYPNsI1Wie+0u6HzQuYjCbYnDkwWzVXkq4oGTNOfdbt1TpK5IOdmnXE9BF5KHbZEJ47F2ajGaW1QbxXfWS5q44dhefXHMSeOg/e3FKDaetWA+5q2AtiaPCVAPZ8VEZzYA35GJIDuYVHMuaZh2tW3aEqzZo2FXaXBSaLEZFQFJ6GAPLK5wAX/R54/U7Aox334fACwF6AwlkVwOwZQOk04KkbVEpdwwm3qLgga/c3wuC0AH6gslo7trwS7TnSVNv9dltfwWdxvV9zzxlmH9avlsXcdqTVtcpUXJwVVs18B9Yf0M7/sFGlQ7IP53e74W7QsiINqxjdLjNUY1WlCg5sFBfT9EUQChGMydGfjZFrrrkmPj1r1izMnj1bRYandchZZ6VO8cM0erfffnsbS5CKigqUlJQgLy+v124iPiy4zqF4AwltcQfdePPAm7DaNdcv+m4uHNPzOCBy/QhHg1w/wkC7dux2bfS2N8SUL3/5y3jiiScQac3gwAGPq6++WsUOy28NrCgIPSUSCWPnu0+p6YJLvgqzsa1L90AnGgwi0uoatt/mhu0wYDKY4MhPPzudGh02GFRHydvcpOKErN2vrXPBuCL1aS4shH38eGBjHeyb9iBycUSJLbl2C64+rgJ/fXc3lr7+Osavfo+pKGAoK4V3fwl9LLC8ErAyZogRcBUceTZYylotQTpxh+HzidYgTIFLl5i8YgdQcRxw3fNA1XogGkbjygJgTSMKyzXXF5TNAsrnApVrgO2vYULJAiWChK3atiMtBhz2H1bBIUlzbedpevuTSCyCt/a/paYvnXgpzAZzP248ojLDkILLLwPM/bjtDBENR7DyJe2YF910BYzWodeHa6jSLD2YEclqP5I9KaewCBa7HSG/H001VSgs1yxDspm0r3g9CFImGT9+PIqLi7Fjx44ORRDGEGFJhg2+3mz08UHd2+sUBh6RaERlgnGH3Oqcj80bi8VjFx91ACu5fgS5foRM0BfPnt5a1xe+8AWsXr0aL774Ik488UQ1j5aft912G770pS8pcUQQjhaTs3cGxDJBpNUVJmazoNkSRhktQQxGOAvSF0HYESosK1dpcmv37MboWXOw/qAWw2PmyCNCY/6Jp+Dgxk8wcZtHZVgZ4dIyy1x+zChs+PA13LjlfkTDIdiKnHCf/b/A3/8FW34h1ux243hEEbYGUJBzpK7NrfH9QtXVqk/RkeUB44JQBGmu92EkWo/LbANGHasmG15Zrz4Ly3OO/GjKeZoIsu1VTJiu9Q+YrNfFuCB+lwqOOrVUs4Bprq1BNBoZMIFxXZbWtL4ZwOhKqMMswT7Ej7mxNf21nglKh/dbYdkIlTmG936hiCDpiyB6BWaSAwcOoL6+HuXl5RndDyF7eH3f69jbogUYyrXm4orJV/R/BG9BEIQsgOLHq6++ilNOOSU+75xzzsGf//xn5R4rCEeL2WLFsRfcPOjjgUQK8wBDE1xBCwwUQfILurUexgVRIsjeXbCOmYJ6dxBGowHTyo+IFrmnngrz3+7H+D0+HKrdFRdB7N4qfCf6MOqrQ/DFrMg973No8Gr9g3pjLmyhGExGwGv3oNR2ZL/MJSXqM+bzIep2w5TbasmRREGpA/s3AY01Wha+RKLRGBprtPS4hWUJ6XHHnw4suweo2YxJJ2puy4eCIcwwWeDw52JX4y7Mn3wMTGYzIuEw3IcPI69Y259MQpej88Z1niCirzCYzci/4AJkE2arBad/7mIMZRqqNBGkYHj7vnL+8DIlglAIFLopgtx5551wOtvm5E7m3nvvTXt9brdbWXXo7N69G2vWrEFRUZEqjO1x+eWXq+wwjAnyne98BxMnTlSNIkHoazbUbcBHlR+paZqbXjn5SuRYhraCLAiCkCkY9DyVywvnMTi6IGQ7oVYRJFjAtkgT8gKaO093LEFI6dhx2Pbhe6jatQP14zVXmCnDc2G3HLGOsI4bh+DwApgra9H8zjJgXKs4+f7vkQ8/DtTYUG/IxxrnBEw4dBDhaBSbPDbQO85qBgI2NwpsWhwCYrTZYCosRKShQaXJ7VgE0foZTa1iRyIt9T5EwjEVNyS3MMENL6cYKBynAqSO9m2E0WhDQzQCk8Gs0uTuatqlLD8YF4TiT3NN9YAQQQSht+H1TQpSWHrkl2guYU0DyCVs0Igg69evb5cS92gsRVasWIEzzjgj/rcey+P666/Hgw8+iHXr1uHvf/87GhsbMWLECCxevBg/+clPUrq7CEJvUu2pxgs7X4j/fe7YczOWxkwQBCEb+OEPf6jaAY8++qga/CBVVVX49re/rQZhBCHb0S1BvPlaO9jh10SL7sQEIeWTpqpPpsk9vEcbFZ41Kr9dm957yhy4nnoDprc+Aq6nqcdOYOdS+KpjMFoK4TY68cjhHJy3fTmCLUE05hViWo4NBr8Hfoog9rYWKubSUiWC0CXGNvFIet5E8ltFEFqCxKIxGIxH+hYNlUesQBLnKyqOVyKItXIVRhedhVq/G4aYJoLsbPi4dd1lqpPITuAopowRhCEE3cwaWy1B6PqSjB4cmCKg0E0R5Nlnn+3VwKinn356p7FGaBYrCP2NL+zDk1ufRCgaUn/PLZmL+cPny4kQBEHoZebNm9dmAGX79u0YPXq0KmTfvn1q4IMZ3hgXRBCOBrpCbHz3OTU9Y+Elyj1iMIogLbkm9nhg8WrpcbtrCcKgiewQ0Sx+56bNgGE4ZifEA9GxnbEQkWeWwrm7Cr516+Bo1NrlTZUlsNtMsMw/lV0vuKsPwhCLwjBsJI4vKsDmulr47W4UO7S0tDrm4aUIbN0az3CTet/sMJoMKkOMuzEQT5tLDld51Gfh8BRW6QyOuu5JoHojJpRcjH01bsRiJpjDFtQ3N6og93pwVAaGHChx55ZXLlfTJ5afqILP9hexSASeDz5Q0zknnQRDFmQLCYfDWPnSu2p6/gULYR5k939X+FqaEXA3wRAJIt+m9WESiV//tTWdxuXJFtI++9leUUJ2wIfCczueQ0OAIbWA8pxynD/+fLn+BUEQ+oBLLrlE6lXoN2KxKHx1e+PTgw1dBDnsAkwhwBSm3wq6HROEjJg8DY011Yge3A6MGo4ZKUSQ8pFT8MbMHMxf70P9X/6KkTPWwV8bhe9gELC5cOat1yG6vRIbthlgcuThvptOw6rHd6jAowGbR6V9TcQyvDVDTHXHIgRjk9Al5nClB/UH3W1EkNp9WjruYaNSBBMt1axbUL8DE8fYsdRoQNBkhClKaxAXdjftRp7eCexk+51RvXsnNi57Q1mUzDv3wqNOMxpDDJWeyvh0vxKLIXSoMj6dFURjaDjUeu6jQ++YG/bvBlqqkWsNwvzsTcD1LwC2I25nucM0F7Cgzwu/xw2HK7VLWrYwqLLDCEJf886Bd7CtYZuadpgduGryVbAYj+S5FwRBEHqPH/3oR+qTKXHff/99zJ49GwUF3e/QCUI6MC7EiLmL4tODjUhtnfqsdYZh82nxyuy5uTBZut9OGTN7HlYvexPFvr0IFC1CvqP9Oka6RmL5gnxM2+KFf9M6VO6tRbDFCFgdyF20CJbycozZvhmVLhtGTZ+K4XkOtDT4EI1FEUhlCdIqQoRrOg/MWFzhUiJI3X43xs7S1hEORVB/ULMEKR2TIsNP3ijAmgMEPZhur1ezmgxRFBoZHDUPOxp34OSSOT2OicCAk0v++DtEQtoIOzuRJ1/1GRwNDLR/3PDj4tP9itEI5/HHxaezAWYym3ZKa30PwWNuXPkiTXxQ4AgDgWZgw3+A+TfEvzdbrXAVFqn02M011VkvgqR9BTz88MMpA5YJwlBhe8N2vH3gbTVtgAFXTLqinT+rIAiC0PuYTCYV96uhQbPCE4S+gCP3FZPmqHK0o/iZINSa1aHS7odNpcc1wVXY1toiXconTkbAaIUl4sdMi5YiN5k8ax5iRflYsrgI4bAXvuooImEbLCNHoviLWpadmr271WfJ6LEIBSPweYPq75gz1C6YPGOCqOOo7koE0Uao6w5olh+k/oBHxQhxuCxwFaaIDchObYlmDTI2uk/7TSyiBrL04Ki04CDepiaE/H50h+VP/ysugBAGlm05rIlSPYXCx9j8sar0twhiMBphGzdOFU5nA0azCWNmTVSF00ONxh1r1GdRSav4uPnFdsvkSXDUOGld9R9++KEKVppOQFKv14uNGzems1pBGDAc9h/GM9ufiZsjnjn6TIwvGJ/p3RIEQcgaZs6ciV27dmV6NwRhQBJxexDzamljD1g9miWI0aTie/QEikD1re2c4tqtHbrCMzXutsk5aLooH3kTTSi8eBFG/v4+GHM0gaNu3x71WTJmHDwNARXnImwOIt+V286V2DJcE0GYHaYzSio0d5fDhzwI+unzAxzcrgmkpePyOnZRLp2mPnKbt6MwxwqviUNamjsMRRCb0wlHbl6bVKLpULd/L6p2bFNiwVU/ugcjpkxDLBrF1g+0+BKCkHH8zWio18TMgpNpoWRQgYLh0ayi2gVHrZU0uWmJIJ/73OdUWtqnnnoKHo9mipbMpk2b8P3vfx8TJkzAypUrMRTx+Xy45sorMXJYMT579dXqk39zvjB4CUVC+PfWf8Mf0UYFphVNw8kjTs70bgmCIGQVP/3pT/Gtb30LL774IiorK9Hc3NymCMLRwo5rY12VKpweTETqtHgghlwX6mMtrZYgRmXe3hP8oQg22sap6dC+zfA0prbCGpEzghWH/a46lCywouhLX4fJpYkUAa8n3plSIkhjAJFYJGVQ1ERLkKjbjWgH/QniKrQjr9iuQlUc2taoXPIPbD6svquY2snxlmgiCGq3YEJJDnwWuvObYPflYV/zPhUctWiklrb38KEDadYUsPWDd9TnuHnHqvqedPyJ6u/9G9fhqLN5+BtV6e+wA9xemOmKGxqyJuRBlPd/Vb0qnB5KxA6uQqPfSHMXFEw+DiierH1xcEXK4KjNIoKkJ4JQ4LjgggtU+jr66s6YMQNnn302LrroIpxyyikoLi7GMcccg927d+O1117Dddddh6HGsmXLMKqkFE1bNuKW04/D5fNnqE/+zfn8Xhh88MH/4q4XUe3VRiUYxOtTEz8lgVAFQRD6mfPPPx9r167FxRdfjFGjRqGwsFAVtjv4KQhHSyQSxta3/qkKpwcTodY4GtEizTXd7jfASHeYop65w2yqbEazfRj8+SNgRAzrli5JudzI3JFAJICDhgiQWw7kap0oUr1rR3x02ebMgadJE0FUUFRH+/0yOp0w5ua2OZ6OqJimiR17N9Sr2CAthwMqa8yISZ24KbdagqBuOyYWO+A185wbkB/W1rWpfhOKRrSKIAfTE0EY5HXvOs3NYNLxJ6nPUdNmKasQptttqe+5Swzr6vV9r6vC6X4lEkHLa6+rwulsIBqO4MNnX1OF0yTo96GJAYIHeR14d69GMGKEwWJHPsXGUa1ZLQ+uarNcfsnAypA04AOjWiwWfO1rX1NlxYoVeO+997B3715lATFnzhx84xvfwBlnnIGiop6p0QMdHuflF16Ez59yDMryc2kfqObn2KxYNH08Zo4sUd8fqK2Bw+HI9O4K3eCTqk+wrk5T8q1GK66ecjVspq7dvgShvwkGg/jx3f+L5x7/KyZOnood27bgkk/fhLt+9L+wWq1yQoRBz1tvvZXpXRCyAJMtRXrVQZQZJlSguaG4AlogU1dRz9xh1h9oUp+5804H1j6HLe+/g6knnYrC8pHtgqMiHMBBDpuWa4FFdQ5t3aw+R0zWYnEwpW0kGobf5kapc2zK7VrKhiPQ0qJcYhiPoiMYEHXju4dwYGuDKmre7GJYbJ3EcsivACxOIOTFTMdhPGMGgpEockIFMESNWF+3HqePnNktS5A9m9eh8vB+tBh9uHPXr3CV7WqcO/ZclI4dr0Sgyh1be+ySROymI9lv+hujI3PbzhQWuz0ubq186WVsWPa6ivWSU1iIhdder7Im9SURZqXpA8ubhv2tgmRRIUxmC1A6Q/uiTkv20M4dpq5WWcMN1HgwtFBqeOyfsM+YAdcZp/fJ4HS3EyQfe+yxqmQTN153HY4fV6EJICng/OPGjcLnb7gR/3ryiX7fP6Fn0DTy1T1azntCC5ASp5Y+ShAGEhs2bMCnzjoBn5kBLLvShHAZYJ7jx/8t/z9Mq/g/PL/0QxVPQRAGM6eddlqmd0HoLdjIf/MnwJ73gImLgIXfGhAZKMwWK469+BYMZhHEW2BT9Wv3GlR6XNewYQj0oE+1rlUEmTFvNnKie7Bv/Rose/SvuPC278Bis7d1hwkHccgQA8pmtVnHwW26CKJ1HOkOE6YliN2N4c4jFiOJmEtKEdi+o8sMMQXDnRg3uxi712mWFiazATNPbSvQtIPXWPEkoHItxhsrETQWwB+NItdogz3gUiLIZVPPVYsePrhfdYS7cpd+9OXfwxjyor4CqPXX4YHVD6Al2IJx4yYoEYRl8oKeuVCbjWZcNOEiZAKD2Yz8iy9GNmG2WnDWjZcqK/B3H38EOz75UPvCYICnoQGv//kBnH/rN5VrV28TjkRx7+vbsGRjFSoKHfifE0rR6h3WKzS2xriJi5glre4wddsBXuet2bD4vKDwEQmF4Glq7LE7XV8SCwZR+b07ENy7F80vvYSo14v8Cy/o9e1k/o00CHjrtddx4gTNfK4jTppQgTeXpDYlFAYefIE9te0pRKH5BJ404iRMHza9zy2KrrrySowo1mLK8JN/S0wZoSsLEAog/70C+PGpJhQ5tcc2P/k35/N7LicIQ+HZwwDrW7Zswbp169oUYRCx8Rlg0/OAtx5Y9ySw9vFM79GgRxdBWnLNMIcAc1R7F+QUFPWoQ0Z3GDJrZD5OvPwaFTC04dBBvPv439vES2FgVLrDNBli8BQdse5gTIGm6irVoSqfpFmCeBqDCZYgqXt45uGaOBLqIjgqOfaCsZh03HAUj3LhzOumIbcoDcuFYZPUR2lwPyxmE7wmxk45kiHGVJgLs82GcDCo9r8zHt34KKK769Qo9KcWfx7XTL1Gzf/Hxn/AXajVf82eXYMmA+LPP/o57vnoHuxu0jL6ZCsb3npdCSC8dk/97OfxuV/+HhXTZylhgOJIJHwkC1Bv8Y/le7FkQxWYf2HfYR9+/eY+uAO95JIXjaChXhM1nSPG4+H3d+OpHUbEaNke9gFN++OLMjW4brnU0hpnaKDhWb5cCSA6Tc/8p09iOIkIkgZUDOn60hn8PlsCCw12wtGwEkDcIbf6e1zeOJw1+qy+jylTWoqWLRvx5dO0mDL85N+cLzFlhI6gCwwtQKaXpDYB5vxPzwB++pMfSyUKg/rZU1tbiwsvvBC5ubkq9ti8efPaFGGQwLbQmlbRw9ZqQbvib8qlQjh6EaTBhXhQVEdePswWzS2mO+yodSMQisBlN2PssBzkFBTizM//j8oYs2ftKnzw9OPxTocz6EVBJKpGyw/ZtYCoZM86LdZA+aQpKusK8TT6Wy1BPCjL0dLRJmOOZ4jpOjuF1W7G8ReOwzk3z0TpGC2rS5cMm6g+jId3YmyxU4sLEjWgLFah2ulbGraguGKMWqa2Nb1vKvY278WbHz0LcxAoLRyBMxd8Cp+Z9hmcPeZs9f2TjS+pjIIUUgJeLwYyOxt34nvvfg/LDy3HB4c+wLff/jYOtKQfGHYowXO+4sVn1fQJl1+DiccugMVqw6mfvVEJgY3VVdj20Qe9us3DniCe+ERL2/w/p01Aeb4ddZ4Qnll1sHc20HwQjbQMgwFP7jHj0eV78eA7e7Ap1GqNVZvkElOsWb031XYtRGaC5iWalX7+5ZepOEKhQ5Xwr1/f69sRESQNqAB7Ap2PsvL7vvBXEnqf1/e+jv0tmiqaZ83D5ZMv79P87CqmzEUX4fMnH6NiyOiCmh5ThvP5/UAdlRUyyzOP/Rm3Hdv5s4XfP/2P/9dv+yQMDgbbs+frX/86Ghsb8dFHH6n4WkuWLMHf//53TJo0CS+88EKmd09IF5pfN+wBTFbguhcAVxngbwJ2vJHxOoyEw1j/zvOqcHowiiC1jgjsHi09rt6Z6bErzIh8GI3a+2X4uAlY+OnrldjB1K/L//OENrhXsxkjowbAaMFBv+aawvm7Vn2ipsfO1gTKSCgKT0tAiWAUQVJlhyGWVkuQrtLk9phhE7TP+p2YUOKCz2xAKBxDhVFLB7ymdk3c3aEzEeSRjY+gsDIGu9mOGfNPUSPo5AuzvoB8Wz4OhKoQsGuDn4cPHRlp7w5MJ0xhgoXTfUE0FsUf1/wRwUgQkwonYXz+eAQiAfzfivvgfv991C57F9srm7RYFUMcT3MzXrj31/A1uzF69jwVA0eHgX3nLD5fTa9745UuXaW6w/NrDiIciWH6iDxcdVwFbjpFs6h6ZvVBlaXpaInV70KD34wwTNjuPxKbco27CIFwVHseJ5BXMnAzxDAVuK/V8jP/wguRc5KWicm7sm2A195ARJA0OGPx2Vi+s3PF9IOd+3HmuZqfoTBwWVe7Dh9XfaymTQYTrppyFXIsWpCxvoIppo8f20VMmbGjcP111/fpfgiDk0gogGGtLjAdUeykf6eMsgqD+9nz5ptv4t5771Vxx4xGI8aMGYPPfvaz+NWvfoV77rkn07snpMvut7XPMScD9jxgxiXa39sy7zIci0Xhrd6hCqcHC7TKiNRpAkSVw68sQZgZRg9y2F02HNREkNmjtEwzOhPmL8DCa69TQsiW99/GR8/+G7G67RjB/rHJgoPug3EXEGZXMVksGDtXy0LhbvQjEgsjbAqhIDdXxbtIhZ4mt6uYID2m1RIELZWYUmiA18LYHlGURkbEA+IzqCmp2rk95Sq2Ht6KlYc+QVEVkG/Nx9g5rZk2aBljceJz0z+npvdaapXIQDeinkBLkgPuA6pwui9YW7sW2xq2KTHnBwt+gDtPvBMWkwVb67fgveVv4cF/vYNbHl2BL/5jBWopYg1SmN3F29zUoXjB+e8++ld4mxpgMFlx4mXXthu8nnzCKbC7XCo+yP6NvWN5QMHwtY2a4Hf5MVpohVMnlaA4x4IWfxgf7dZSPx8Nnv1bEI4aEIiZ4LPl49YzJ+LcmWWoNA7XXG4aj7iWtAmOWjvwRBD/hvUqW5FlxAhYysthnz1bzfetX5d5EWTXrsHh+9abPPyPf+Dj3ftR1dSS8nvO/2T3AfztkYf7fd+E9KnyVOG/O/8b//v8cedrUc/7mGXpxpR59UiQVkHQMVlsqPdGEQxH8YM3g5j0QBQ3/Bfqk39zfp03qpYThMH87PF4PCht7SAxJS7dY8isWbOwalXvjwIJfcQhLZ0oKhZonxNb3U33fwIENDfUTMHR/OEzT1NFH9kfDESamhALhZU4ccDi0SxBDD2zBGGnbH2rCMJ4IMkwDewp12id/E3vvImP3/oAoyIGZdlDFxGyfqn2zBg371jYczQXGffhgHI39jtaOnSFSYwJwmOK+v3odSi8ubRtTLXWwNeaIcbhz1PCDNuCoVK76gAzJoKvqbHdKv615V/IqwPyok648gpQPnlKm+8XjV6Esflj0ZQTRnOwOe1MM8nQCnleyTxV+soi+aVdL8X3mWmLaaFz9uizEYpF8afgdmwtHoeYwYDddR78/OXNA8a1PxoMpnV90KJrxX+fwT+/fzueuOs7eOx7X8f7/34MDZUH2wggHz3zbxXI156TgxMuvw4O1xHXLh26lulpkLcuf7dXjmNnrQfVzf7/z95ZgMdxnV34LDNpxcxkWZJlZohjxxBy4jBDkzZNg23TFNKkSdu0Tf42bZiZwUkcO2Zmy5ZlMbO0Wmbe/7l3tAJLliVbpnhfP/PsaHF2dnc899zvOwd8LhvT05jYaA6bhZkpTNTzxopTr4gyNNfQz83H5uOywz9g2s5vsDQrDB2sKDjcPvj1DUOKIBbduecJ4jjM/P8h6mmBFfWIIK7qGvjHuGp11L+49PR0Gof7wQcfwHk6Dl7nIKQs98vvv8NbO4qxvryutzWGXJK/yfXk9lA87rmL3WPHZ1WfwRtgyl+LIotQFFV0Zl484B+Rpwy5X4gQx7Liprvx+BYfkv4bQLEhBbfOmobLJ4yjl+Rvcj25/epb7gntvBDn9bEnKysLVVVVdL2goACvvvoq2tra8MorryAmJuZsb16IkUBmYTt7ZuyCcaqqFECZCPg9QHNPGsNZgnheJOdMogtZP1/wapjBCidMBa1HD6E9KIKMvhKkRe+Aye4Bj8NGZtTQVWIk7WTmtTfR9bIqDdhNMtoOQ4xFW8qOoPloCTWVzF+wuPcxFoMTHiKCCC2Ilx1ffOVIpbTP/0y0xCQG2no8QQKw6t0ojCik1+/RHYA6IZGua48xNq3UV+Jg10GEt7Mg48uQUkgq0wZ+V0gr0p15d8IuB2weG9qbmXjS0UKEj3RVOl1OhwhCQgBI5QthScqS3uuXpS6D0elFfVQ7FHmJePuOaXSQXtJixLYapuLobMejNt92OxpWXAXDJ58e/34eD9a9+gKObPwRHhczJiWGt6Sd6+tnn8IP/3uO+n98/+9nUbFjC/3OLrjjbkxYNBds7tC//8xpTNJPW2X5mHi97Kxl9uekZBWEvL7XnJXCCJB76nWwOE/NiFXX3gZi4ROmNWN68yE4Vq+G+sPXYZcyPjgOTT1RgnrvHxRPzT0xuecSzopKeikcn9crmnLUalod4qob20KMUf/iyGxMfn4+Hn74YURHR+Oee+7Bvn1Me8FPmXnz5qG1WwNVbgFe3rIfXx4so5fkb3I9uT3EuQk5AHxd+zUMLiZnnlR/XJJy5lqXiKY+Ek+Zc0N7D3Gu8djvHsfn5WzcNH3ikL4O5Povytn4zW8fO9ubGuIc43w79jzwwAPo6Oig60888QTWrFmDxMREvPDCC/jrX/96tjcvxEjQ1QIeO8CX9HkzkJJz0hpDaNkb2o+n4AcCtYrGtgp6PEFkJ1EJUtzMnAuNi5XTge/xyJo+m6bGwOeBtlOC3P0C8A90YuM7jP9U7uz5UEb3iZPBShCH0MIkygzDaBJiTqUlRmRuhFwtRIAFOJxezFQyMdxbWrYgLotJBOyqZQZdwfPFd8veBdsXQIJeSitHUosmD3p6Mmj1O5MQE8dEAzc1VY6ph8RYQdq/SbtOkjwJiXJG9CEIEAm3k3x3/Jico0GiWoyVkxLobV8cPPuGqbpXX4NPr6cDd/3778PdOnS70e4vPkJHTRWNdF5w289w2/MvYckvH0ZyQRGt9OmsrcaRDWuhbW6iiUBzb7qDtnwNhyIyGqqYWCoOEMHvVNnRI4LMSh/okZOoEiBZLaZeITtORXgKBKDv1sPvCUBqc/cKLfYdO5AvFsEHNjxOO2Dra32RhvWLyTUyx4NzgYDPB3cj418iSGd+w+RzDK67605ObBwzEaSwsBD/+c9/0N7ejrfeeouesMyaNQt5eXm0lzdYvvpThFR6fPzpJ2jTafHBp5/SS/J3qALk3GZr61bUGpkfjpgrxsrMleCxR++mfrL4A94Recp4cX6ZtIU4MxAvhKkpicP6OkxJScQ//v5s6CMJcV4fe4j/x2233UbXJ06ciKamJuzfvx8tLS249tprz/bmhRgJ3T0DyshcUnbRd32wNeYsiyBkYGM26uhyrs2ADoe3J8rSrZSC4wlA4GGB/DuZdpiDTcygpyhJdcL75uSlYm6yCXw2CwoTDzH1REywITYzB5MuXTHgvlaDk4ogLqH1hK3GpNef4Glvx2mhJyaXiHI5sQrYSEuM1490di5EXBG67F2wxzFxu5q6GnjdjBfGIc0hHNUeRVg3B3K2GFJVWK9/SFAkISLB1S/vxqOflWB33US4WQE4XDYU1+we9WaS5yPVGmQ5HW0oxHCVMD2WMZcMsvpIB3jObChJ4ZbuEH3tywtjqUluWZuJtsacLXxWK6zbmVYUjkJBKwBM33wz6H5NRw6jhqS4sFi46M57qTcNqdiJSc/Cgtvvwco/PoPJl12FnFnzMPnyq3D17/9C27fMOhNd/MP8/pPGMxVDjUcOndJ76TQ5UaexUh14eupAEYQM7udnMb/fzVWn4M1h10Nn9SPgAfheFsJ++UtI58+nN02o3g8NO6LHHLVpyJhcs/bc8QUhx4OAywWWUNh7jCAI0pjf4FmvBAnC5XKxYsUKfP7553j22WdRW1uLRx99FAkJCbjlllt6Z3NChDibEHMrIoIQyAkDSYIhrt5nkrt/fh/2NjQP6ylDPGd+/ov7z+h2hTg/+Oidd0fg6xCP998OeRKF+Gkde8RiMYqKihAePnTKRIhzEG1PFGN4zyA0SFwRwOLQKEeYxigW8iTw+byoWP8OXcj6+dYO41AKek1RiYEjX8S0lYwU0hZS0sp4YEwcgQhCRIQ0tQtXzVWBVRSP7nhAvrAQi+69HxzuQONT0g5DWo5JJUi8dPj/s3hxsWMigpBZ4+4X/gvd2+/Ab7MNNkfV1SI3WgYbD3Qg6NB7eyNu11q2UZHD63GjqbSEprO8Xcb8PzpBFwMOi4vUiVPojHkQEmn60uZaarQaLhOAjxhYBHL4fAF8uP1NeEjL1yjwBXxY27iWLmR9LCGCFAkDIEyJntJ7PRE8NlR0QeBOxewaF1ibdsHjcSJcKsDUlDB6n62nMig/Rex791Lhg5+cjIiHH2au27dvgEhEDFB3fvo+XR+/YBEV5Y6FVDuQ26ZffT3Gz18EsVwBv9eHXZ/9QBeyfjyS8pl2+bbKst42m5Nhb4OO2cY4BRTiwZOvczIZEeRQsxE2YmB6Eni6qmGycxDwsyAOsBCzaAHky5bR28IqD6MjEEU9cdzagQKCoichxnQOmaO66uroJT8lGax+7Yr8NKaq0FXP3H7WRZADBw7gF7/4Be3TJRUgRACpq6vD+vXraZXI5ZdfPqYbGiLEaNE5dPimtk89JqZQJBrsTPP0M3+FgOfDWzsODukp8+aOg/T2p/7y9BnfthDnPg67bUS+DuR+IUKcb8eev//97yOO6CXRuatXMyZ/Ic7heFxCeObA60l7TNQ4Zr317LZQs7h8upyP7TAWGe+U/EBqNBZYnV5IBNzj+oEMQM8MnCSxGUicNwMNBSxoE1iDPDIC/gCMOhstzfdKHIgUD79tvDhGJPG0nbwg5m5qQtsjj8L8ww8wfvop2h97DAFPjwihSmZEN5cFeUoXrDwWrQQxdtlxWdpldP8d0ZaCm8XMNpMknM+rP0ejqRFqmxDibh8VP7JnMu0zBFId8fJWZhB2+8xkfPqzaXjn9sngyEhbDRualnZ8UPbZqN8HqUw+HdXJJBHG4XVQX5M0ZU9rGnmvnRZaoSBhx0AilsLJ8qJKVzVgUL79LPqC2PYw1WIkGlVUkA8Wn0+ThNwNTJsEEUN2ffYBnDYrVLFxKFpy6aienyQakWU4wuLiaaUEaRdpqyg76fdCxI3hBMfEMDHiVCIqTu47yZQYfd0R2grDIwlS6bnUc0eYkw22Qg6O0wGfTUJ/l7rWHoH6WHNU7bnTweGuZwxcBSkDx2qCVOZvT1MTbZk5ayIIETyIU/uMGTOo2PHee+/RktWnn34aKSkpmD17Nt55552Qk3uIswrJQydGqE4fo+DmhOUMKgc8U/D5fKzfvh8yoQ+tmlq8tHkPvjx4lF6Sv+VCP72d3C9EiGPxeX0j8nXwDjOrEeLC5Hw49pSXl1PfDzKpQjxA+rfUer1eHDlyBC+99BI95yAtMTLZCAZuIc4OZKa2txLkGBFkQEsMY9R4NuDy+Jhy5f10IevnWzuMUYpT8gMJtsIUJihpQsUJ0fXMvKrTkKJIoav1xsEl6Q6rBy6XCwFWADEREXT7RlQJ0nbylSDa116j1R/ciAhqtOqqqYXp22+ZG4nIpUqiq6msDjiELPgDAXR12BAlicLl6cxE7dfcnfAEPGioOYLVWz4gPYSY05pETUpJ6wSpFAny4uZa+P0BmvBx07Qk2s4QrxJj5fyp4EACqZWF1w+/j2r9wMHmcBDPkSvSr6DL8SKFT5bDGiZloyCiYIDp6u46pjphcloUuMsX4uBEOYr1JfQ68t5ISwwRfFoNp24KOlqIwOEsL6frosJCsIVCKoQQHCXMNlbv2Ynmo0eosfHcm+4EhztyAYnL5+Hiu66mC1k/HuSzTRjHvC5JlDkZyHflUI//zoTEHhHEbQN2vgBs+yfY9oFeIUED1dGib6oFKSISeXxQTGQqWEgVhWQKU/0jNzP3cxJz1H7Ig+ao3afJl+ckCFZ68HtEj/6x2kQMIwlZ3i7N2RNBXn75Zdxwww1U+Pjmm2+wfPlysPuVihFIxN2bb745ZhsZIsRoD6IkClfjYH4oEaII+h/esXngZxLimVPdbsKKn/0W4SohpEIWvSR/V7cb6e0hQgyF3+s5oa/D7roW+H3DCyUhLkzO9WMPmUjZsGEDPB4PPbcghutElCFih0AgwIQJE6j/GGmzraysxJw5c87q9oYYBls3nXmnM/AkEeZYEib3VYKcIzGc51s7jEbs7YvH7ZnJJYOtpsNGrH+zDBveLkfDEe1x/SUONAb9QJh4zhOi7xFBwtJ6K2mbLc2D2j6IH4jb74FLYEMKqcI4Abw4xjOEzPD3Vm+MAmdFBRwHiwEuB7H/eBbqe5h0NMNnnyHgdg9oieEZ6xERLaHr2g4b3TfXZ1+PDFUGDBwbSqO1MLlMSC0BLiqPAzotNCp10rIrel+PiALFTQbq7fDLBekDzieTUpMQKZVDYZPC7vbgkU1/htE5OHb3TENSbgh54QOP8SSNhDAtVd2bkki8UAhyIQ8TEpjvximZdZ7C99yn0wEcDgSZjJAqHMdUkDkryqFrbcaerz6hfxctvRxhscN7z5wKcVk5vSkxJ+PXUttthcXphYjPQU6MnLly+/NA8btglX4G2c5naJrW9LQweLiN2NSyCQ3GPt+OkaJpbaUiiNDtQ/rcvranYMSsokfMYpuYSpogsp7jh/kcaodx93h+CFIH/v9BRB1efE/1WPvYtVOOWnasqekpdRwGcgJz6623nuw2hQhxSuzt3IujuqN0XcAR4Jqsa+jl2Yb8LkjZ+Z+ffAoajYaKhccKiCFCHEuYVIzihmbkxUUMaY5KfB2KG1oQJmFO8kKEON+OPSQO9/XXX6eRuKTyg0yykBYZ4gVCzNhDniDnCYaek2x5LDMTfyzR+QBXCDgMTJtFMD0mxLAQkYAmZQBoFzj6tcNE0DaUXV/UoqFUCw6HQwfnXY1mdDeZMXl5yoDButHuxpEeP5CpKeoT73Wfp89MUZ2GKHEUJDwJjYRtMDUgU9VX7WPRk3hcD5xiy4jajjkqFVgiEQIOBzydneAnMMkkI8W8Zi29lM2bRw0UyUyx4f334dVqYd2xE7IF85nvFxmy6GqQljwdlhILnA4vHBYPxHIh/jzjz3j9yOvY4dmKCDMHETYxpIw+gFnX30o9JYJ8VdzaO2sfoxAN2BZVdBz4HDZiPTLwPECLuQt/3PEM/m/B38a8umOkkESYKgPT4pIdlt17fbfFhVqNlZjkMf4fHGagXGesg9lthpwvx6yMcFoxtL1Wi+um9CXKnAmI0BEcBJMqEIIwJwdefwC60qMoe+sV2qISnzMOefMXntZtiU7PpNUmVr2OtowERceRQkQzQkGw6krfAJT3tejztOXoLv8S7+kPwqY4RMXMn637AVdnXY67xt91wmqqIN3tBhoFJwQXqty+zzooHom1egS8AN+hBTwOgCca4Ali1nbTZKNjW9zORiyyz2CgRrf8lMEiOj8hHu76erhbxy69aNRnQW+//TY1Qz0Wct277747VtsVIsRJQfo51zeu7/378rTLES4KmeqFOH+55mc/wzwBH+/vKMaGY3wdyN/k+rkCHm64596zvakhQpwSRJghogfxFLvuuuuwcOHCkAByPkFO8glhQ1SBEDg8IJZJXUDL2fEF8Xm9KNu5mi5k/XyADOxJ5QwpB2/nmCG0Mu0wZBBTvrMdzeV6sDksFC1ORN4cZma85oAGFTsHBhTsrNXRApz0SClilQMH8kNibCaZlYyfizSKCiq5aiZWtkw70CeBiiA+NzVFHYkIQp6rryVmdDO7fpcL1m3b6Lps8SXM83E4kC1h1i0bNhyTEFOH3HgF7D3mqCYNMzNOBvwPFT2El2a/ij/8+UPMW3EL9QBZ9sBvBsTimhwerC9nWgZWFA02fCUGtSKZHHIhH3N4V4Hl52NP22G8WfrWCd8LMWPd37mfLmR9rGi1tMLusdMJwGR58iCjzpxoOZRCDvglNZjSIQHLH0CFjmn7mJ7KiD+VHWZYT9Ks82Rx1zJJjoIsZjBPDGhfaAigyeLCbqsOLU2tkKrDMffmu05q0E5aLIvX7qILWR8OErsbTAY6mZaYYBR1UbAVprbne5k0E4FJd0HPCuDxI/9DlaESUr4IXG8cHB4fvq//Hi+VvDSi6hOfwwyjhUm54UcnDjATJcIgNzyciqP1hilosEyEqaWvkEGiUlGRx+/zwW48fZVLu9p34Xfbf4d/7v8ntESIOQ5E4CDwYmPBFg0+PvESGEHOewotdKcsgpC4xqFmZcjM0l//+tex2q4QIUYNUbG/qP4CfjAHhFlxs5CjHuwYHSLE+cQTTzyJPV4PXlSrkdyhxdub92HVwTJ6Sf4m1+/1evGHPz1xtjc1RIgQFzLBSpChWmGCxAdbYs6OL0gg4Ie1vZIuZP18gLSMEIj3hcGsBc8NcFkccIVhKN3CCAg5cyOQPT0GBRclYPJyZtB7eEMzDJ19htnryjsHmF+O2A8kLI3OzhLGqZnZ5TLdQBGko0tLqw88YjvSlT3JLCeADHZORgRxFBcj4HTSQZ4wr8dst6cqhN5eUgKfxdKXEKNvQGGcDFYeM6juaLMOFmSEQuRftBgzVt6AqJS+CiUyECVxssRUNS1Sivz4odMFVTHMe7khLQbhnhXweP34sOwrbG1h0gmPRwABNJob6ULWx7oVhrT89K8o6GuFCaPCGknXybUpwQqgVwSJlAupWScZgx9pObNtPa6GhgGRqK9tq8f6qm7URsvh5HHgcAfQkXcpBOLRpSL14g9A09BEF7J+IoKpM+1VTIXKSCHfs9I2xoxjQmJP61ntRuYyfSG8WUvxrATocpsQLVTjtxP+AbnlDijsK+ld1jWu6022HA5t+T4SpENNUcPzmaqe/t9rfnYOKiKWoM6zDNXWJfjxww64Hd6+mNxw5lhg1DDHhtMR0fy3vX+jsdPbWrfhse2PUXFuKFw9IsixfiD9K0EI9pbmsyeCNDc3UwPUY0lKSqK3hQhxNiBRYJ9XfQ6bl/kPn8xEzE9gcrJDhDjfWxlW79yNh4062sD4QWQk/hKmppfkb3I9uT1krBsiRIiziqGnEmQ4T4igCNJ2kPbDn2nIiX949ky6nO3y75Hi6eoxLowII2UJdFUWFo6a/Tr4vH4oYiX4wWTBr784glWH25BWFImEnDA6iN33XQNtmWnW2VHaaqJaxuJx0aP0A+kblAT9Jcighpx3BelsZ9p1wqPk4JGKnxHAD/b4j3Jm17ZzJ72UzJgxoN2H+IzQMnqfD7bduwFZDFP67/cgzN0BgZJpi66uHVkKBzFZbbzhRqgfuw9FdQdwVVHccb3llNGMCOI1duO3cy+D0DkLZqcH/9z/b7Rbj//+iGFpfng+Xfqbl46VCJKlyuq9zuX14WCTsdcPBGw2NR1VT5yGAAso1/cN9IPVC8FqhjOdDkI+R+LD8tXBZuS2bAEkPJDmGD87Fqvqnajs7HH7PIlqw9SJ4+kykpbQuGym8qmjpoq2jIyU8nYzXMSoVMxDiloC2PW0LYuSMgefdmxDJZ8HKVh4MnoeLsrIhICIPKZ0LIy7it7t9dLXYXEPHW8fpP7IQRAtV+ryIGlywaDbuxS5MApiAT8LLJYfFoMXh9b3jdWVUUw6krFzYNXYWEDEjpcOv0TXCyMLoRap0WXroqEVwybD9Ahgx6sEKe88iyIIqfggPbvHUlJSArV6BD2GIUKcBn5s/BGtVqZPTMFX4KqMq8b0P5QQIc4mxLyypluHiLt+hjstRjxl1NFL8je5/mybW4YIESLECdthCBHZAF8KuK1AN+NZcCYh5d9p46fRhayfT6aoLpUEImLnwGJBER6DukPdtFLhR7cNG2oMKG424j8bavDk9+XIX5QILp8NbasVtQc1+Hh/c+/gN0I2Qo80HdOa0N+7hVR5yAVy6gsSrAYhXgYWHZPEl5o4cm+Pk6kECfj9sO3f3xuheiySWTPppW3nLjrI760G0dUiIZWp4tC0DKwEGQrTd99B+9LLsHZpIbCbcdmh7zFV37M/hqkEMXa246KcSCyOvxpcTzK6zBb85+ALtEpmKMh5alZYFl3G8py11w9E3ecRcaTVRAfmaimftkSRCGBhdjYyplyMAJuFGkMNPMQHhhrnBkUQ49nxhEhKwif7mpHYdRjxzjYIxSJMcAYwkeOi/hfv7hq9gSiBzeUgc0oeXcj6iVAnJIIvEsHtcEA3igqE/q0wJG0HHSW9gmKFvQOfV32GqHY55u+OwobXvse+z97DlFjGA0XsmolEeSLMLjPePvr2sK/TQnw6/YDM64Msp0/wIhDxs97ApBslGnehSPku9fmpK9bArGPEVFUM0z5n6Bg7s9Eg65vWw+gyIloSjT9O+yN+XvBzej1p97GS4/8wyTDkuLa/UY/PDrRQMYxA2uc0XBY6iMHJGDHqX9z111+PX/3qV9i8eTN8Ph9dNm3ahAceeID28IYIcaYhMWAHug7QdWIWRoxQxbyTLJULEeJcNrd8+hmUt3Xg9Y8/pZfk71AFSIgQIc46JBWmJ/Jx2EoQUn0RV3RWW2LON4LtMFYFn/qBcFlcBAJy+Dx+2AQslLmckAm4uHZSPLgcFk31+OumKuTOYyot9qxpwOZSptydRLuOmN543L72FtJaMTV6am+vP72b1gSX2wU/24ep6T2f7QgIJsSMxujQVVsLv8kMllgEYS4zS98f6UxGBHEUH6TxuVR0I2jKUZDLtPK7jC543cef1SdGrbrX36Dre8fNQXHKREgFXJhee7UveeY4lSCGjnYqUj10cRZi/FfC4+NiV9sh2t5wpiACVbO5eVAlSDAalwhh/StaYiWxVNgilT21xtreCGVintqotUFndZ2R7SatOQRidGv0c7CzpBZJ3SWQi3iYfsllUPqBDLuGbtfeeh3dttMNqRaLTmf2YXs1U10zEoLiUa8fSI8IYo/Kw3MHn0N8ZQA59UrwPBx4nXbU7t+DuJKvwfW5sKvWgF8U/KJXSKg2DB25TIQCY0c3FYUUbA64UYzRaRBikGx3c8D1uxHdfRgKtEDOa6QVYrUHmGNKWFC86xg7nw0CEf1ISidhRcYK8Dl8TImeQsUdl8+FzS2bB97f5YKnlRFieMkp+OePVfjtF0fwypY63P3eAfywrRG1hztROVIB93SJIH/5y18wdepUXHTRRRCJRHRZtGgRFixYEPIECXHG6bB2YHX96t6/l6cuR6yU+VGHCBEiRIjzAxKRy+VycfQok+w1Frz44otITk6GUCik5y379o3MjPOTTz6hg4QrruiLyAwxQj8QcTggGJxiNbQvyJk3RyWVBHariS5k/XzA29MOY5JzaSUIESLsZiEdBJXBQ2fOb5kUjZ/NScXfVoynZfUkCvflhnY4BSx06hxINQQwLyuyL6rzRHicgKm1zxOkH8RvjbC5eTMted9fdZhui0/mRGZYX2LMieAnMuXtJBLVZz1xdQbBcfAgvRQXFoLFHZy8wktKolGaAY+XqRiJ7BFKusowMSsCbg7plgmgqub4bR7Gzz6nYocnMwcfJc7EjxOXQR4bBZ9WB/O6PuP9oSpB7CYjXHY7lGI+fn3RVIjt82BxePHyoXfg9DLVMv0h+43sQ7KcTAzrUAQHzSTNRyVkBuHkuYN+IEHjU3Kd326nCT05KkYsqtAzviAKEQ8ZkVK6fugMVYO4Gxp7W2E2V2qQ0HUYAjaQnDsOmYuXIsBiwd7dDKHs39Cr/o7Ht/0FGiKKjAI/+f2bbXQh6yMhNpPZNx01IxNBHG4fKjrMA6Oou5j/1173d8Nd14n4Bg7kAiUmJ7pwSboeIjEfbIsW2e070aSzg+9LxPxEpqWfJBgN9d0waDTwOt1EE0JYXHyvsEUMdmsNtTi0v4ZWQ0WxOyHgcuA3A0mC7fS5SBWZz+eHMlgJ0tk+psdDYpzcZe+CiCvCgsQF9DqyfUtSltD1Tc2bBtzf3dRE29jYCjk+rrFi7dFOWkGTECZGksGP0i/qseHt92FmiSAKcM6eCEJmHT/99FNUVlbiww8/xFdffYW6ujq89dZboRnJEGcU8p/GZ9WfwdtTGjUxaiLtOwsRIkSIEOcXPB4PiYmJtLp0LCDnKQ8//DCeeOIJFBcX0xjexYsX04jg4WhsbMSjjz6K2bNnj8l2XHimqMNUgRwrgrSXMDGsZxCfz4vSNW/QhayfD3i7me+sTuJnkmHAgdUkpEkntRwvZEIuZqQw4sbEpDD88+p8SARcVHZascZvh88fQKoduKNwcLLJ8P4uJHdTAYiZkvog5DwrThoHh9eBd8vexfbyvfT6qBjVcT0zhoItkVBz0/4D4BNhP8CIIKKJE4e8nbw+8Qqh9yW+IFE9xqmaSoi4ADeMmUkuLunxWTkGr14Py3qmamPzuPlUYJqTG4PwaxjDSsuPTDTvsfCFIkhVYb0tMUED2quzLwfbr0SzsRvvl64a9DhfwIfVDavpQtbH0g+kfzQuGVh3mpzgcdi9rS5k0Gn67nu65CiZaody3fC+II6yMli370DgNCQruXtMUYkIsulwPaIMtfR7POGSS8EWi9Eh89IWkTijiah0qDIdwEObH6JxzSPF7/Vh24ff0oWsj4SgOWpXfS28x6kE6k9Jq5G2iEUrhEycMhEwdLXYyfFjo7EGieWg4lTG9LnIm5CFWLkHCy/Kp5MACbZmhJlbsK68C7fm3krTfcjnSUxFj+XAgcNg+32Qu10IHz+eXkdamu7bdB/dLwcPVVKRSBnuBIfLg8/MRjSvAuD6qDlqV70J8ogI2hZI3pdF35MPPQYEKz2IYEreQ5CZsUylFqk46rYzbX79k2EM4XF4dzfT6vTIxZn4v6XjMM7GAlwtcFiqEAAbXOGUMdvOk25Ay8zMxMqVK7F8+XJqihoixJmElFp9VfMV7TcjkP+QL0lm4tFChAgRIsT5x+9//3s8/vjj0OtHZlw4HM8//zzuvvtu3H777cjNzcUrr7wCsVhMJ2yOBxFgbrzxRjz55JNIPY5DfYhT8AMJQioLhErA6wA6S8/4LiVeCGQ5HyCzs95uZrDQIXRC4ADYXi64PBVsYjacXBbmZUbQwW2QvDgF3rh1Ei4tiEVsmhKyZCmiZEJUbGihPgEjQl/f1wpzjLBBvCtuzLmRrv/Q8APcBha9bkL66L2p+MnJA1ohhsNntcFZyQzwxZMmHfd+kpmMCEIqQQKSOIC0R5Pvmr4BCWnMzHxz7dDVDaavv6ZVJKzMLHxtk/XG4soWzAe4HLhqauHqMXA8FmV0zCB/hV8tyEKWeBEdB7966COUtPUN/IKwe/6NFVV6xg+E+IwE2dXTCkPaXIS8fjPpxK+CzeoVTMhjg1UHfb4gBnqdadUqtD/yKLqeeQYdv//9mFdSuRuZ/eqMjoO1+jBY8CMuNY2m9ZCklHI5YxJ6o2gmol13AZ4oaGwGPL3n6SE9Jsbq96+IjIJYoaCR2prGnhax0UTj2rTQus34r9CHyBYuwn1SKFURyJy9AIEYZuI2wtuIcXMvgljARVrHXmwq74RSEIaVmYz49nbZ24MqieoO7gV8gNLlhiC3kH52j+94HG2WNoTZYyDwiOBk2bGdsxUevxdumwQsVgBCJbMfm8v0tN0n+L0NinenCqlE2dvBCKNzE+YOuI2IP8HUzj0dewYkw5BEnY02Jhr3qonxWDI+BpW7OqAUsOBz7IaNQ+Koc+EWDKxMOxVG/asjJwlvvvkmbrjhBixcuJC2wfRfQoQ4E2xp2YI6E3MwknAl9EDBZQ8ujQwRIkSIEOcH//vf/7Bt2zbExsYiKysLRUVFA5aR4na7cfDgQXqOEoQkAZC/d5PZ4ePw1FNPUfP3O++885TfywXHSJJhgpABSOI0Zr1h8Azn6YTL42PKVQ/Rhayf6xCjSDIoB4eDLqeJRpmyAkKw2ELUcZiZ7CkpAys1CFFyIR66OBMvXD8Bt95RAB6fA02jBVV7O0dnitovGaY/s+Nn4/rs6+l5l9IVgTCRGpHRPaX/p0kEcRw+TKsXSLsL7xj/g/4IMjLAUasRsDvgKC3t1xJzFFOKmMf5dS509STtBCEtOabVTHt1cf48eP2g7UNk4SgUEE+ePCCd5lh6TSb7DSa5HDZevPJmSHlqeANW3P/N+/hwbxP0Nje8Pj80Zg/UgdnobCvAg58cwc1v7sXjX5diazVjensyE4RDVYLsqGXEl5kZjC8KgbQTqVaupEt6OGPMSiYWux3MfcfHKcBhs6Axu9BS3wrdm30CsqPkCKwbeyJfx4CAzwd3E+NjcoStRLShBnwOG3mzZtPB/xulb6Arkg8ZX45skwiLMyZCZrkJAa+CVju8cOiFEe0vLp+HxfdcSxeyPhJIdVFMRvaIfUGKexJ4gq0w3u4qPCfwwQEeUpuE9D0ULloGLp8P9IggaD+MgouXQKlUQOoxQ9xSgr0NOlyRcQUixBHQOXR04jcISaqxNldTU1S12w17vJqKQWRf5Ufk41dxjyFKEg1EOdAU7oPeqYffwohfHC5TadFSaaAVK31+Nm1j1o5ldpupN2MwUrs/M2Jn9MbnBjFX1kBrdaNVFokJiSrcOzcNbqcXzeV6+Ozl4HIccPIl4KYOjAE+VUY9aiQGqO+88w6WLVtGEwlGU/oWIsRYQNTO7W3b6TpRz6/OvBoKwdDZ7ecSRED84bvv8N5//4uwyEjoNRrccv/9WHrppeCcJy71IUKEOP84X449Y+XBodVq6XuOOmagRP4mrbxDsWPHDjrBc5gMtEaIy+WiSxCzmekDJ73mI+03/6nA6qkECahSyA448QNS5oFVvRao3YjA9PvhDwQYj4ILbL+dCHdHJ2lKAVcdBkt3N9REBIES3gBQzfKAy2ajIE4Oq0l/3H0nVvAwYVEC9q9uRPG6JkQkSqGKkQz7uqweU9QAEUGO87zXZV2HFWkr8M2REnjZfsjCBaP+/HgpyfT9OWtqTvhY+4H99L6ioqIT3lc8bRrMq1fDunMnhJNywWo7AHQeReqc5eDx2YDbjzW7mnHTxWm93zvzd9/Db3eAHZ+Ad20qBBDAyolxva9FntO2ew9se/ZAeeMNg15T0RM3qm9vG7B9SqEQv5x0Df594FXYfAfx+vYJeGP78Vs4Wg0OamI6PTUMv1+aAxF/5MfoVksrrB4r+Gw+EmWJdDu6LS5UdFiod8SM1LAh9x2PxUOKIoW2KZRryxEeHw4+h4WcGBlK28xo/vAzRLvdEObkQDx9GvRvvQ3T19+Al58/Jr9ZYo7rd7vBFgiwq9UIscsIkViAxPET8H3d91Sc8SRFQ1Zsoua4C2+LwLcl7YDuMrDiP6EmvcSjZl7CPJwOYjKyUHdgL9qqKlC09PLj3s9od6Oum6lKKYhX0H3zVtVHKOX4Ed8tgxoKyNURSJs8HTq9Hv7IcWCxOIC1E1y3AUVLL0PXu+8gSXMIX+yeiGkpU3B77u149sCz+LLmS8yJm0N9D8uOlIHttIFLfD3AwrNt78HgMiBJloTHpzyOPR830fHRoimz8VrnOnj8GjisfkiJnuouB180ES67B50Nxt5KkGO/tycLqfAgv52iyCK6DcHnrNNY8fnBVlRpJehmubDdXoxPD1TC7eIj5lA5uKTqLT4Jf16WDRYCaKnUw+2wwWU9DImIi0Oqiahnc7DA7zp7IggxDPvss8+wdOnSMduIECFGitahxde1X/f+vTBpIZIVI5h5Ost0dXXhhsWXYJLJhIf4fPDkCuqEvOqhh/HvPz+Jj35cO+iEPUSIECEupGMP8e84G1gsFtx88814/fXXER7eN1N6Iv72t7/R1plj6e7uptUoFwxeF8L1jbT3XeeTIXAC3xWKOANqcMAyNMNQvQceRQpMJhMdkJKqnRAMnppqxidHKoOruwlsPxccQRjcvABsLB8ylQJYjLoT7jt5IhCWIER3ow0b3i3DpCtjIVEdvxJG1VkBjtcLI1S96TRD4TB74HJ6wGKz4PCa4dQwpfYjxR8WRt+fvboaXe3tQ5qdEsh7s+7ZC7/PB2da6gm9fbzZWfB9+y2M23eAM30lFF4vvC2HYNRpoYgRorvJhgP727FgvBQ2i5mmU9i++IJWJBzIngaT04MEpRCZCn/va/mTk3u3tbOiEmz1wAocP18Ar8+L7pbmQds3SVaIcLEAFm43Itnd6NQxj+US80elEBkRImRGiBEm5qG0w4rvy7TYUaPBQx9b8YeLk8Hnjuw3sbdrL3xeH+Ll8TBombaMtZU66n9Dnt9rM0JznFCVBH4CqrxVONhyENl8pvIhTclBSaMbvu1b4YMPgYUXwZWdDd9bb8FRWwtbeTkCOTmn/Jv1lJTQfeuPjERzWQlSAuT7mgS9xYRvqr6h76lw/HL4vngfvrY2hDl1tE1CZ4/ANPFFOGheg1cPv4oUTgo14xxreKpw+tlqmurR1twEnnDo19hRb6T7mnymHqsRq+p3Y1V3Ma3gKuqKAgIsxBVMhFbX95sNkyeDq6uCpWIrFCnzoI6KgKWpA/ribdhVGIV0dToypZmoMFbg6Z1P43f5v8PGtRvB83sQ7nSgWcVCpbkWUp4U96bfC1O3GR31BmoArAjjY5nqetjETwBWD9h2QChogiiJj/ZKFyr3tyIsTkzfW2dj/Ql/VyNhZ/NO+nllCjN7n293own/3d4KL23HY8GtVMPB7cL/7fgBUboEPOhygsXj4t4rCuCyGEAOIyQNxm48DBbLhbDoWHjVGeiyeqGwHz+q+rSLIMQYNT29Ly4rRIgzhdvnxmdVn9F4JQIps5oW01NSew5DDuxkEPKgyYR0gQABNhvk/yAlh4PbBALMMpno7esOHjinZmVDhAhxfnM+HnuMRiO++OILarj+61//GmFhYdTYlAg1cT2RmieCCBnk/RABqD/k7+jo6EH3J69FDFEvvfTS3uuCs1fErK6qqgppaYP7kH/3u99R89X+lSAJCQmIiIiAUjn61oDzlu4qsMj3RyBHRGLWIA+J48FKnQ3Ub4HaWAJ/xlRaWUz23ekUQUhff/VBJpkgc+ICcI4z6D5XMLrdcHE44MVFQWRtAsfHBV8QAadKAI7bg4LkCNrCNZJ9N/8GNTa8VQ5TtwMHv+7C+PlxSCkIB194zD5wW8Fy6cmXH2Hpkxhz1OPQqtfT35oySoyo6NGLqYGICLgUcur3obTZIcgYenzhbmyCzWgEVyhEzOzZYAuFwz/v3LloeuVVGpMrYkXTz5ljbUGkQoSp0xKwprkaYksAR/XAhAglBPv2wWGzgRUZhY95aeAggDvmpCM6KhIelw/aFgtE8jj48/LgrKiAuL4O8py+dhNCmFKJ3Tw+/G4XJHweJMoeTwgAkYjE3KS51NtiVnYn7hp3JZweH6QCNo7ojpAjDgrC02jyz4ICYFGBGb/9qhQ1Ojc+KjXh14syR1R539neCQ6Xg8LYQvq9IJRu6wSHw8VFeXG919F95PMxLUakuqawEBNcE7BZsxlt7rbe+83K4eHw5oNgW83gxUUgduFCsHg8BKZOg33vXgiqqhA5d+4p/2YNBiP9nltjkxGmaaFtOEUzZ6CD1QGjzwiFSIFlk1eiK3YjPF1dUFqsWJAbg68OtUPgnYd4RSk6bB1Yr1uPu8bfddzX8Xq9KN/KmOvmzp1Ij+8jIjKSDsTN3Rp4TQbEJQ7thVl5gPweuJiTHQ0dV4f3G94HK+DFCp0IcPLAlYpRdNEicAXCvt9s8lSwTHVQ2hugiL4Oc1deD81//4MkfQU2HO3EjGum4rey3+KBLQ+g1dmK12teBa++G+E+LyROO2riORDxRfjzzD8jJywH2lYrEGBDLOUiNTseqax4/JD4MlDRhn0eFmb4NXBlhqOrxg5jqxtTFheg+MuP4TDqoZRJwReJT+5DJP/H2rrQ6eoEn8fHRZkXQcqXorrLgpd3VyHA4mBmehguyYvGD80zsVPzHcJEHbjEE4UwCR/K3CwkZDD7lbTpGNsa4bZWQijlYeryK8HxReHlrfVw+E5dqAky6m/tI488gv/85z9jFuUUIsRIIN+3VXWrensVI0WRuCztsvOiHYuUoU/qGYQMBbl+osmINT29qCFChAhxIR57jhw5Qk3Xn332WfzrX/+iggiBpNARwWE0kzUTJ07Exn4960TUIH9Pnz590P2zs7NRWlpKW2GCy2WXXYb58+fTdSJsDIVAIIBcLh+wEMiA4IJajI201J4VlkqTBkb6OFbaRfRx7Nr1YLNY9P/zAffpLAF72z/APvwB2D73mGwrOWWwtpbRhayf9X13gsXXpaH7yBEmhtgMcPw88AThaGH76PW5MfKe93XMvhtiEUn4uPj2cYhIkNGBffHaZnzz3GFs/bgadcXd8HmZShK2oefzFIeDLVYN+5yGDgd9bXWc9KTeHxFQBJlZ9PXcNTXHvZ9j3156H3FhAbhi8Ymfl8+HZMoU+hh7cSVYigSwAj6wOw4jZZyaJuqonMAH2xphd3pg+eoret+dWTNg8QSQGi7BvKwotNeY8O2/D2PLh9VY88pRVIUvoAkVjn37Br0mXyjsay1obRl0OzHvZ4FF27k5XD/CpEKwOWw0mBvoQqppgvcdF6fEny8dR31L15V1YVVJx4j2J/FjIK9B/EDI3zqbB4dbjPS9zcmMHHh/Fgue+ga6kPXc8Fz62HpTPU1dDG5HpqaOJgwFJkwCRyCg10unTaXv01tWNibfc09zM93GGq4cCruGmrcmjy/E+qb1dJvmJ8yHkCekfi/kfp76OszNiqTr+xvMuHv8PfR+JGWnydJ0/NcCC521jXTx640wfvABjB9+hIDNdsJtDKbEdNZWDXl7ACzsb9TTbUqLdVOPDo/fjSnuABLbxQCHj/TJ0yCUSAf+ZuOKmN9bRwn9O2l8IRIzMsAOeNG5ZyMqOi2Ikkbhj9P/CCFHiLpDh+DztMEDD3huJ7qjxXh00qMYFz6OPl7fZmMElkQZFcTIbyy3aBG9zmkBjFwjjDwneAIOHBYPXHYepGFqGgala2k+pc9xv2Y//Rxy1bmQC+V0n/xrXTW8vgBmpKnxzJXj6ed2W9FFUIn5EMtbsDLSA6mAC1FaWu/zmLocsOprEAg4IVMrkVxQRI1Syfeilc9EN58VEYT0zZJoXDIrQmZNVqxYMWAJEeJ0sLtjd290F4lbuibrGvA5576pGeHdF17AFSdQm6/gcPHOf/5zxrYpRIgQP33Ot2MPqaq47bbbUFNTA2G/mV7SfksMU0f7XKS95d1330VFRQV+/vOfw2az0bQYwi233NIrrJDXIh5n/RdSySGTyeg6EVVCjCAZRj1K1/6UOUxyh7EZaOlLCqBUrQG+vBso/RzY+R/gx8eZqMlThKQhhGVMoQtZP9fxtDMmm1opC0I7C+wAGxyBGkddTFJEVjSTYDJSyKzqxXeOw+RlyVBEiODz+tFebcS+7xroYL+t2jAwGeYE6NoZ/wN13PAeI8NuUw4zuHSWlR33PsSLI+jLMVKkc+fQS+uWLQjE9qTJtO6DVCVEUpoSPA4LPI0b377xLZwdXdCxBPiQn0bFsYcXZULbbMG2T6rhdvoglDDH0Q6bAo2KSXAcLoHfOTCtgxCRyLRna1sGG73mhedRk0tiXnmwk6lGIGakZMBIFrLen0nJYdQgkvDK1jo6o07wuF1oPlqCfau+wKa3X8X3//kHvvr7n/HpXx6HZE0D0osD4FbqYNZ2Y+3RDvqzyY9XIEbOp8ae2z56B589+Tt89MRvsKu+HCaVnJoVR4mjoBQoaVRvnZHxhCGDzvGmVrreHN33+yaVIwRfbR38joEGs6cSj1tlJbWKAShi4uCTcHtTRhYlL6KXgnRmG1y1dRgXq4BKwofV6QWcqdRwkxjDvnz4ZXo5FFRkyM9BQloiOn7zaxg++hiGDz9E2wMPwG+3D7uNsVk5w5qjVnSYYXF6IRLZ8WHdv6g3S4Y0AfcZWWgxCokjKXJmzaMmwOY1a+HXdMOsc8DIzWYObfo6wGGkYsW8lddBwucixlCN/32+hVYNker3p6Y9jfg6IRVN1DYr+GDhykUPYkYcYzZK6G5mvifhCX3HhsjcImpUGmlgYZWcDW17DWLTmWrF1koDIlOY/UrafU6FfR376OWUaCbGdnVpB+q7bVR0/M1iIswxE9eZqkzI+DLYPDZoKg7R6/ipfcliXY1mOM1l4HDZyJo+h4rrMiEPi3KjoJWNvGV1zEUQcmJw5ZVXYu7cubTkVKFQDFhChBhrSAb4hqYNvX9fmX4l1CL1ebOjrSYTLT8fDhWXC2vPrGeIECFCXIjHnv379+Oee+4ZdD1pg+nsHGGqRQ/XXnstrSb505/+hMLCQlrRsXZtn/9Jc3MzOjo6xmzbL2iCg2ZiijoaBFIg9zK6ytr/OsmDZa6v3QCsJ/4wASbZgxgHNmwF6pg2llOBnExnFM6mC1k/1/H0fEfbAzawfVywuBKIohRwBgKQCrmIU47e/4AMRDKnRGPZfflY+vPxKFyYAKlKAKfNg60fVaGptKfcXJ16wgpdfTtjMKGOPfnZWVH+eHrpOHJkyCpzr04HVxUT+yoZopLreJAYXY5SCZ/RCJuhpz2tZT+9SCuMoCX4ydYAkneuQ4fJgVXxk+Hh8vGLeelIFAqw7eMqGimckBuGKx4pwpzrMqlnSZuiEBbI4Dx6dNBrqhOYcn5tC5PA0R8yuJ0ZO5Ou95r7s9h0cEuWY0UQwtUT4zEznfhRBPCX78tRvmc3Pv/L77HhjZdwdPN6NJYUQ9NQB2NnB/SadkiMQEQnB0e/+x5fPP0HVL//b2S1bMOEju345InfYu1L/4fafbthNejhstnQ1dWBTT98jbJtm+j2BWN1gwkzJDEnxsB8Bw+KmSoXAi8mhkno8fvhLGcmKE8WIiaR7zkxR9Zb9OAEfBivtmDnml/B5zIjTZlGTVsJgh47BmKOSlpmZqUzA+Jt1d20DYZMklboK7CpeehjBZvLQc7MQoQf3Aa/RgO2Qg62VApPewf077037HbGpGfRfWTq6oRVz0QO92dPvQ5+lhku1YfQOrqpgekTiZehUStGgMOjj+fVN6LlF/eh+7//xZFnvsJ3/9qP1W81YbfpevgDLKCDaU8iscAFs2aBwwJUpWvxxGd70aC14buPdkNqkUICKQp1VkSyBcidyAhEQWg7DBHk+okggtRUmkoTqQfK+UBj5y7E5zC+NMSANDKZ+a1rGk5eBCGCRqmWiTyfGjMVbq8fH+5hfge3TE+GQtyXxkPavohxKsFSw3zXBP1aTpuP1sHjbAeXz0XW9Fm91185IQ7d8giMFaNuhnz77bfH7MVDhDgRJpcJX1Z/SZ2GCbPjZg/IPj8fkCoUMJotww5GDF4vpBdSD3mIECFOO+fbsYe0lwQTVvpTXV1Ne6dHyy9/+Uu6DMWWLVuGfSxJwQsxQsgM5jBxqsMy4RagbBXQWQrJ4TeA6HRg57+JYQGQcymw4E/AnpeAg28zVSHpF10wH0vA44G3m2kB1rhMjCkqPwxOGQdwAtnRMjooO9n2dPJYVbSELtnTY2g1SP3hbuw6EAFFdDiUYcNX9lh0TrjsXrA5LOoJcrIIsrOpKaJPp4OnrR38+IHePySNJXg/btjgOODjQQQL2aJFMH72GUy7aiBNZTHfVZuOeqEc3tCMJJsNQl4YLAE/6gtm4TfzsrAgLRw/vnGUVoCExUow48o0cDhsJOSEISkvHHVGI5plExB34AAVWoasBGlupJ/LsS3bJFr4m9pvsL9zP60IEXKH9zYhj//NJVm4+z0L2NV7sXpPMdQSASQqFeJz8mgsr1gmB18swcaWTdhV8wPGc1IQ7UpAU1UVuDYdYll6eBuF8LFY1O8hZcIkpBROBF8kQsWOLajZuwv7vvmcepiQNhpSfREUQYjQI+Sy0ChVY5+JPeA9CXJz4Wxvh6uyEtKe+OCTwdPSQqu87EIxwuytiIAe6Y46/K/bSfq/MNPRlwbC7xkoe0iajMOBOZkR+K6kHdtrtTQSmsQ2v1P2Dt4++jYmR08eMjnSVVMD69ZttPol9q9/pSJZx+//APMPa6C64QZwetoaj0UgFtOKia76WjSVHsa4uQOPRVvr6mGWvw8lx4oIcQyemvEUJKXfokorBNh8ZE2ciu7n/k2Fo25RKjokuWDp9WBFR6PBnANlYBJyWw8AqUzCzZyV16OttgbNze1wbnoPz+2JRISZqZiZliCHuCIAboQKHGmfAGkzuWA3u2k1U//qLF5cHHhCMRRWHpQWD8rFexCb/kd6P5PGAbGS+c11N9Uj4PeDdRIeL8VdxbQCJ04aRwWgVYfbaDIRERuXF/QJaEEmRU/C3tpN8HVrAXEk+CmM0EWEx9ay3XQ/JcRIIOF6ex+THC5BdPYoKw6H4aScbIixzIYNG/Dqq69SV3VCe3s7rFZGfQoRYizw+r34vPpz2LzMTEO6Mv20xV+dTm791a/wjbfvRzwU3/i8uO2BB87YNoUIEeKnz/l27CE+HE899RQ8Hg/9m5xsk4qN3/72t7jqqqvO9uaFGAqvG+gplx91OwxBFgXMepCuiiq/BGvHc4wAkrUEWPBHOlBBHvnsWUDrfsDMtIecCm6Xky7nOp4uDR0IsIRCGI0GcPwccPhqdLKZipns6KEHaycDKTufenkqYtMV8Hu92KO5BH7V8KIWKVknhCdI6eNPFhKLKswdR9eJ2eax2HbuopeSUbTCBFFcdinA4cBZUQ2HK565snUfNYNNz5ODbbXAGDMbk+6/Gx/+Yg4uzo7E9s+qYdY6IZbzMe+GLHD7RdTmzYuj26sTJUF/cHAFBBElSIWRy26HRccIWP3JUGbQthNi8H+g6wC9zuPz0OV4kDaAe9N9SO3cD7vbB27uDKz8wzOYec1NyJ09H8mFExGbmY16cTeMUSxkL1iApb98BA3T70RZ4gJIixZg8mUrsPjeB3DD0//CzGtupPcPT0jCzBXXYdzs+fR1tn/0DhK8TJV1UAQhxqkCLhtN0anQWl1oM/a1vgiymAnJYJXOyeLqaYVpkUqh9ukh4XkhTkxBiYSpZJhavxeoXkfXuSoVOOHEvyIAV309ChOUkIl4sDg8KGk14vL0y5EoT4TZbcYLxS8MKRB2f/4VvGBDOncurT4gkcv89DQE3G5Y1jGvczyINwWh6QjTwhFkT3MVyjwvwc/RI0Eejb/P/juiJFFoKCmB08uGRC6DorEFfqsV3KRkdE6/lX4vE4wHkBfVDXCFOKqfDlfTkb79KxZjxQMPIykpDrKAgwogJBI7Z/YCjPdqmfukDDRo1bYw43AibPb/3hLjan5yMmR8CaL1QDuvGyW6ekSlMMcQq1EELo8Ht8MBo2Z0VZdB9nX2tMLETGGqQPY2079vmJoIAXfwRExRVBEitF54/R4EwvvEHH1jG2y6o9TDp4CzD/j0JsDQ1162aFoGxopRH7Wampowfvx4XH755bjvvvtoFByBGJk9+uijY7ZhIUKsaViDNmsb3REqgYq2wQxVLnius/TSS3FAoUCta+hsa3L9QaUSS5YtO+PbFiJEiJ8u59ux57nnnqOTKSSZwOFw0LZbkkZHvDmeeeaZs715IYbC2MS0sQhkgPgk21THX43AvN/BJ4sDFAnAzAeBhU+R3hXmdnkMEMt4EKCJGRCfLF6PG4e+fZEuZP1cxtPe1tt64NVYwQqwqSlqdU/88mj9QEbSJjN1cTh4cEDnjEF1/fAii6aJmQSNTDx1MUYyg2lzse3aNUgIchxiBpzSObNH/bzc8HDIlyyh69r9Tvi9AaBxB01GidjzEfheK5wiNY6a0tBaocfGdyvQWW8Gh8fG3OuzIJIN9ANSRooRnammho+tRikjVPWDpNCo4xgjZW3z0C0xs+KY8v7trdvpZN83dd/QhawPhdNqRduGL6EQ8dCqzsN71mTsre6C8csv0f6HP6Dr2X/AWVWNKj0jRmSpsnCo2YAD7Q7oVam4/tbrkH/RJYjLzh3QAhbwemH6ZhXSPUB0Wga8bjdav9sKToAFvVMPrUNLvU9I3Yc/O48+pqTF1Pt4YU86DhFBTiUsw93E7CeLXwcOfIgJF+LQjLvgFakQI4tHAnnq7f8CXJYBLTHu3pYYdW9LDJfNxSOTHqGXZFBOjFL749LqsbukHkdksZD2pIGRzyT4HbGcoEKQmJYSOutrYTcz++JI9xH8Yddj8LNNUPEj8c+5zyJSHEn3SVk5IxBnT5wA6+of6Lp91lWwW30QqCRIsByBYtfnUETJ4fELUN9AUmT69rE8PBI3PP4ErrjzDiy9+krc9thjuOau2+FuZsRgQc/nMtgPZHB7GvHc4HFFmNgVABdefFj+GeKzmcqq9mozwpOYSgzSXjVafH4fDnQe6PUDWXO0A1qLC+FSAZblD64Coe+NL0eBjXl9fb9KsqOfvIhAwAMhn4+4WBVg1wLr/gD4ffT2SUl9qUunyqhHlA888AAmTZoEg8EAkaivF5H4hPR3Yg8R4lQ4pDmEYk0xXeeyuNQIlZj6nI8QZ+aPflyLfysUeNvlpOXnBHJJ/v63UoGP1q49ZyIqQ4QI8dPgfDv2EF+x9evX47vvvsMLL7xAW1l++OEHbN26FRLJyRsvhjiNdPeYBIZnjjgad0jGrYBh+VsI3PQVUHQzUwHSn6Qe47+mnbhQ8Pb4gbCjo8E1MJUCiug4NJoZA8eU8LH/TYid9SgM3wqweTiyrZv6hAwFKVnvrGMGa8HZ5FN63R6vD+Iv4enn/2P5cS2d9RfmjwcvNvaknjvs5puo94Nb70bXDg8cuzeik1ScHdqPHMsOcNVKdDVZsP2zGjqIJAIIqQAhrTBDkT41Dmw+HxpxGuwHmIFff8J7WmK6m3oMg4+BtMQQ9nfth91jp++PqzPDq9cPef/iNatoZUliShJSFyyDytSNjl/dj9aXXoXjwEFYN29G04P3I6q8iw7+4yRJ+PeGGvrY5fkxiFYM33JDJhfn3XQHBBIJTB0dyGthBplVjQepiSchcjJTAXG4xUAvXXYbWg3daBZx0eGwwlY/+oFzEPIaPq8LTtLjBSB+0W3YS2KDAyxMklyPdtYM+G16oOQTersgLegLwrzmnAymVXJ7jZZGq6YqUnHruFvpda8deQ3bWvtMta07dtLqKrZM1iumEKQzZ9Jjjru2rteHZyhIigqpoCGfWWPpIXxW9Rn+uPOPMDot4Hrj8cD4J6kAQuisqYTe5ASXHUBSfDa8Wi3YYjE6/IwokDAtFjyZGH69DskxXpoeU2suRKCVMc0NwhMKkTNzLiZfugJxxJzVqoFLw1TIC/IHVkdpWy2D/ECCCFLTAA4P47UkIyeAw93bIE5ixCvyvVfHMZVfbZWj93ghlUPECFbKkyJZmon3djPC1vVTE4asAgmSY2R+Y7UqZqImYGhCfS3znYvPmwHWte8yArumAij/hl5PhK+z5gmyfft27Nq1a5BbenJyMtraGNU6RIhTod3ajtX1fert8rTliJZEn9c7lZjxrTt4gEZR/vuFFxAmFECfmEDL1f+2bNk5MwgJESLET4vz6djjdDppUsusWbPoEuI8QNMjgkScZq+uxBnA7heZlhgyI3iSyS5cHh+TVzDtN+e6MWpwMKaTcMD1sAEWD8rEeHjbNBDwOIiWDz+4PSm0VUiXl6DWuxAGlw9Ht7Zh0lJmUN8ffYeNCiRcPhsRSadekcKLjIRoYhEcB4thWvUtwu/5GTXlJOsExaWMge7JwFEoEPXYY+j8459gb++Gvc0MSLaCJZYh/ZHbIZXHob3UAYvehbAYCcbPi4cs7Pj7Ni5TCY5IAIdbge69ZVAsWzrg9siUVOq10VnHCBHHQgbpMZIYdNg6ULbqXUz+fj+8mm604QvwkhKhvPpqyObPp54mNqMB1XsY4W/6VdfhYr0Zh3e8TfdNg1AGziWXI9/SCtuuLVj+gxFbMnLwj7W1aNHbaXLKnbOOb1ZMnl+58mpmnc3GjKtvwOZ3X0dYlQsSeQAd+7eBnHmTNoq83ATgqB4lzUYc2bgWh9d+D6/HA7eED3g8qPjHU0iZPpNWnFCRYBS4Gxph9FrgZqng5YqRMns5Dqy7E7nlC8B1JGGLPw7RgXjMK/4UnMIb+yXE1NLLoiQVJAIuDDY3ytrNGB+vwOVpl6PZ3Ewjdp878Bx0Dh0uTbsUzm2bUWhphfqau8DmcdBp66ThC2RRRwOyWg2+eeNuVEyNpkk5yfJk6kNI0kzipfHU0DNm3Di0NFTi8zUv48BEO9w+P9iOXCicl2Fhdl8LWdm6VfQyPdwHbxkjiPGmzEBnI9OyEpOtgHT+PJi//Q6q2m3gCMbBbFfBUFGGsPQFx91fvvp98JgDVDThZ+f2Xu/1+HqNivsnwwQRpDHbJrYKkelyoJjjwLruH5CYPA2aRgt8PeJMW1U5/D7fqI6PwVaYSVET8ck3GxF/dBvGBeyQKDLRIV2ImIyh/3+I7HKB1FIVS7RY6fNAv+lNWF0+sNhCZC9YBkjCgSn3MJVAB94Gci7HWDJqEcTv98PnY0pS+tPa2kpLVkOEOBWIKk6UVRLRRZgcNRkFEQU/iZ1KBhvLL7sMS5cvh0ajoSXfJK4rRIgQIULHHiZ9bsqUKbQNZv78+Zg+ffqAitMQ5yDdFcwlSXE5nYRnADwR4HEw/eEn4z/Sw7kufgQhiRWELjipKSqLFwaPgg+0AclqcW/c5JjSXQU2K4CiSV5s3A9U7+tE5tQoyNUDf4ckVpMQk66kpqFjgeLyy6kIYv7+e8guXgjjF1/Cb7NRYUAysy8C9GQQT5iA2H/9E/q/Pwp3YwP4CWKE/e458DPSIdNoMPvahBGfjxE/keg0JVqKLWitsyLN66WCQpCYDKZNRNfWQis4iLfDoJSYuJnofOsNcA5+AJ8wDGwel1bXeJqa0f3c8zB+8inCbrsN5fpOOiCNSkiAcN1X0Hy7BTE8NppSM/HauMthY0kRFZuLq8P3IKzFj4TPW/DJBC2dLX/i0lzqJzIc/Q0wiWEqSZsp27MRqQfdcDrWADY2RKmTkRsjB4/lQ0TFj9hT0U69KZQxseD6WTC1tsDpcqHxcDFdUosmYdLyFbRq4kT4zGb4OlvQxechwGbBnzYF1eZaSJqjEW5IBJ+ILBw+Os0ZONLRhQlHvwQ/bTF9rLu5GX6XCzyBADPS1Fhf3oVtNd1UBCH7+L7C++hYgiTFvHX0Lazf9wluPdgAFpuFtwWbUPv9p3B4+zxOJkdbMa/ag7CabnTlsdBl66ItRj82/khvJ1U2Iq4IbpMF+a4A2J2AwilEnOJK7LPFYmp6OKQCbm8VUHMFE/k8LicKpu1MKpEleTICFQEaTy0N40N60UIqgrj27ET04kK0VQMtFQaEMZ06Q+Lav5Ve8iLDqEdKECKAkK4kkZQHiXJwrDsRs2i1npuDS3R+HBK4sabhRzxdcAkVQboauRBKpbT9qqO2mqk6GQGk7Wd3+26wfQGo99rQvP9jhCEAtYSP1rIjdMm/aDEmLr9ygFEwMbblderBZnHQEsFCqeYw9LsOwBdQQChNR0w6U1GDcVcCB94CLB1AwxYgfKAZ8akw6iPXokWL8O9//7v3b/KGSA/vE088gaVLB6qhJ2Lbtm249NJLERsbS5/nm2+YUpf+O5bE28XExNAToYULF6KmZmhlNcT5D3EV/qL6C5jcTIllgiyhNxs8RIgQIUL8tCGG65dccgn27t1LTVJVKhWtCPn9739P22RCnGOQiozu6r52mNMJqfwICi1dg6NJf4p42pm+/y6HFWw/B2xBOLQ9Y+3T0QpD6WZ8JaLzUqhJKhlUHd7QMuAupOWApMgQEntiNscC8eTJEE+eRFNxWn9xH6ybNtFBW8Qv7z+ptIpjEWZnI/aZJ5F8lRCxM+wQpo8y0rkfyVOS6DZp2TGDImLFcgUUUdG0ZaKjdmjT0Onlfkzfa6IJMdJrVyL5iy+Q/OmnCLvjdtq642lrQ+szz6D0kw/g7e5E1PpvoH/vfcDYAnleBOa//V/88spJUEv56LJ68OYEAXwBIKO2G0kuPf62Yjzy40eZ+uX3Y3qsFnKfHiIbCw6dFF6PHSLdt/Bufh6zWtch0lQPlw+Ycc2NuPzRP2DCgksw3e7HTJEKqROn0M+rvvgAvn72KdTs331CrxB3TQX8DgM0EjFsbAlSp83Dnra9SGqeQJNzJi9NxpzrswChAhXGKbDsWQWuSgEOSQny+WgyDYGkxAR9QYKvSao2Hix6EPdNuI+mxMSXdMDlc6IyNoBSXzMVQIiwQeJ3FyQuwKSLb4RapMY0Qxj+MeNv+O2U32JFxgqMCx9Ht4V4tljcFrhEgCtGCBlfhtsDS1HdmAwWWFiSx1RSkNff/91XgM+NDLUTYmkc81vmcNDdYzwbn8OIF8SQlZ+URL/zEXzSEsJCiyYMMB2/s8JZysToCnNzjuMHwqRGHQtpxSH+QmwuH7ndQJQXMDmtqBQfAF/Igd3sRVgc85z1xfuO+WoEUL6lHmv+ugqb/vo+unf2/X/cZG5Cl6kdOftY6DpUT7M8nWlTcMX9DyF75hx6nyMbf8T+b78c8H1w1dXT3wg7TAm7hIOdBz5GQzf5nbMQljCNGhNTeEJGCCEc/Yr+ZsYK9skYl+3cuRO5JBrJ6cQNN9zQ2wpDzFFHg81mQ0FBAV588cUhb//HP/5B+4JfeeUVelJEeoIXL15MXzfETw+i1jb0xD+RvrKrM6+mB6gQIUKECPHThwgejz/+ONatWwej0YjNmzdTY1RyLkDEkRDnGGTATGZSSc+26uQHlCMmikkQQRczw3oykFn1ygMb6ULWz1WIcae3i/HGMBiYwQ1HFo4mB3P+m6w+DSIIqbIhRreEiGxMWJREJ45byvXo6PH/ILRXG2gMJxk4kdjYsYIM3CIefrh3cMfi8xHx0IMQjR9o/nhKxBQC4nDGZLNx+8k9h02LePsqkNNTC0+N7i0DB4yEuCxGsGsp60v7CELMVLkfrqKD9O0z5Fg3lYdScyVYEhFU11yDpLfeolGtrWIeNe8Vm81QGu1gC7mImMZDROJRsA+/g8XjovH+nVNx38JomOJcqEwVQikS4SlBIyYln/hzIVGoJP2FLMQkFZufgbDqSyxOtYDL4sDNFmFvVCwOe+RY9el6qE018LL5sExegewZc+jnxemJrBW0tGLOtTfj8kd+j8jkVHhcTmz/8B3s+QQ5aV0AAL8vSURBVPIT+HsMLYfCveEtaPk8uLkcGLhqTJ86ARVHmsB3CyGTiZAxOYp+x2JyYhBg8VDRkQ5W9RqICpgKcbLthIlJKgh5HBrJWtnJ/F4IZBsvSb4Eby1+C5d3xEAuVEE8/lLciZvwwtz/4PNLP8cLC17AQxMfwpK5d0EcFgm+B0juZgxsb8+7nSa9fLLsE7yx6A28eNGLeOeSd/DLW56hxp6Vu/fCaTTQGNhpqYzA0VJWis7aanACXkyIscGuYSrPeNnj0N7ItKsk9BiSku2TLmSidiU1u8Hi8WFyh8NcehzvI4cBjnqmQkw4eWBapqZHBIlIPH5XhiAjA+AIwDGzsczqhNvrw7dNq5CUz2y725PQm37jcTM+HT6fH9s/LMWhVYeg73SgvYOH9R90ov3Vf9Dv0I6mbcg4AEh1XFj9XJSlLcHPfnEHjXCesfJGTF95A32eo5vX48iGtb3b4qplihrkPeauDftL4Q1wwRfFIzrjmBY8KoKQg9Fe7K/ve44zLoLEx8ejpKSEnqg89NBDmDBhAv7+97/j0KFDtLx/NCxZsgRPP/00NVU9FqIWkYqTP/zhDzSJJj8/H++99x6N4j22YiTE+U+FrgI725kfPRtsKoCQA0yIECFChLhwqK6uxmuvvYZbbrmFxuISk9Tly5fj+eefP9ubFuJY2ntiImMKBhuZnk4RpPPkK0HIgMzUcJguww3Ozjbe7m4EPF74eBy4jYyHgDQxAg26HlPUiNMggmhrmKQfkvIjCYcySkwHoYQ939TBYXXD5/Xj8EamMiRtYiQ1ER1LSHl/7HPPIfGtN5H00UeQL1o09hVF2T1pWOWM38ioIBHNH18H4ZHXEMGto3HOzQca6WBwqBSR5qMlA75nZGyjfeklBJwu+DJTsHuqHFtbt6LaUE2roekmSiSQXXcNujJTwBEB+VF2xNw8F0lr90F+xx+YWf79rwP1W+nAPzpCRwfh+vnZkAv58OzaAf9IJov9fpoq4yQRt1v/wRhPstiIuvJPiMlOADvgh0UkRJUzAS4fGzF8ExKTODjkkPfO6LPCw8FRKgGvj6a1qOMTsPRXj6JoyWW0KoR4o2x66xXqHzKItoNwHd6FdrEETo4Inrhs2AJacJvC6GNzJyWA3dNqNW5OAiCQo848Ho69n0FUkE+vt/eIIGQ/BEUIUg0y6K3WNkDYbYZYooJEmgJhpx8J0oQBE62kskdcyHxuwUSiIESwIpG3JH6XVItEp2UiOj0TVrsLGe27sCQvirYgkcSYnZ++Tx+TG+OFVOCHs5URPuzpk+Dz+GmFgyqmr0VKOmcuvfQdLUEkU9CC1uL6IT+yQP1uuHR+anAqnDS973p/ANoeESRyGI8eAUn04fDgM3Exx+4B28NCt70b1tQ22iZk1srBFylpVG7d/j1UANnxaQ1aDzeA7XdivHIfJIZ2uBxc7NzCQ8tvH8LRj76DpNsPV0CIIymX4N5rFgyoVCOmrlOvvIauH1z9DeqLmdYg8n0hROdNQaRXAUUbG+4AF2JFIcLjj0m3IQlhyTPp6o6qLzFWnNTRi8vl4qabbqKzMy+99BLuuuuuMe/bbWhoQGdnJ22B6e8cP3XqVOzevXtMXyvE2YXEcH1T2ydsXZx8MZLkozNWChEiRIgQ5zdxcXGYNm0a1q5dSy/XrFkDrVaLr7/+mibThTjHaGcS3BA74cy8XlRPRYCulqlaOAnYbA4UKYV0IevnKu6mZnrpiIoETU5lixCeGoE2o+P0VYJoB7c2FV6cCFmYgFZ+rHujDOvfKoNJ46BVIHmz48Z+G3pmx0kSDEd6mlp+ci/rSxqyDR4wHxcy8F//BJ2NhzQaCdGdNGVD55L2tmUEiUpLp14gLpsN7dV9t9l27oJ9716Ay0Hkr35FB/vEnDNVnkpTWoLU7t0Fl0kDuciDvBlqSO5+DmyhEMhfCeRfy9xp/Z8AYzPKdExlVMSE6eBGRSFgd8C2awTjJDYbwqxMCD1HgbIvmJn2i58CspdinE2ITF03OOFsjFt0BeZdsQzLs424hL0D8w1foM1g7/2sBFmM6SURVJin5aBw8TIsuPVucHg8NB89gg1vvNhbWUBxGIENf4bOwEa3iIggAsQXTceelr1QGWMh4AiQOaEvDSgyWYbw1Ej4wUNlUxREYczvwFVdQ31jCHMyw+kl8QU5tg2HtlYBkE2dhoS8bMTnZAzygHE7vWiQTcShiMuwZ68bujZGfBwK8r4TFlwOhzcAtaUFcXVb0HTkMNa8+DwcFjOUkZGYENZOt8PR0EUfYxIxVRYxaYxnSRBeVCSEeXn0+6XmM/HXrW08wMI8rj+uPauJ7ga2QgleXN/vz6ixw+30UaNiVczxfzfCHKbKymsRgucH0swq+AMB/KBZhczJUXS7fP5M+H1+HNm4Dls/qkBraQvYXivmRH8LRU0rcvTbwGV5YeFHYnN1E1TNFnjZQG3GMjx83TwsyGaE0/6Mm3sRXQjbP3qHmga7ahgRRJiegYJKAdh+wMeLAFeSNFgEIeRdBT0rgCMWJj1mLBh1rwGpxhgOMnszFhABJOhs3x/yd/C2oXC5XHQJYjabew1dyTIWkOchX+yxer4LGZfPhU8qP6GXhDx1HiZHTv5J79vQ9ydE6PsT4qd07Bmr54uIiEBlZSX9P54sXV1dcDgcEB9jLBjiHMDrpqXJlLixM6obFmkU08pg1zKtOLHMrO1oTVGzJzEn4+cy7mamLcUsl4HV5UBAoIIkKgz+im5IhVyESwcbH46VH0j/pB8en4N5N2Zj47sVsBpcdCEzxjNXZoAvOk/blVXJTPVSRwlQuRpIGKGfYcM2RvjjioAVryG+TYuD/1cOozAOxjXfIjq3zxyYCAHEI6Ni+xZU796B+OxxdLCufeVlZhNWroRq/FxEtL9LJwK9AW+vCELatEo3/UhbdsbH2cGe/BDAF1PPB+LFYtIsAUsXBpW/Csmf/g1H03qqJSLzILtIBsNHH8GycQNkC+YP+3bIgFfk3g8YfmAMM+f/DshaQv+PUNV1w+H3ozzdiVuWLYOYJwaORIP//ZO41LMWzrVsYOUz9HkEWZlw7N07SAhKLpwIgVSK9a/9D+1VFVj/6n9x8d2/BM9vB777Ffy6NlRwlPCBDa08CXPGZ2LtgW2Q+dMhDRNAESkasK25cxOxra4DNaZC5NWvpkIZ8dpwlJZCMm0apqaoweey0WF0olZjRUYUUxFBWn2sWxgzUcXFFyFm8uDjlcvuwYZ3KmDoEMPDj4DFAax/4yjm3ZKD6BTFkPtvVb0bVfGzUNS1E+2H99GFIFYosPCqpeCu+wEetww+o5mKXlobSRxyIjpt8PNJ582D8+hRSOsPAPyZ0Dpi4SpZDcGsO/ru5HHAUcwcc0X5hQOEFE1Tnx/IcIbJgtRU2mYGFxdsB7DEYsNrPjY1gBVOt0NeJ4JJkwlT137YjC0wabdCylFjbsxX4DvUcBpaIIqOgnt8JByH1sIn4EHqtKN1Wjxev+e6XmPYoZh8+VWwGnRULFr38r+R1t4CUvhypK4C/FYzrULyiotIZjNNaRpE0kxslUjhJ8f/MWLUR7BjZ2M8Hg/sdjuNzCUnKmMlgpwsf/vb3/Dkk08Our67u3vMvETICZ/JZKIHilC6x8lD9t/3rd+j1dxK/1YL1Jgim0I/q58yoe9PiND3J8RP6dhjsfT1YJ8Khw8fpl4gxDR969attO22vLwchYWFNC3mmWeYk+4Q5wBtB5hqDCJKnO5kmCDkpJ+0xDRsZcxRT0IEOV/wNDMtJx20lYIFv0AFr4AYXXYjSS0Z0vjwlNH0GHxGDjRclIeLsPQX+agr1sDt8CI5PxzKyPNcmMy9nIogrLKvgTgmbWRYSGXB/jeY9YLrAEUcFPJYSKVlMBu4aNtZjqgHfWD1Sx7Kmj6biiBNpYdh7tbA/eVX8Gl14MXGQHnddfQznBE7A9/WfYudbTsxNWYqfVzD4QOwdrVCyHYjPV4Eb+oS7P2yFo1H+g3+/NnQWBQoN/og6qgHL7sL48PHQ7ownYogjuJD8Gq14IYz1RGDcJqBbf8AqtYwf8+4n860E7wdHWBpDWBxeWiJ5eGo9iimxEyhVSiV1Rokl70EVfM6sD6ugyDjavBTEpmnJG01xxCTnoXFP38Q6175Dzqry7D2mQcwP6oW0oARpa1yaERi+AJsVMdPR2KEH/YmFoh0kZEXN+g7Hp+pgixaDUujGXU1bKhTwxgR5PBhKoKI+ExLDGmH+aG0Ew/0iCC2PXvhM5lo246oqGjwR+sPYOeXtTB22SFSiJDWUYoulwoWezh2fVGLZb8sgOAYwa/VYMfmKg0CqgzMuXQCdAe2wm4y0jaZoqWXQdy6hd7PYSf73w52Rh6MGmYMOpSoIp09C9qXXwa79ijkM+bBrHWife9BpEy/mbavUGrWw9HmBDGjEU5hWmiCdPeIIJHD+IEQWDweBOnpcB61g202YqK4DjHsy6FDKb5rWoUHb3sE2z+thss6FRbtZjiNuzErxYAopQ9Nu0hJGrB/8kWoKfkBkT4tTe5J1Lsw1dGXjHM8iDA456Y7aHtUS0kxjgqIEQofvAN7wPe54YmWQOBQwCkzg8sfXKVHjoSrSXXY2RRBDAYmFqs/JLHl5z//OX7961+P1XYhOpqkU4POBJF0mCDkb3JCdDx+97vf4eGHHx5QCZKQkEBnmORy+ZidSFIDp4iIkAhyChAPkDZPG4QiIYQcIW7Lu4322v3UCX1/QoS+PyF+SsceISnTHsOYXJIMM3PmTMyYMQOrVq3Cxx9/TM3RQyLIOUR1jzld6twz4wcShAzQiQjSPXDWeTQEDVHP5ahcGv9JBjcWxpDUHyFDi9F1+pJhPE7GE6R/21E/yCAwd2Zfe8J5T8YiYMf/AZZ28Dv2AdGXD3//zlJGJOLwgULG6JEcS+MnJqFiYzO0vkjYt22EZH6fh0lYbDzic/PQWn4Uez94Gynrt5GGE4T/8pdgC8gIEJgRNwOraldhT8ceeHwecMDGoTXfAS4zcqMcYOffgk2fNtKZfqIJpBRG0HYKvy+AjhI2yg81QW1MQcTBaED1JXhqNoRRfDgbu2B98/dQLpgMyGIBWTTAFVBTV+LFgfJVgNuKAHFFmPUwWBOu791uezHjh+FLjYeX58eBrgOMCEIEsSk34Lk6Fu7zvocwYwtke/4JBEjrhgdeqwa+VY+DI+v5fpK2IbsOUbZuLFFp8aNWjm4LG1+0ciGTxkNvEyIQsAIsFWITE1ChL0GYPh48Dh9Z4+MHfQSkAilnThL2dWhRaZiEBUrG04W0/qjvuYd+HpcVxlIRZG1ZJ26flQy5kAfz6tX0frLFi6lI5ff2/P65zO+/7lA3OmpN4HDZuOjWHLg/2Ar1hg0ojc+AwypE2bY2FC0e2KL/7q5GqotNTQ3D1Gn5wLRJQ7aWOfWMgGFNKABMoD47QilvUPUkR6GAuKgI9v37oeY5YGZz0KaPQErpF0Dh9TSJy7/nbTi6/NQbRTKVEcwIZFJD08x0PUQmnXicS3xBSKKRx6EEB3okdwqhiwV2d+zG7Xl6XHznOJi6U7H7Ix06Dm/E3mY/2q3EI6Yd+ggFyvatA6nRYQkE8PMnImCrgGpXOfWhoS1bw8DjC2g10K5nnkSVRgsfnw+JQo4pYWXY45uBFicbtdyjcPnm05ao/pDt62IDUvorGhvGpJYtIyODmqMSnxBSyjoWpKSkUCFk48aNvaIHETTIiRARXI6HQCCgy7GQE76xPOkjP7axfs4LiXpTPTa3bO5VeldkrkCEpMcR6AIg9P0JEfr+hPipHHvG6rm++uorbNmyhS6kAiQsLIwmxpBUurlzB858hTiLkIFU9Y/Mes6lZ/a1g60awQH7KCFpGwe/+S9dn3jF/eDyTkNbySlCBjVEBDGzAQ8ZsLH44CfL0KBlvA9Swk9DFYa2ipp8UlNU0nb0U4cnYhInit+DsOY7YMIJRJAjnzKXmZcA4r7klbjJuaja0Q69NA3GD14ZIIIQJi67Am0VZWjYtxs8TgA5c+fTwW6QDGUG/PBDY9fgYNdBKBpcMHe2QMhyIicmgF3106gAwhOQtqSsAYPc1MII7AlbB9vOcEQ5wrFxrQOL4z+AVKaF0+WBbftOKMUHjvuWAspUGG1TgGoOlOO9YHGZIaH9IPMY5VRivLkT+zr34eeBn9P/O3Ji5Kjkj8OD7CfxYX49JHWrwbd3gCfxwmP2wLnrB0jiB4uLRLe7tMCDHa0R6LTyYOJIAK8B0TYPDsZloihRhQNHt4PnSYBIJkDEccw9UwrCUbJeDVunFTqWAiy0w6vRwFVVRSOQJyQokRohRX23Fd+XdODqOA5jcspiQb50CbxuDza8SfxPgIV3Xk1FoEPrGf+dgosSqEhhzh8Pzvr1SHMcQplwIar3dSF3ViyEEkbQONxixMYKDbVQuW3GcVKxtIzfhbOd8U4xiuKpCEIErOMhnT+fiiDSql1A1BJ02FLg3/0K2HFFQN0m2MtIeiYbvNSsAX4gpGrEYfGAzWFBHXdigVSYnUM2BXDIAZYBUwwlsOXmo9J4BF/Xfo2fF/ycVnpdnKnDtkYnGi1y1LZ2AQIWgi4p/ORx8GeJ4NunhjmsAIGmEli3b4f84otP+PpEfE61uRBl80Nx43WIyFeDtWYTytozqAFtl6QR39d9j6symcokAoknfr/8fVoFc4k4GV9hYCz1yTJmZ0HELJUkt4wGq9VKy1/JEjRDJevNzc30x/bggw/S9Jhvv/0WpaWltNUmNjYWV1xxxVhtdoizgNFpxBfVXyBA06SBufFzkanqM+IKESJEiBAXHvfeey89j/jZz35GE+c0Gg0VRn71q1+hoCcSMcRZgLRkkNnj1oOMb8SGP4O6dUbnA9Hjh30omZW97rXddNlQPtjob9SE94gg+gbA289o8ScETYZxOGDgceD3sxDgRyAiUYpGXVAEGcI08FQJxg6TdqPT0WpzLpJ3NW014nccZL5Px8PaTVsRKEFT0h6iU+TgKpVw8pTQ1RrgKGHGM0HUcQnIUkYi4PGgSsxBXXwkvG7G/JJAfEDSFEzM7LaGzTi89nvAaUJhjB310tvRXG2jg9s512cOmuUnaTLFnBqUFG1EWJQALm4ktlnvhfCiKwChHE6LFJ6YixnPHjmpBokB1OlAzmXAkn8A134IqAZWOJDtdBwuoevp8y6js/E6h45OXAZTWHJj5HCxBNipvAyGZW8gcOv3EM5YQgU0l2wmMPVeYMo9wNzfAkueBa5+C7hjHeT3b8KSZz/FFX/4BxbedR9mB4QIN3nQro5DbqwI3bXM9zsxS31cXwsuj4Os6XGAUIlK8xSI1SZ6LLKsW0dvJ2PHlZOYKpKviluh/5apFhFPngzeMR6ThLqDTIsXMf/NmsrcLspnkmekdXugihTSRKSGEqYFw+3144WNjAB7aX4ssqKHEGtIiYi2Gl5HAB69DQEWC1orUyERnXr8Sg3JjOlgS6UQd1aCy+PCzVag26wCPrmBtmJZGryASAVJT5pMkPYapkMjKlk+ZBvJsQjzmJQtr8ELno+FPF8Fkr3Mdesa11FBjvjfcOvWYX6aFTMLpiLO6YOSxUdFZBGOZF2JK++7GTuEW+HhuREQSmHkqns/gxNBPFqclVVUgFBOnARW6x64fQKYfbGQ8eUwyTX4qPIjtFoYqwQC8Y5st7ZDLpBj2YTjF0Kc9koQIkgcq1h3dHTgf//7Hy1fHQ0HDhygfb5Bgm0st956K9555x385je/gc1moydEpE+YzAgR1/ixLL0NcWbx+D34vPpzOLyMs3O6Mp2KICFChAgR4sKGiB4hzjHseuCruwHDMY78bB4zyBmG8nYznvyujI4JCH/9oQJiAQcz0o7jUzASpJG0HJy0C0BfP8i/4kSQyo8Jl93Xu34u4mlh/EB0MilNrA0IwhGbFImOw4ynQLJafHpFkAsFRRyQMgeo2QhW8TvAor8Mfb8jnzBVMiQFKTJ7wE1k0BmdE4cWvR4GSSq0zz2N+Dc/pt4LwdaSyL0HkcQNoDVGicpdm9BWtg+TVtyE5InTaUTrPQX34LGtj6Fz/R6EGRRQcmyIVUiwtol5rUlLkof0kag31sPsMtOW8qX3LcKPL1fA6PCiWjUdYZMdcJaWwsaaDOWKvhn1/hCZQXklM6kcrAJxVlRQAY60Z0gysjHBMIG26uzt2Is0JSPWFCQocaTVhJJWEyZHh9HKIcGk+bDsKYPTrgSm3H3cXU5eMyw2DnK+AHVd3fD6ga6wOLh5tVBq48BhczGuIHnYj43ENpdtb4PekAh7fArQUAvLhg0Iu+MOcKRSLMiOxDs7G2HVaNG29TsoOYDiMqZijcvnYcHtK3orEip2ddD1nJmxvXG8RCwhKTveri4kRjhg0LBQd0iDrGlRVABp1NogF/Fw5+zjVIGQxCGXGU5ib0jiaFPGwW710Xae4dpVSCuJbPEimL78CkpTHbTKHLTx5yMK78HrYMNuVAJ8KWT9UlMJ7TVGehmbSTyDRhZDzU9OhruxEXZfJnjsSmQc3YjWSXnU/+XTsvdwf+lG5s4F10P0ThmyXQF8ljIT9TGTcNvMZOzsWgsvywNWoh28ahU0smyoDu+Hp61tQJXKULhqaxFwucCWycBLSAC27oHWGYMAR4SoCBVy4jJwpPsI/rTrT7g3/14qwH1axVRikSoVsXjsjlGjrgQhVRj9lxUrVuDPf/4z8vPz8dZbb43quebNm0dFlGMXIoAEFb2nnnqKusQTU9MNGzYgMzNUMXA+s6ZhDdptTMWQSqDCiowVp8fgK0SIECFCnHf4fD58+eWXtAqULKQShFwX4iyx4QlGAOEKAWUiPQmnl8ufHzQg7A85l/v3hurevvmLciLp9f/eUAOn5xQ+T3K+0NsS0xPpOkr4AiFdzuV4XLKHDCwSwBqATcEDh80IRwoxD0rxaRBviNHscfxAfsoEJvWkb5D2LlPfzHMvLitAfBkIE24e8jnislTgKOQwyDPgrquD5l/PwWe1wrp9Bzr/8hew/H4UzZqDS8Y5IHZ3wNJej80v/RXfP/sHtFWWI4kVjYJaOVStPjidBsxItGCv6w74AhyaJJI+ifntHAsRJwgFEQWQKySYtJQRD0q3tiEwkZlctG7bPuz7J0khNC2kB/uBg/RSNHEiWGx2r1krEUGCFCYoe9tCglG0wmzmN0naUgIjSAsjZqbkONChikFqUiQO1RyGyCGDiC9EbLpq2MeStpTMqdGAOAKVrIvBk3sR0DbC+MqztGqNx2Hj7jkpuKR0DdxmA1gqDkRt7wJvLQFevwj8z64Bf/fzaNxTRaOfyfOlFgxsxw9Wg4SbqqhXCImF/nRDA34o7aCHoMeX5lC/kSHpOS45zKRKhAVrPFPFSKq5TlSpobziCrB4XChai+F3e9DGmUuraIzimwG+DMLx48GP7/NL8bh96GpkTFFj00cmgtD319OSxeNk0WNqjnkXlvpj6P7bUPEpmu1dgCIBtsAEaj5rBA9bo/MRIRNgab6SjuUIM2ZMAIsvhl6VA5/HCfP6noqpYXCWMYKrcFwuWJZ2wNSCbmciwBPSNqhfT/o1YiQx6LZ34y97/oIPKz6k978y40rMips1ppVqo64E+SlHl4Y4vZB+x0MaxnCJy+LimqxrICJRYyFChAgR4oKntrYWS5cuRVtbG7KysnoT34i5+erVq5GWxsxEhjhDkL72pl0AiwNc8x6gHvn+P9hkoDGVAh4Hv70km5bRl7aZoDG76EBiRdFg48MRE54JtO4/aRHkfIjH1XMAL5k3Z4tgCrfCZiMDqu7TY4rqMPYJAGcq6edcITIX7phJEHUfBg68BVz0p4G3k/QYt5WJ1U2ePeRTxGQowRLKYQ1LgrclAOvGdbBuZSJZCaLCAkQkVoHV3YCrCkU42iVGaasH3VWH8OOL7dRsNdINmAN+aJINMPknQOuKBVfExrTLUoecKCTiw7bWbXSdDgxJhdB4NRpLtWivNqLWlYAENpuKEp6uriFbQYaCeFIQxJMYo8/J0ZNpyw6ZjW82NyNRnoisKBkSbQGEaZzY9U0bxhUBafmJjFGmzQZPayv4iUxizPFwlJRQEaQhIQUTk2QoOWBCDGIRl6Gi/icngpj01uzvgsExDs6iGeBs2gnTV19Cal8LQVIMptToEd+ggz8A8KJN8De1gxPcj04jAsYvUN6iBDgZyF6YAw5vYE2AcHweLOvXw1tegtiZM1C6txMVm5sANRt3z07FlJQ+X5hBBE1RdcxzGoXxgGvoVJhj4ZIQj2XL4Vm1GgGDDiYeD12lXbCuZVpNVNdfN+D+nfUmmm4jVQkgU49c2BVPngTTV1/BW9GA2gWXIbtrFcbtfh1T1Gzs4/jxgpiPv1/yd5j+/hq8/gDWxxXCw+Xj3rlpWFX/JVw+F5IVyZhTOBmr1m6F1W6Dnh8DwcaNCLvlFiqgDSeAEUR5eUAzI+RpWHk0IjciUQalUIl/zfsX3i17l44bZTwZLku/DAsTB1bAjAUhV88QZ4Q2a1uvcki4NO1SREuYBKAQIUKECBGCeH8QoaOlpQXFxcV0IR5hxCid3BbiDEMGgMEEmFEIIISvD7XRy2Xjo2nlAhFBrp/CDIw+O9ACr89/aiIIobv6pJJhag5vp0swJeZcw11XDw2PBW+AhYAwFpxoL1r0Hnpb6ukQQTqPMJekwkc4NimK5xP2vBuZlYrvAE2/cAe3DTj0PrNedMtxU5DkahFkERKwxHKwp2eBJ2TavVlCIZQrVyJmphes7iO0iop33buY8PgXuHpBNLLDbRA4O+ByWyGLDENVrhYV4Tzst15C2yhIIolEOTjogVBjrEGHrYN6dgSrNYhYMuFi5jfWVm+HJ5e53rqNEUuOhVRsOI6W0YWsu1ta4G5oADgciCdNpPdRCBRUCCGsa1oHr8eHPZ/WoMDIQqQD0NTbcGB1I1a9cASdqQvgY3F6B7nHgwg4tkOkEsSPhshUyJTNUHbFU1PM/ImpGAmkeiN7WgzdTxUR90BYOA6BABvtG+zo/L4BXRv1YLNYcKfLsDN8Cl5nXYX6uf+F/5qPUZH4GHZblsDgUILrbEe6dD9sLi+6zE7UdFlohUulMhE2tw+dh8rwQV0rLE4vouzADVMSce3khOE3rrMUPlcAbr0HAbCgszHiREz6iUUQQtgtN0MYGQaVtYG25Bz575eA1wfJjBkQTZgw4L5tlYwfSFymclRV9aTShS2Xw282IzJ5CX7gXQyLO4C7HWw6OV0lD8f6vT/CWV4BncuP3amTkRenQFykkUY6E27JvYW2ECVNSgGLz4FWOQ7e9mYqcB0Pv8sFR8mRPqGteTc8fh60jrheXxOCnC/H/RPuxzuXvIP/XvRfXJx08WnpGhh1JUj/+NkT8fzzz4/26UP8BLF5bPis6jP4SE8lgKnRU5EfwZSahQgRYuQ4HTboNa2w2d2ICA8/s9GUIUKcZrZu3Yo9e/bQVJggarWaps+N1nMsxBjQ2FNKn718VA+zOD3Y16Cn68vy+2JVL8mLxnu7m2g1yMZKDRaPO8mJkP7tMKQcfxQnx36/D/qafXQ9ZdzUcy4mlxhTOhvroRGw4SciiCAO4YlmNGiYXIYk9WkQQdqZCl3qeXEB4g3PBdIXArUbmPavle8w6TE7X6ARr1DEA5lLhn0OMgit1FihZWVh2qIa+CffCPbk68Da9X9AyWaaaoFlz/WKieJrXsIM4a8wpeMQvuJ20q9wDssPW8vVMIOH7BQ50icO3QZD2NrCVJoQAaR/RTVJ9WAqQnRoVk9DGnbDtm0bVCtXDn4Sv7+vNSE7C9atjFhC0ms48j4xjAxASTvM5ubNyK6eg446E4RCLo5yPUhQcRHDEsBmdKMW2WiMUiJtRysmXuI7buuHp60d9o4ueNlsWJPS0NBaCpEjBiKREPHZw1RYHANJbKk9qIHV6IFh5bNQCv8LV/lR2Aw+QMqGbP5ccO96AF99VQat1YXP1rkRK9Mis14DkSkSEo4Iufzd6PhuE/62TocazkCh94GACAqHEQFNPfz8dETzubgkSjX8YJwcjzqOwKnx0wofZ8I4eLyg1S1hsSMzNGaLxYh55ml0//4FaP3J0PCSkJ2tR8RDDw54bZ/Hj+Zy5jgbnzPy/UYgUcGS6dNh+fFHRB89gNLk2/BN2zIsS5HhjjwzXjz0Pxg+/BBGpxA74qfBKZXjttlheHb/U9SQd0bsjF5xLDk/AhUbpDAqMuDt2kD9WcTHiDVBiEAScLtpxQsvPg74cT+67Inwc0RU8BtNNctZEUGIYztZPB5Pb7lqdXU1OBwOivrFPoV8HkIQyI+FJMGY3UyGdaIskR5QQ4QIMXyMo17TBmNXM2zaFrgNrfCb2sF2Mqq/z+uFbpMYAWk0uMo4iMLiIItMgjomCVL58P20IUKcq5B4e4uF6W8+NkmO369vPcQZgLRHmNuYVph4pjR+pOyo0cLnDyA5XDKgfUPA5eCqoni8sb0en+5vwaLcqJM7VyStCcSYlbQpWDqY5IsRwmKxIU/M610/13A3NUHn98HNEQIcIewKLsZFp+DzciZq87S0w/SKIH3n8BcagVmPgNVWDOhqGSNgZRJQvZa5ce5jxFFz2MfHZqhQubsT7SCxsqvBOfBvoOYL6ndAWfjngb8jvgS47L9gbXoa6fVrQMISwz2Lsd+eCivHiuzF6uP+NkhcaLAVZqhggfHz4tF0VAeNTYIofjhQU0t9HXixx/xOWCwI0pmBP3H2CLbwSOcNfM5JUZOgEqrAapOisr4NYr4IE69Kw2dbqtDsd+E3v5yCjnIDStbUwGQWo0IvQfNzxcicEo3MqVEQSQfuO1Ip4vD40apOwPh0OVrLjYhFDOIz1eCNIN0kCBEWJixKxO6v61C2R4vlf3oa/sP74GltgXDcOOp7QfbhqzdPxKvb6rGhogvtJgfkPjlS/ICJI0W31Ia0gA/3u17DE9InwBIpIRZwIeSyYUvNQlxNMe6OciCQm4Ta/V1oKtUiPmuYcyzyeTuNcBCPbw4flvhCwA9EpciPm3gzFMT3o+ClP6P2r3vh8YaDc8cycGQDk2haqwzwuHwQy/mIGsZw9XjIFy+iIggRye7953X4VbsZX1W58fv0QlzhyUNcyw/QsRzYUGjHuKxSPH/kdZhcJurXQao0gqiixZDHKGCym6AVJoG3fRt8P/85Nak9FtuOnfRSPGUKWKQCzW1DuyuH7qtY0lZ2hj0iRy2CXHrppZDJZHj33XehUjFfBIPBgNtvvx2zZ8/GI488cjq2M8R5ysbmjWg0M67ypK/r6syraclbiBAhmHJUo64L+s4mWLub4TK0wUfEDpuG3DhgFx17us7yucEyNcNvaoatCSDhcp3kOXkSOijgqeIgVsdDQcWRRAiEpyFRIESIMWT58uU0De7NN9/ElClT6HV79+6l0bmXXXZZaF+fSVqYagkagUsGbKNgcxWT8jM/a6DZIOHSghh8sKeJJiyQapGpqerRbxuHx8yod1cykb2jEEE4XC5ypi7GuQpJTtBwWfBz+AgIYmBSahArKoDWysSHEmFpTPE4gK5yZj3uwhVBIAkHlv0L+PZXgKaCWQgz7geSiLAxPJFJMuor4XQroY+/Eeq2D5kBMakAmfcYkDVEJQlfDM4lf0WR7RGYu4xY+7EOPE4nqpJ2YrPBhZtjhjZi3dG2A0aXEUqBEhOiBs+4y8NFSMxVo6lMR1tU0is/o/4WYbfeOqgaQDyRaXtx1dfTVCJikiqZNm3A/cg5+8KEi9GwwwuLx4KieamYMDEa6v0N0JjtKG03YWpRJJLywrD3rifRzEqF02jD0W1tNH2l4KIEZE2L7hUB7Pv3UT+Q+shUyKXViOhIBZfNQ+Hk0Xs+peSHU28QbasVhzd3YOZVfYmjQVQSPh5bko375qehRmNF9epwWJstiMhRoWDRs4j88R7EmRrxZdZOYPEzvY8zR+vR/XwphJ0N4F8fTkUQIjyQliAS1TsknaX0wmEk51ssGAWxgINE446sFaY/PIkYqdOT6furOahFbNbAY2XVXnLGB6QWRtDkmdEiyMkBPy2NmvnG7FqPlZNm4/MDLfjb92V4eFsT/H4+9uawYYqqQo2zkQoUxBPmielPQEoMsnsg16dOTsLhlk50RU5EdOvXMP/wA1TXXDOoys22axddl86dA9SuoYUz7b4CkhWNuIyRG7ueNRHkueeew7p163oFEAJZJy7uixYtCokgIXop05VhVzvzhWeDjZWZKyHjD5GpHSLEBYDFpIe+sxkWTRMculZ4TW1gW7sAn3vA/Y47N8nhwy+NBkceDY9ZB5ZL31sZ0h+WxwboauDV1cBcC5AaLDIX5ReFgS2PBV8VB0l4AlTRSVBFxJ6zMZEhLjxeeOEF3HrrrZg+fTp4PRGTXq+XCiD/+c9/zvbmXVgEI1NH2SJhtLtR3MxENs7PHlzOLxPysLwgBl8caMWnB1pOTgQhhGcwIghpiUkbPPA5X7FUVKCTx4KfxYVPEAeTvAJcXwyAWprMIBWM+rR9eMigjbQqS6MBGXmdC5iYAuC6j4CjXwAuC5B+MZDI+GqcCJIgEp+posJDg/BKqFcuAoxNQNxEQDZ825ebo8DW1a3wuP2ISpRjU2wFVtXWYVnqMoQJB7Y5+Pw+Wl1NILfzSEXUEOTOjqXb0s1PQhxHBs4Pa6C6/voBSTD9saxjjDfFkyeDLRkstE2wzUaXsxh2rhm2zBawWEmYlhqGbw/bsbeeiJnh4PK5SB8vR9TGz+EsuAmt0nzo2qwo/rEJrVV6zF6ZCR7cMO49AK/fj/rkPCTVNkDuSYZMLRpVK0wQMvgnqThrXzuKxiNaKgjEpA0tOJBjTzKXj4pOB0R8LuYtSYEiQgwsfhL44nam8idjEeOBRHwzCphUF2dVNaLVHEgUfNhMbmo8mzjuOMetjiOMH4jRD5+IC4OD8XQ53jadiKypUVQEIeKLodMGVTTz2XQ1mtHdbKHvn0QGnwwsFgthN9+Ezj8/CdPXX+PWf82EIz8G/ndeh1jTDgc/Apo5N+H6XAN8cGGcehwWJC4AnzP4O5Q2IRIlP0hhk8bBwpKAs2oVlFde2RsVTbDu3Am/1QpOWBiEOdnAe4/C5FbD5lOBzWPRapkzzaiPpmazGd3dJPx4IOS6ocpYQ1yYaOwafFvLmOcQLkm5BAnyE5gJhQjxE/Ht0HU0w9QjdniMbYC5gxEnRiJ2sNjwSyLBUcRCEBYPWUQiVFGJUKqjqOM2SejSaDSIjIyE2+UY0WvR13PoAYce7q6jILKLYYjXkoYnICw6qfe1QoQ4kyiVSqxatQo1NTWoqKigJ2k5OTlIT08PfRBnGiIwECJzRvWwrdXd8PsDyIiSIl41dPUZaYn5qrgNh5uNqOw0Izv6JE5+w0k79nc/uYSYuvJS+Eg0LjcM4KkhjAmgy8Qci5OH8QOhx3y/b/Q+UaQFhBBbOKbRk+ctijhg5gMn9dDkgnAqPJBWlKLFRWBHnzhu2O30YutHVTBrHRDJeLjktgkoLs5Elb4Krx95Hb+d8tsB99/UsglN5iaIeWIsTV163OcNi5FQI86OmgDao6YirX0DrDt2QLZgwaD7+u12WNYx0abypYMrVnw+P+p26SHlSVEStw8f1e7E9MRpmJaqxreHW7G7Xof7AwF6vBZPnATrxk2QV23FopevQ11xNxVBNI0WrHm1FEVJOtgdLmhlEYjOlkJ0kAhvLEyenzGqdpH+qOOkyJwShep9Xdi7qg7L7is4bsJMycZmepk0Xs0IIATyOU24CSh+D9j6LNO2xJfQRB1uVBQ1J3UeOYKkvFiU72xH41Hd8UWQzqAfiIC2wgTApuLJyXpdkG1MHBeG5jI99n3fgItvz6XH1wM/MBX2aUURtB3mZBFPnUqFL5IK1PXYY7gmLhaW7mq4xXyEPfgwXrhs4YhaVIRSHhLzY9G024CusALIug7AsmUL5Bdf3GuGa/6WGRPKlywBq6uU+u20uefQ+HViiHqi+OBzQgS58soraesLqQjpX67661//GitWrDgd2xjiPMPpdVIjVLefmeHOD8+nPYUhQvw0fTuaYNO2DvLtCDLcfx+nWp0hFEkQl5pDl+GrTtrBtnYOqjohLTfk+oC1E862YjiJ12C/qhOuIhYidXzIbyTEGSUjI6NX+Aj5i50FvG7GG+EkRJAtVcwk2fysgVUgdrMbDoublupHyYW4KCcS68u68Ob2BvxzJTPj2h9y0txqcEDAYyNSJhwmIaZq1Mft4m9fpOtFl913TlXC+dwuNBg08LG5YEszYZOakBWfRluHCCkRQ4ggdj1YPz4OdeNusBSxwMVPAgnMufmIaO8RQS7kVpgxIjZdQVNLnDYPNaxMHh8+7P1N3Q5s/6wKra3dYPECWHjtVIhlAtybfy8e2foIbXvJb8jHkhRGmOi0deKN0jfo+jWZ19AEjeEYNysOHbUmaJR5SOjcCdM3qyCdP7/3mBrwemH8+mvY9x+Az2YDPyFhUPoIof5QNzU+DVcpYUlshdliwseVH+OqtOvA47DRaXbRNpPMKBnEUybT2X9PUzM89fXImJSOyCQ5tn1ChB4ntm6yQyEZh/KYeIRVGcDxCCAMYyN/WvIp7Hmg8OJEtFUb6HbuX92A6VemDfq/g1RPtFbrYdUehqFdBa87GVx+T6XClJ8xxrjmdmDvK8BsxtqBvB/zd9/Dvm8fklbeSUWQ9mrGi2OQ0OKy0uOmvZMRQQyR4+nVpMLlVP4fIylB7TVGaFus2PheBfy+AIxddvCFHBQsOLXJZRaLhcjf/gYdv/8DjVN21dSCz+ch7uH7IF8yOv/GjOmJaCpugjZ8PBK1u6F/511IZ8yglUX23btp0gz5bsiXLQWOvEYf0+iZQcXXhNzRVwGdFRHklVdewaOPPoobbriBmqPSJ+Fyceedd+Kf//zn6djGEOcR5MTlm9pvoHPq6N9R4igsT10eOpEN8dPx7dC3wmfuGJFvR+9z9PPpkKgTII9MPK0+HTJFGF2QVTj0+9C2MO/jOP4jRCxhB/1GmofwG1HGQhyeAHkE8z6IGBMixFhA/ED+7//+j1aDBAWRBx98EHfddVdoB58p9HWA3wsI5CNukfCZzWj9/Buo95iRGZGJDA8HnQ0merJOZsbJCTyBy2dj0pJk3DYjGZsqNDjYZKDVI7PT+2ZWO01OPL26HBWtRhQ2HcYsmQdLf3E9BIlM/GdvOwyBGKM6zaOKdiXHwnORmvVr4SQWlWwRvKJ4GJRHMEs9Az/U2IauBCHvY+1jQNtB5m9yLP/+YSbdJHwE1VNkv7X3xJnGj0I4CTEkJC40Y3IkSre0oXJ3B5LyhjY3JTP5lbs6ULKpBT6vH2yRH7KLbVDHMZ9vuiodN+bciPfL38dLh1+i4ke8LB4fVXwEu8eOTFUmrki/4oSfQmSyDOHxUnQ3+dCuLEBy9R46GCVRq73bYrPDfvAgWFwuVDdcP6gClGzf0a1M3PX4uQmIjr8H/9j/DzrROV49HpMTZNjbYsO6sk4qghAzTPH0abBt2w7z2h8R8ct0KCJEWHx3Hna+ewgNLW5oImdBKJYjYLDAy/FgwfX5J10FEoQYqk6/Ih0b3y1HQ4kWYbESJkK3B+Ljse+7BrouU/PB4x3zeiQNaN7vgG/vB0o+AbKWUgFYMnUqFUFse/ch8Ze/hFwthFnnpO0pxI9kAK37EfD7YO/kws/mQgtGCD7VAb5EIcCslRnY+nE1raghcLgszLkui4pupwpHKkXcc/+iQo9Xb6DxyLzo0Sd3EV8cdVI4tFUWtEVMQkp3KTr/+lcoLr0U3f95gd5HcdUKcGUi2nqkd0bC6AoHW8hC0vEqa841EUQsFuOll16igkddXR29Li0tDZIheshCXHgQ5brKwMzMCDlCXJt1LXjExCxEiHMccmJstRih72iEpbvl5H07ZLHgKmKYCgoqEpwbiS3k5EYVEUMXYNqAmVFDdzsMnU19STRE5CHtM8P5jdQxfiOt5ERKqAJbQSpa4mlFizIqEWGRcefULGuIc58//elPeP7553H//fdTXxDC7t278dBDD6G5uRlPPfXU2d7ECwN9Q5/QwGKhy+zE/62vpqacRLwQHmMKSAzvWh//I/boMxDFj0RklxUVaxpR2S9+lowFycyp2+nDnlX1mH1NBq6fkkhNUp9bV4U4ZQGI1d72Gi2eW18Nq9OLi45uxMyqHfTxR4/sRv7rL4IXF8c8obBHoCEiiK6G8V4YARwOF+OX3NW7fq7g9XhQ/ONqmtLBF+fB5vfDoGqjffgv6ZjPI/XYSpCqHxgBhCuEcf5foK75jA7EsPlp4Oq3T9ze0rKX8QMhaTvKULvyWED8Gcp3dEDXZqMD5YRjfC6sBid2fVmL7h5RMDZdifxlObSlgUOSmHogHnp6px6r61fjq5qveq+Plcbi99N+P6KAASLAEG+Qba1WdMVMRbzhILQvvwJhfj4d+AbYbHiam6lBKj85GdK5g5Nmag500Sou0qqTMTEK2bwYFGuKsaFpA57Z9wwujrkLe1sE2FSpwc/npYPDZtF2ByKCEJ8R1Y03gKtSgS/kIrvrR7i6OlEXOQ1+oQMmeTskU5zIS7seYwHxlCBpMcU/NqN4bRMVRlInRNDKiV1f1dGWI6GEj4W3rYRAzAObe8w+TJrBeILUrAM2PwOsfJfuK5ZQCJ9ORytbSBsNEblISswgEaR5DzymALwuPszhifCy+RCKuYhIPHUvxLhMFZbeO55GArM5LKRPioRc3ReNfKqwuNwB4thJPQeLhYJLsrCpoQtdkZMQazwKHCyG4yBTbcZPT4PquuuY45bLgirHYnrsIr8RvujsHItP+lU7OjroMmfOHIhEIloBECpbvbCpM9Zhc8tmus4CC1dlXEVjtUKEOJd9O+y6FniN7Sfh2xEFjiKm17eDeGkowiLPOy8NIlRExCbT5dh9pO9s6dlHrfAYiN9I+9B+I6QFyGmAu6us12+kob/fiCoO0p59FPIbCXE8Xn75Zbz++uu4/vq+k2Jiipqfn0+FkZAIcoYgho4EZRKNun3yuzJUdlhomovZ4cFvLskecHfz2rWo1ihhkUTRCpJIcw3YQjOQkQ+RQoCEnDA600dmLQ+ubUTV3i7s/bYeK+/Lx8FmAyrazfjFB8UIE7HRZfPRFsJpAjuu7jwIp5gPg90Nm96IzjfeQsITfxzYEkNEkO7qEYsg5Pgslp6cSeHppHzbRliNBvDARUCSBx/HAWEMIIQaJns17atMDBMPrAI5+DZdDUy6E97wXASSngLrgxWM2WndJiD9ouFftIGJWUXKnNP51i4oSBxs9vRolG1vx/7vGxCRIKPfezJGqj/cTb0cvG5/b0UUGaQPNXYi192Tfw8KIgrwY+OPsHqsdJ2cVxM/kJFCzFpJC5qJeInFTUNs63Z0/ulPCLvzTlg3baZpHaRFIfLBB6gY0h+P24eybT1VIPPiafoNgWwXqU4p1ZZitfZl8KRLYbRmYn+jnvqEiAoLIcjOhquyErpXX6PtFqQCxbJzB4QmJzZPzoJl3Mfgc9n45+Sx7SDInh5D24yIFwkRW0mCitvhpYamxER09rWZUEUP8/snbTBNu5h0oNLPwS64DuKiCbDt2g0baYm5+AoqgrTXmuByeCEIDt5JzEnTTtja/ABXBGPSFHqsic9WnXKVSxBllJiawJ7LRKcpEJkeAU2FA115s5Fur4dXb4e4qAjqe+8Bm8sGDrwFm0eGRmcRwGPR5KCzxahFEJ1Oh2uuuQabN2+mP1JSspqamkrbYUhKDPEKCXHhYXQa8WXNlwjQeQxgXsI8WtIXIsTZhFQ56LrIQL4F1u4Wahx6pn07zldIi0tsSjZd+mM1G6DraGL8RvRt8BrbTsJvJApcRVyv30hYdCLTvhPigoa02E6aNNg/auLEiTQlJsQZwsiYB0KZiPJ2MxVAgqwt68TKSQlI6RfVqv9xM9olk2Hli1ER5sGjVYfArtsBSUwbon71uwHCcNElyehqtNA2maodHfjrlePxl+/LaVtMu9kFAY+HlZPicdmBb2FjsxAxbzbelU3ApZ8+B+3mbYi6vRn8YFtMRBbQsBXQjs4X5FzD0NGGQ2u/R8DlQhgrHp08DkyKLhTFTECj3k7vE6sQDazAIVUchkaARFWOv5rE8jAxrxNuBPa/Aez+H5Ayl9TND/2ixES1aSeznjzrTLzNC4a8OXFoLtPBondh/ZtlSCuKpFUhJM2DEJEgxYyr0iFVDW+WScZY02On0+VkIQP/cbNisfubOnQmzEGU6Sj1Zmh/5NHe+4T/4ucQ5gz2/iEtO06bF1KVAGkT+uKuhVwhjUn9y+6/oLizGHbZl3AHxuHrEj6mpc6g2x3+83vR9tDDsG7ZAk97O9wN9bC5vNiZOQ2alL2Qc1l0nJAdNvD84lQhrz310lTaQlK6pRWGTub3IxBz6T6PTjmBAEp+QyQWecvfgN0vAqnzIZ4ylRFBtu9A/PXXUzGCHL9ayvVIn9jjfaQpp4KsvR3w8SXQ8Jhj1HENVH+isFgsFF0+Hj/W69DuykRClhnpv/hTX7vivtfpfjpiWQE/V0arZMIT+uJ2z3kRhJSlkug6UppKXNuDXHvttXj44YdDIsgFiMfvwadVn8LhddC/Sb/i7LjZZ3uzQlxgrSwGbQcMXS19vh1E7LB3j9y3g8Q3y6L7fDuikqCOTjhtvh3nK6S1h7b3DOE3YuhqhqX//j+u30gL/KaWIfxGYsBTMuKIIjIp5DdygXHzzTfTahDSEtOf1157DTfeeONZ264LWQTZVUelS2pk6vb6abvKFwdb8OvFzODF3dyM5k4OvHIudGI+1JMTEH/9n9D++OOw7dgB/dtvQ33nnb1PTWZFixYlYtP7lbS0O29uHP55dT6qOs2obe3C1KwEqPksND7PVCmorroKC/wq1GzLRG5XDczr1iE86A8T0TOA6iof8Vvz+3xoKN9P11NyJ4N9zOz3mcbrdmPLe2/A63QgzO2FR1YAG9zQqptwdfQNaGjr8QMJP+b/ocrvmUviXUCEEDCDPUy4GTj6JfMZVq0Gci8f+oW7jgJOEyCQATF9x/IQpw5JuZh7QxY2vlNB/SMOrWd+T6SSYvzcOOTMjO2tDvAH/Kgx9PgfqTLAZo19JWlyvhplO9qoManu8l8juWYVnBUVNPlEOns2BGlp9P/w/mIlaR0p285UgeQvSKB+J/0JCiGvHngV37euhZVfgnX6CqQeuhE35V0JSVYWwn/xC2hfegmu6mo6PXokMgPfTzFDJNBBJQjHnXl9x4WxhAg/pHKFCBRdDWYaX0yScsjn4vf6UFtcQe+XXpQzuCWGMG4F8/siFVXb/wXJ7D9B++KLcDc0wF1bS71eiAhSd0jTJ4LUrIfXEYDTyIdOnQIfVwiJnI/o1HOv6ux0o46VonBpDg6tOoQDzYVQfPRnRFx6L03OISJIqzUN9c6pAJ+NCRcnntUuklGLIOvWrcOPP/6I+Pj4AdcT87Kmpp4SyhAXDKTEj/QsdtrJMAY005wYNoVao0Kcbt8Os6YFTn2Pb4elE/AzRs0j9e0g5p7CsDhqUkraNM4F347zlYF+I1OH8Rtpg9/cPozfSC28ulpY6gDLkH4j8VBGJYX8Rn7ixqjkPGPatGm96XNk0uWWW26hEy1BjhVKQowRpKw72A6jSsLebUzay/Q0NU1pISLIxgoNfjY7DQoxD/aDxdCKkuFm89As5+KOvBiIMiMQ+fDD0PzjnzB+/gVYIhHCbrhhQMk0ifDUd9hQtacTBRclUFNFJcsBtVQA+86dCDid4EZHQzguF/PdPvwuYyIyO6rQvXY91LffzpTuR/VEkOrraY85HdCfAL/fB20lUwGRlF101kWQ/d9+CUNHOwRgI9UjQ4k4Ej6WF64YPQojC7HpMJPSkxreb7bU4wDqmNZj5Cwf+IQCKVB0C7DzP7TsHNnLiWPn4BeuWstcJs0c+vYQpwSJNl36i3z6/SbtGSQiNXNyFCRKwYD7ERHkiPYIXU9Tpp0WEYQIGFOWp2LDO+Wor3Eh7Y6HkZIkZ9JhvvwKjpIjEJA0rh4RJOAP0HY1nzdAf6vJ44euZuCyuViZvBIL0hfgwbXPodvVhHfL3sPG1m+xKHkR5s6ci/ic/8B1+Ah+MJjwP+92+AXNiBRK8JvJv4FSqMTpRCTjI/kY3w6/34/6g6V0PbUwC2wM8d0n+2H+74FPbqRtZZzMxZDMmA7r1m1UhE275W5aZULMnkl1T0ScEKhcDWujDwGeDO0x06nHBhFIxqoV5nwjZ24qOmu70XG0GRtLilDY9i/ESWrRZf//9s4DPqoq++O/6em9dyAk9N57b4ogCPYurq667ura/q5d1951bWtfFcECigoCAoL03gMJ6b33ZOr/c+5jhkwygSQmUzLni8+5U9+bmzfv3fe75/xOP+ytXkw1dZE8OqJT/FLsKoLU1tYKc9TmlJWVQaOx/nEz3Z+9hXtxqPiQaKvkKmGE6qnsPLMexn1p4dtBnhTVBR3w7YiCJijapX07XJXW/EYaG+rE37aqKAu1pdkd9xvxkzxZ2G+ke3D06FEMGyaV6jQbr4eEhIiFnjPDInsXUlcqXWTLFKjzCEdGaYZ4eGhsIAK8VOgd7oPThTX46Ug+rhodh/J9R1GpSoZWoUJdkArjekkXTL7TpkFfWoqyDz9C+WefQyZXIPCKyy1/v/4To7B1xWmc2l0gzBup2oEZutggaJaaXuutUSJo7Gg07PgO9cWlopSjR79+gHewqFYlylpSNEjcOQG2NWQyOXyi+ljajiTr6CGc2LZZtAeHRqGkIARahQnlAXkYlzBaXGSmFkkGmolhTUSQ7N2AoVEyhg3rJwlXTRm4BNj3KVCZI5kQ9p3fsgTyqV+kNokkTJdAXiAk8J0P8s9L8EuwtLsKMg3tOSRU+JJsW3laVGvx8lEKQ1Rp5efWfXhTDooyq0XkCqWWXOh42zeoL16f/gqWrfwcDcZtqNBUY3XqarFoFBpAqUCavAQmFRDm7YP/G/1/GBgqlY+1O3IZwnrEW9qtQqbQJCaS787Gp+A7/v/Ecalm02YEL1smxBUqHXxoYzamj80Sx83qTAXKfPug1jMcapUcSaPC4a7I5DJMun4ktn6uRN7xXOwrno59JTOltBiNH6KSAjB0dpNqX64igkycOBGfffYZnnrqKXGffhykrL3wwguYOnVqV2wj46RkV2cLwyYzC3otQJjX2dAwhmmnb0cFRQuU5kJnrk7SQd8OuiCWqpPEQKF0Hvd/5hyUYnRev5HirLPVefIhr847v99I3oHW/UZCYxEUmQAf3wAWvlwA8hpjHEz52SgQvyicLmkExbGH+moQ6C15IF06NAYvrD2J7w/k4NLBEchPLYfRE6jQyDBlUARUTcLmA5csEbckhJR98gnUCfHwPhvhE9M3CL5BGuGbQBcTVFqUMNbXo26PlK7iM+lcWu2YpHCkRvSGb94x1O7YKYkgRMQgSQShUOs2iCB0Tug//iI4mtqKcmz96lPR7j9lBvx+WItjHqNRLzegJDQDd/S6BzqDEeklkjBM4pNNQ1O6QG0uglC5z2HXAtvfBHa/D/SmKgxNPKwoTYYiZ3wigFgujetIqMrLyIiRdlnX8LnxKMmpFmkxGz4+jslXJiNg9Cir0r0HN2ThxB/54v6oi3sIP5C20C8yAPN7z8S6YwPggWwM7pOBlIqjqNXVoai6ESaTHBHq/nh/9r2I83dcJSKlUolhc9pYBWX0bUDuXpEW45n7GZQhwdCXlAohZODkycg4XILC9EqkV/2GyCIj6uoDkRY2DnIvL/QZEyEq0MDd08JuHI60/bE4tasAlSUN8PZXo/eIcPQZF+kUUTLtvkIgsWP69OnYu3cvtFot7r//fhw7dkxEgvzxx1mTJabbU6OtwcpTK2Gg8mo0QIkcg/4h/R29WYwr+HYUZKKmJKfjvh3CNyKKfTvcyG+ksqwIZQWSOCLtN/mQ1xa2229EGRAFr+BY9hthmAtWhonDqULJyJFSVcxM6xOGT7ano6iqEd/9sB0+xiDQr7DQ3xN3jGx5cUNCCJWXrFy1GsWvvQ6PD/pD4esrBsBUyWHPTxk4uSMfvYZLxot1u/cIg1BVVCTUFKJ/Fqo68VN0MgZkH0H5H9sRfPNN0hMRA4FTayWPCxdKI9765adorK1FcEwsBg8dheMfrUFNiD+0aiMS+oUh1jcWpwurRXUeHw8lIvw8zlWFyZDKBiPhPN5rgy4HDn4lCUQHPgNG3nIuCmTfJ1J7yFWcCuNGUJnaadf2xfqPj6GmvBE/v3NY+FuExPiISicZR0pRXUpTCsCQGbEicqQ93DG1F47kViC/Ig4njiZifOJSbM0/Dc/aekRrQvHekrEIN+/HrgCZCs/+t0iLkZWchF98PMpKgPLlXyFu2lRhgHv4l+PYdWYwoksaURTdBzrfMPgFeqD/pLOlvN0cuVwmRA9anJF2iyADBgzAqVOn8NZbb8HX1xc1NTVYtGgR7rjjDkRGUj44090xGA345tQ3qNZKAyQK5ZsRN8PRm8U4rW9HNvQkdrTDt8Ok0MDkK4kdHsEx8KMZffbtcEsodSkgJEIsf9ZvxNCK3wiZsfqEkjgSi+Dw2G5f+Ydh2mKKevpsKkZSkygEKmt566SeeHrNCRz8bQ/6qSKhl6swckQkQnxszxoH33QT6g4cgC4zC+VffoWQv9wqHqeLLAonpwuyvFPlUAcBtb9vEc95T5xkFYYf4KWGaugwGHd9h9r0TOhyc6GKjpZEEIJMDCkiwoEme23l5PbfkXfqBJQqFaZcdwtqtm9HukdP6BRASXgW7hl2g3idJRUm1OdcXxSfBOpKpGiP85UFpufH/w1Y/6hUkSFmJBA5WIoMoTQZzyCg/6V2+b6M80CeJHNuHSjKx+amlAvhgxYzag8FRl7cAwkDrb002oKvhwovLRmM+785jNzyevx4iKYgfBHlF4JnLh3oWgKIGUq3m/8asOqv8A/JQKVJDX2eAeXLv0b/8QkoV+5BprYX0jTjRXqdZ4i/MMVVqdlnxxVQtrd83Zw5c/Duu+/i4Ycf7rqtYpyaDVkbkFktzRb5qn1F3XIK6WPc1bcjQ5SgPefbkQ+Z7qxTfVt8O3wihLeDh/B2kMQO9u1g/pTfSEE2qgozz/mNkJfMWdHWlt+IrvAYylMkv5EM2ie9Qs96yUh+I4HhsQgMieSUGqb7YzFFTUB6hpSK0TPUuoThtD7hyCqtQ8W+ddBr4iHXqHDV7HNRG82RqdUIufVW5D/8L1St+RH+CxdCFR4mwqV7jwzHsa15OLmjAAOneKJuz17xHp8pk1t8zsh+scgI7QGv8gzU7tyJgMWLgZAkkQYnKp2QgBN4Nt+/FUg83b/mPdEedvFf7C54VpeVYPfqlajT16FhSDieOP4CBn1/GHqvG6FTyTB9xghE+kgTimYRKrFpKkzGVuk2bqx1iostqHIMGaie2QSsugMI7wfk7pOem3QfoObKZ45Gb9RjzRmp0s/FPS8WPjD28CqZclUyijMqcPrbP1DXKIdXciJC4/1EZAhFjHSUSH9PfHDdCPx2skikcsUGeWFm33B4OokooNfqsOmz1aI99boFUKrbkLJC4uG8FyH/+X4ED6hB0R/VKH/3Rch3AkM85JDnjUCZdx8E9O+J4XcMb2F+yzgv7drTqTTu4cOSizHjnhwtOYqd+TtFWyFTYEnSEviI8myMu/h2kNihLc+TZt0bKqxe1+ocHHkHeQRJVT4Cos5eWMYjMCyafTuYzvcbSUgWS3O/EUqpITPWhrJc6CryWvcbqS2EqbbQ2m9EroLRN0L4jZBg5xfGfiNMN6QiW9wY/WKQXSaJ2fHBLS+WbxjfA9s+9sRpoxwxCb7QXODCyXPYMHgOHoz6Q4dQ/r/PEXbvveLxpFEROL4tTxgxlm4+CQ+9Hur4uHOGjU2glJj3opLQq+gMqnftlkQQBbkt9gPyD0oX+BcQQQgTpYQ4iG3ffImCyjyU+mtxwq8cimJgbFUfVAYoEBrvjznDznnrmUWQ3mG+Lf1AEiZceGUUPTLrKWDNPUDO7nMCyKi/AEmzOvmbMR1F1yxC1l5QGowyRhI6Axb0EBVNOgMPlQLzBjpvZoBB14H+jh8HXPYRfH57Gg1FB1B1WodS+jmpfRHplY0eyYGIeuDuTutDxj60+691zTXXiBJ2zz33XNdsEeO0FNYW4oe0Hyz35yTMEXmrTPdKZSkrzkNFYRZqSsh/Ie9P+HbEwDs4Gn7h8QiOiBUXpwzjcL+RpPP5jeRK+7stvxGjzuI3Ukdm8E39RkgcCYxmvxHGtaF0EkpbJOFPHgStPk8YndLsbnMMNTWoqPUAvICoAZSqdn4aaqrROGMKdIcOoXrDRiFgkNDh5adG/MAQpB8qRur+GpCzmM/kyTYrUiQEe6GsZ3+YDv6CyoOHEV1XJ0wIETdGEkGydgIDFp13OxQKJfrOvMHStic5J47i2P7f0WjUIn+IB67oeyniTxmRFqCEUqnGuIuGW5lUpjWvDFNTJKXD0HTD+fxAmqfFLHhbiiChSBlKoaGIEMYpoMlEGkub2/ZduQJ+8+Za2u6AXKnAuKXzLO12EZoE2dJPETItFarvv0fl1kMw6U3ieBV04w0sgLgg7T4D6PV6fPTRR9iwYQOGDx8Ob29vq+dfeeWVztw+xkmo19djxakVFsV6SOgQDA8/Tz4q49TQxV91VbnwUzD7dhgq8iCr6bhvh3+YVILW27dra78zTFf7jRj0epQV5UhiYHHWhf1GytJgKEtr6TdCYmCgJAYGRMSz3wjj3FBkn75eNM/US9EHMYGeUNhw8W84eRKVmkgx8I/od34R5MyBPdj25afQ63SQhfthUHEVvD75BJGPPy6eHzQ1BpkHC1Fe74NyTQwSJrdMhSFIGOk9OBHl6wLh01Ajokq8x44FYkcDu96Voh2MhvOafdJv3i9AKuNrT4xGA9av+BD1+gYU95Djkbn/RlJgEjZ+sQJGuRxBAUBc/3PblVVWhwadARqVAnFBXtapMBEDAK+gtq+cSsL3tN2njGOhfZrSyh21bjIpdifk9PsP9u/4B8hkkIX2RsCt9yNAsjZi3EkEOXr0KIYNGybaZJDalAvVkmZcE3IyX5W6CmUN0gVApHck5vWcx39vF6GhrgalBZmoLMxCXVlOq74drf565UoYvcOgPOuR4BsaI1JZ2LeD6a5QGc02+Y1U5AFV+ef3Gyk6Dkoaq7DlNxISg8CIePYbYZyDs1Eg8ApGVqVeNONspMIQJQdToVV4QqVRirD61ig8k4otn38khHfC6OuNQ7U18N65CwHHjsGzf3/4BnkgVpWDVMiRGTsTw0JbF1VG9QzB7ojeCM3YK/xDhAgS3h/Q+EplX4uOnzNLdSLS9uxCUW4G9Cpg0Oy5QgApza5CdiENw40YPiPaakx1Ir9K3PaJ8D0nQlmqwrQhFYZhGIb58yII+YBQVRhS0DZt2tSWtzDdiK25W3GqXBK8PJWeWJq0FCq5e9e/dgXfDgrtN1Xnt8+3wzNYzF5raPaaLtDYt4Nh2u43UpyNhtIcIY7ISGg0NLbTbyQKHkGx7DfCOIbqfOnWNxI55ZJIHhtoWwTJP1lMUyIICVNBobQdL6jTNmLrV58KAaTHkOGYcNX1WPPqcyiprsEZXQ28XnsdMW++AX1JKcL2fI3MoIVo8IrFrh/OYNyiRMhsRKAMiwvAV5G9MTJtNyp27UaIyQQZRX7EjALSNkopMecRQYwGA7JOHRDtuKShkNshDcCg12H7mhXQGnUo7KPA3wdcISaXdq84IvomXJeF6GkLrN5zLE8SQfpGnp2p1zUA2buldg+O6uguGE1GnKk4I9o9A3pCLmvVRr7ToX1Pm5Ym2upevdzC+NuoN+DMIel6pufgpPanxDDuJ4IMHToU+fn5CAsLQ8+ePbFnzx4EB9s/nJCxP6fLT2Nz9mbRlkEmKsEEeHC6gyOhQVx5Sb5UGrSULrooVD+/hW+H7DyCh5VvR0gM/MPjEBTOvh0M0xV+IzUkjpTlwEC/U0o5O6/fyK4mfiNe4oL0nN9ILIIjE+DhaZ2GyjCdGgniG4Gc8npLOkxzTAYDiopNYgQZ2S+81Y/b//MPqCougpe/P8YtvQYqtQYjF1yGX3NzkNfQgJ7Z2cj5299grKmFQlePvgGZSPFKEiU79TojRsxLgLe/pkUZTs2gQdBv/xp1eQXQZWVBHR8v+YKQCJK5HRi17LxpKYVHpTK8MYmD7CKCnNqxDaUl+dBpgB5jxiDQIxBZx0pRnFUNhUmP/v0VkKmsJ5aOn40E6R91NnSfUn30DYBPBBDceiUexvVEkAPFkiiX4J9gVxEERiPq9kvrVvfoIaVNdXOMRiNSdx8U7YSBiZCDRRB3pk0iSEBAANLT04UIkpGRIXYipvtT3lCO705/BxNM4v7U2KnoFdDL0Zvlfr4d+RmoKs5p4tuRT3J2m307xEVUQDQ8gqPZt4NhnMBvpLwoF+WFmU38Rihiq0wypmz6GZSyZtNvJAByvyioA6OEOMJ+I0xnR4LkZkkiSFRASxGkLjUd5Ypwkb4RN8b2mKAwPQ3HtmwU7fFLr4GGDEwBRCf3Q2B0DMr0ehQYKhCbJVWjUUVFIfLWxQjSh2LHqjPIOVkulqBIb4T38ENYvC8iEwNE1MmIpAhkhibAtywddXv3SiJI/HhJ9i84LFLUSOS3hUwmh1d4oqXd1VA0zMFff0aDvh65/YDbe86EQWfE/nWZMNbXI676MEImW0eB1DTqkVEqVe3oF+lnnQrTY6JU9YXpFtDkYoxPjKVt35XLoI6V1u02+5RchpDYaEubcW/aJIIsXrwYkydPRmRkpDjpjRgxAopW1PMzZ6SwLsa10Rl0+DrlazQYKGAb6BPYBxOiOQ/VLr4dpdnQk9fAn/HtIJPS8Dj4BYa6RYgjw7iS30hIVLxYWvcboRK+OefxG6kQJpbaouPQ2vQbiYJPSBwCKMIrNIqPAUy7IkG0XmEorm5sNR0mZ/spGGUKeHkAAZEt/UD0Wi22fvmJEPUSR41FbP9BludoDNlnwhTsyP8SRf2TMKjvMMg1GnhPm4rS+nrEhwXDL9QTB9ZloTCjCmX5tWI5sT0fnr4qjJzXAyN7BOHTiEQkFqWhZs9eqVSub7hU+SR3L3BqLTDixlZ/fwMnWYsOXcmJrZtRVVmKOg8jKnuoMSh0EE5uz0d1YRXU2irEmc7Aa9hQ6/dQFIgJiAzwQKC3WhJH08+aovaYZLdtZ7oehVyBsVFjHdLVMoUC3uPGwZ1QKpUYcTH/hph2iCDvv/8+Fi1ahNTUVPztb3/DsmXL4OtmjsLuBOWqrjmzBoV1heJ+sEcwFvZeyEaonURFaQGyju1G7oEK4R1golngxvb6dkRBExgN79BYBArBI8YuYb0Mw9jXb6S2ukKk1FQWZXXYb8TkEwFFAIkj0TCq/eChUSAgMJT/lIzNSJBSuZTu7OOhhJ9ny2FibgqZpHsgIkppc1yw/xcpDcbTzx+jFy5t8XziiNHY++N3qKmsQN2QAYjp01+KMK6Xok+Co3ww48Z+qK/RouBMFYozq5CTUo76ah1+//oUhs6OR35CX5gOrUXVwcMiokLu6Qn0mSeJICk/A8NvcPjsdmNdHY5sXIsGfQNy+wIDwgbBUA8c/T0Xxro6JFbugf/UcZCp1VbvM5uiWqJAilOA2iJA6SkJPQzDMIz9qsPMmSPVsd63bx/uvvtuFkG6MXsK9uBwyWHRVsvVuDz5cmgorYL5U5QUZOPMju9hyt4rjNJMSmUbfDuioAqItvh2BEfEQ63x4L8Ew7gJVHKaltjeg1v4jVBKTXVxDhqp6lNlHuR0odQsVY78RmRV2TBWZaM+S0rHOXEwAGNve8f+X4ZxiUiQPD35UDQgyt+zhchBkySFpVJ0YezgliknJdmZOLZ5g2iPX3q1JQ2mKSqNBxJHjhFREuSXQSKILTx91OgxKEQsw+cYcWB9FlJ2FeDAukz0SYhHhXcg/OrPlsodMwboNQ3Y/DxQdgYoPgmE9YUjIQGEhJA6HyNKooBF4cNxdEsudA16eFfnILQ+DT7Tbm/xvsM5ldZ+IObSuHGjASWPxRiGYRxSIvfjjz/ulBUzzkl2VTbWZayz3L8k8RKEevGMYaeIHzl7W+T8N/ft8AymyhAxwvzQy+dP1DJnGMat/UZqS3LQWJ4j+Y3Ul1ofe8hckWGaQtVH6stFM72RIhAabJqiFh3NRoNRLQw9Yyb0s3pOVDxZ/Y247TlsBOIGnBPumpM8dqIQQbKOHkJ9dRU03q2X2SUUKjmGz42H0WjC6T2FCMlsQGpEX4Rm7JRK5ZIIQmVye04GTv8KHFkJTH/UZhW1g798KNpD5t4Mpco6CqOzqK0ox7HffxPGlyd71gn/gX4eg7BrbwFMDQ3oUbYTqogIePS37sNGvQFHcyURZGjcWRP6M5I5PRImdsm2Mo5Db9Tjl/RfRHtuj7lQytt9WdZhTHo9qn7+WbT95s2DTGm/dTsKvVaHLV+sEe3JV18MpZorXboz3X+PZ9pMtbYaK06tgBGS8e24qHHoH2x7hoZpm/iRvv07GHP3WV2AmJSeMMYOR0TvoQiO6gG/gGDO2WcYpkv9RsrOls8uyT6FoKie3NuMNVS1iFB5IrNGivSItiGCnP7tpLgN86yG2t9auMg+dhgFqaegUKkw4uJF5+3hoKgYhMTFoyQrE6l7d6L/5BkX/ItQVMrwOfEoyqyCoaAOVcFDoUvbjoqduxFyp0mKWhl8hSSCnPwJGPUXySukGYZGa6+troBSggw6HZRRgSgLy0ekdxSKduthMpoQ0JCLAG0+fKdd1SLShkrjavVGBHmrERfkJZm8UlQLmbiyH0i3xOy95wiM9Y5bt6PQNbjfd2ZswyIIIzAYDfjm1Deo0dWI+wl+CZgeN517pzPFD5UXvPrMRO9Rs1FZXSuqLcnZtJRhGDv4jUTGJyM8tjcC4weJYw/DWEEX24RvFHIrpIuE6GaVYfQ6A7JSJd+OHv2sIxUp+mPfT6tEu//k6fAJknxFzkfSmAlCBEnZvhV9J05t0x9EW1+DnoOBigI9ApWhaNAEojYvH7qcHKhjY4HIwWcNUvcBu94BZjxu9X6FQonkqVdb2l1BeX4uUnfvEO2qQQFAgwzDfEYhfXsxTDodYjPWi3KkvrNnt3jv/kwpGmd4fKAkkJzZJD0RNRTwCuqS7WUch0KmwMy4mZa2fVeugO+smZa2OyBXKjDm0lmWNuPesAjCCNZnrkdWdZZo+6n9cFnSZfatV+4G4kfSmLnw8PSWDOCqpfJ3DMMwDOM0kSC+4cjJr7cZCZJ+oBDaej089DWInTbG6rnclOMoz8+DUqPBwGktL+5t0WvYKOz98Xthopp15BC8Is+W67QBpXrtWf0NTmzbLASXhlojVB5jkRE3E/7p34qUGCGCEOPuAlbeAJz4EehzMRAzokUqWVdhNBrwx9f/E9sYP2go/ifbJR6Pyu+LahMQYCqFr64YXmNGQxXeUozcd1YEGRYfKD2Q9pt0S34nTLeDhK4AjwCHrVsZeHY/cxNo4jEg4sICLeMe8FUug8PFh7GrYJdFiV6avBTeKm/umTZSUpCFPd+9jrSVD8PYxPeDxA/PgQsw5IZXMGjqZUIAYRiGYRhnNUXVe0eg5Gx53Jgm5XHpov7E+lPiNkaWBc/kJKu3n/zjd3GbNGqcTTNUW6g8PNBv4hTRPvLbOvHZttDrdFj/wVs4vnWTeA29T+UB6Ms3o16tRLXcX6TEWIgYCAxYLLXX/d+5KBc7QD4nRRlnhBgUPWMsSupLoIEn6lOUMJmMCM/YbPFgaE51gw6nCqWS2MPiAoHaUiDvoPRkT6mfGIZhmM6BI0HcnILaAvyY9qPlPhkzRftEO3SbXEn8SN/+ve3Ij76zkDR6DgsfDMMwjMuUx61QNCmP63FuiFiSXYPy/FrITQYkjomx8rFqqKlBzvEjop08rn3mnX0nTcPRTetRmp2F4jOpCA8PbxFZsfmz/yIv5YQQFqZev0xUk9n+zVc4sG4DGht2oyRkEMIP7IaxoQFyj7PV08b/Hcg/BJSmAt8tA+Y8K8QRo8GA3DNHxUuiew7o1NLyJVkZ2Lfme9EeeclinGg8I9rDaiZD32iCF+oRWJ4CZVgYvIa3LHW7J6NMDCVig7wQ6qsBDtFnmYDw/oAvmxl3R8g4N6tKisKO84uzawQ2VRnTZmaKtjo+3i286Yx6A7JPpIt2bN8enBLj5nT/PZ5plXp9PVakrIDeJJVUHBo2FMPDuQZ9W8SP3d++hrSV/2oZ+TFoIYbe+CoGTVnMAgjDMIwDefvtt5GQkAAPDw+MHj0au3c3iRZoxgcffICJEyciMDBQLDNmzDjv67trJEihKcDiB9LUtPPklnQY6+sRVpeGoNnW/h3ph/YJcSE4Jg6Bke2bRPH08UXyuEmiffTXNdBrtVYCyO9ffIKsIweF6e/MW+5AbL+B4mJt7OIrEBoXAxl0KPU2okKrRv3+/ec+WO0FzH8d8I+VBJ6VNwKbnoWxMgd5BzeIhT6/s6guK8H6D94WUSsxffujz9iJ2FtI4wMgLKe3eE1k+QFQj/rNmwuZDfHl91Ml4nZi7xDpAUrnIZJbRo0w3UcE2VO4RyzUtu/KjajbvUcs1HYHKB39xLY9YhGp6YxbwyKIm0Ihpd+d/g7ljVL+aZR3lIgCYdomfpiaRH+YVN5W4geZEDIMwzCO4+uvv8Y999yDxx57DPv378fgwYMxe/ZsFBUV2Xz95s2bceWVV2LTpk3YsWMHYmNjMWvWLOTm5sKdIkFy9JLhadPyuNoGPTL3Zot2QowRmh49rN5KIgXRY+g57432MGT2xfD080NNWQl+/+Ij6LSN0NbXYfOn/8WZfbuF6DHl+mWI7J1seQ9FcEy4/Eoo1XLoDJnIC+iPog1nTUTNUPTEkk/Oiggm4Og3UHy5BAnVe+Hn6w1ZG2bdaba8JDsTZ/bvEeV8qd1UqKGxVM6Jo1jz2gui1G9gVLTY1gZjI46XHkdQWSxUdZ5QmrQITt0CKBU2DVEbdAbsSi8T7UlJoUBJqlQVhkqmJrXNY4VxPWSQIdI7UizUtu/KZVBFRYqF2m6BXIbAqAixUJtxbzgdxk3ZkrMFqRWpou2l9BI+ICo518u2RUleJs7s+A6mvAPN0l684dV3JpLHzGXhg2EYxol45ZVXsGzZMtx4443i/rvvvouffvoJH330ER588MEWr//iiy+s7v/3v//Ft99+i40bN+K6665Dt4YiIqoLRTO90Y+KSFpVhjn98yHoaurhrStH/HWXWL2VxIr80ymiHT9wcIdWTx4ik6+5GT+//YowSF3+6P1CfCCxgcSOqTfciviBQ1q8Lyq5LyJ69ED2ydMo81GhcPsBxDdNiSE8A4BZTwH9FgK734csdy/Ca08hPC0diPCXSuq2cgGYefgg9vz4rTBubQqJMv5h4VB7eArho7pUiuAIjIzCrFvvEo/vyt8FvVGPxKLhUMqUiGg4DoVJD99ps2yaUZIA0qgzIMLfA73DfIA//is9kTAR8HQv80p3QiFXYEL0BIesm6KRfCa2L33N1VEqlRi9oG2VqJjuD4sgbkhKWYoQQQhSnhcnLYa/xrrcHcPiB8MwjCui1Wqxb98+PPTQQ1ZVASjFhaI82kJdXR10Oh2CglovS9rY2CgWM1VVVeKWwqxdKtS6pggyk4GuipBSrYEJOkQFeIjvYNJqkbKO/D58EN9TBY8BA6y+W/bxoyIVxi80DL4hYR3+3mE9EzH6iutw9JcfUF9VKR4joWHc0msQ3jOx1c8dfvE85Ka9Ba02EznqRPTbuQs+k2xc2FGJ2YXvAPmHIdvzPpC9C9j6ElB0HKbpj5GyYXkpCTC7qRLNVimyRKlWi1QfSnWhaJXG2lpUFJwzW1WoVEgeOwFD51wiTFtpW/cW7IVXTSCCKqMApR4hx9dSLAr8Fl1q87tsSSkSz1MqjElbB5z4SdqW5IsumKog/k4mk2vtc04C9x33He93rkVnHudYBHEzSutLsSp1leX+9Ljp6Onf06Hb5EqRH979JMNTTnlhGIZxTkpKSmAwGFqYbNL9kydPtukzHnjgAURFRQnhpDWeffZZPPHEEy0eLy4uFkKMq6AsOYEAvR4G7yCkl9TCYNDD01gvUofKvv4RlboAoRGEXzauRTrRyd07oDfoEZTQq9VUo7YObJUBwZh4699QU1QoIkB8w8KFL8n5PtczIhp+ocGoyC1Eka8vjn23Fj36nEubaYEiAhj9CDyCVsPnwPvAsR/Q0GhAzYi7REQIiQnH1v+EM3sksSxx7CQkTZgCpVoj7ovyvBT9UVwoyvaSABIYHQuVxgPlJIJVVYnX/JH9B6JyBkIlUyOgMRPKxkrIhg5FBUWpNPs+1Q16bEkphMFgxMAQBap2fQGfmmIYvMNR7pXU4vW2+q6yslKsl8Q+pn37Hfddx+C+6zjcdx2Hfq+dBYsgboTWoMWKUyvQYGgQ9/sG9cW4qHGO3iyngcUPhmEY5rnnnsPy5cuFTwiZqrYGRZqQ70jTSBDyEgkNDUVAgGQw6hKU74NMqQQC41CZaYJCocTAXtHwKC5Ayh9pgO8IRCQGIa5fotXbKAKkLDMdSoUS/caMR1hY2J+6KCDBg/pOHhXVrveOnn8Rfv3gE2gNmSjMCsJwlcpmygmh12lx+NfPhCXe4OlPQLnpCXhnrINXdF9gyNU48tuvyNq/R3yniVddj14jxrT8EBLXEiWzU1tQqnFDnR6Rpb3hSaVyUzZCoVAg8rrr4GGjjzbvzYYRcvSJ9MPY5GjIv/iB4vYhH30TwiIi29d3LIK0C0f3HaVMrc9cL9oz42dCSR4wdsKk16P6119F23fWLOkY4EJ91xH0Wh22rVgr2hOWzoFS7RgbAFfsO2dBrVZ32mexCOIm0AwBlcItqpNmFEI8Q7AgcYGV+7u7wuIHwzBM9yEkJERcdBYWSj4XZuh+RMT5S42+9NJLQgTZsGEDBg0adN7XajQasTSHBrUuNbCtlfqpRh0mrBmpPG6AlwZ577+PUnWM8NhImNK3xXciLxBdQz08fH0R1qPnn/7ONB7pSN8ljx6PP775BrXFVSj07oP0lWuQfNv1Nl9Ln21oqJbWl3wDZIZa4PcXIdv+JgoNIdj/02rx3OhLl6L3qI5NEu0u2I2Y3AHwkHsisDEbvtXp8OjXD14D+rd4rdFowprDBaLfFwyJhiJ1nWRS6xkIWb8FtMFd2neMY/tODjnqDHVS287bYJLLYao9t+6OlMh1tf2OtlPb5Ds7crtdre+chc7sLxZB3IRdBbtwtPSoaGsUGlyefLm4dWeK8zKQvv07mPIPctoLwzBMN5opGj58uDA1XbhwoWXmje7feeedrb7vhRdewDPPPIN169ZhxIiOVTpxSaokf4sSWZClMkzD8eOo3n8EVVFDoAwIQHRSy8iK7KOHxG1c/0GQy1uWfLUX5MMxaMpk7Pj2RzSaspGysQxJN+sgU7Wc5aUol14Tl1jaGHQ5GvZsQfm27fjtj9dg8AlB74lT0X/y9A5vz56sfYjMHwlPbS0ijn8hPFeCfCuAH+8Gxt4JhPS2MkTNq6iHt0aJ6T09gK/flJ4Yei2gOmdOy3RPFDIFpsZOtbTtu3IFfKedNQm1UbK5OyJXKjD8oqmWNuPeOLX89PjjjwulrOnSp08fR2+Wy5FZlYn1GVK4HbGg1wIRCeLO4sfub17BmW8ftfL9ENVehizC0BtfwcDJi9j3g2EYxkWhNJUPPvgAn376KU6cOIHbb78dtbW1lmoxVPGlqXHq888/j0ceeURUj0lISEBBQYFYampq0O2pzhM3BSZJBKHKMJWrf0CVOhwyLx/4hHjBN8ijRXRp5lGpNG7cgI5VhelM+k+aBrWPBnpjIQrVkUhZLYX5N4dmu0Mi4sRiamhA4QsvInflGewp9EdNowmq4iLE7twHXWHH/E0KavJhOKyEQi9DUG0eAmoz4BkfAM9IFZCxDVh+FbD9TUDfCIPRhA+3nRHvu2hgODx+fxaoKwX8Y4HBV/6p/mBcA7quofE4LfaOzKb1KUNDxeIuUeEURRAaFyEWjsBgnD4SpH///iIstWl5I6btVGmr8M2pb2CE5KY7IWoC+gb3dcsuPG/kR//ZSBo1m4UPhmGYbsDll18uDEofffRRIWYMGTIEa9eutZilZmVlWQ2C33nnHWFmetlll1l9zmOPPSYmZLo11QXiJlNH5XGBOLUBtdv/QIXnMCh8vBHeo2X1uNLsTNSWl4vKKVFJjh9TUHWa3sOG4Njvu9CIfBxdUYSkS2ZC3kr+uKGqCvkP/wuNp0+jUKNCgb83FLpaDCwqhqmqAXn33ovoV18RF4htxmTCxnXPIYaiQPRAbP4eyPxjEPTkG0CYBtjxNpC2Edj3CZD+O/ZGXY/0Ii+EqPW4se5j6TmKBpj1NJWk6bzOYRiGYVrg9IoCiR4XyuFlWjdcWpmyEjU6aSaLqsBMjXO/+tgsfjAMw7gflPrSWvoLmZ42JSMjA24JTQicFUFSGyQRpEfWCZh0etRE94SMysPGeWFtxlphph7vFy9ek3lEigKJ6TtACCEX4kjxEaw5s0aMR/oH98f8XvPhq/bt1K8yYOpMpO0/iMaqDJR5TMemlz/H9IdubmHmmntoNxpefQuy4jJo/X2QGhUMpcmEIX37YFD5WuRtqoSuqAD5jz+B6BdfgNzL68IrpxK1f7yOk4d94WtUILyuGEHGMvjOnAWP5CTpNfNeANI2AZufhbE0DbFn7se7JjXCZDJo0uRSmd6ZTwARAzq1XxjnxWgyIrcmV7SjfaIhb1KquauhUtC6XGndqujoDnmCuBpGvQG5p7NFO7p3LKfEuDlOL4KcPn1alKkjh/axY8eKknRxcXGtvr6xsVEsTd3azfnAnVVb2FXqiq9LX4fsaunH7q/2x6W9LgUVoqeDrruIHxk7vwfyKG/5XOSH0Rz5MXI21BopxNeef0tX2X8Y54T3H8bZ9h0+lrkw9eWAnirGyXCymi72DQhOOQwjZKj1ihAX958Vvo9DmXuhVqjx5Lgn0T+kPzIPHxBvjx809IKrWJu+Fm8ffNty/3DxYSGq3DP8HgwJG9JpXyUqqQ/i+vfB6T2HoDWkIe9QBFI2bkfy9HMGpw2pp1Hx8MOQVdXBK64HzgzpC11eDgyBkVgXtQja6hTEjTiB2m0lqDluAp5/ATGPPXr+C0QSkra/gS1/7IBv5UJ46ORIKt4FhY8Pgm6S0q8s9JoKU9QQbPr8WcRUbICfvBG+ag8gOBGYdD8QM7zT+oNxfmg8vjN/p2hfmnipXUUQGI2o3S6Vgg5YvKjNJryuDJ2rjm2WvnNkr2jIwb4g7oxTiyCjR4/GJ598guTkZOTn5+OJJ57AxIkTcfToUfj62p5BIJGEXtccCottaJBKw7pDfefjFcexNXeraNNBdVrkNNSU14D+dXfKi3JQdGgtVMXHrB43KL2hSJyM2AEToVJ7oKKSBDJJJLMnrrD/MM4L7z+Ms+071dVStQ3GBamS/ECMXsEoLDdAadBBdfIoalRBgMYTeqUWh+r3kkYCrUGL9w6/hyf6PYSKwgLIFQrE9jt/1MKJ0hN459A7ok0GkJSOuzp1tZj9fuSPR7A0eSmu6nMVZKI+SktqtDVYl7EOW3K2oKC2AH4aP0yMnoglSUvgpbKO0CBfg2Fz56Mg9TSqSzJRp0nE/ne2Qp6bjbixw1C3/wDKvvgC8lotEBqMzLmzcOqPrajWAbvDhqE+pRz7jFfjac2/4Tm0Fo07SpG+bjMOq0Iw9f7b4KW2MWQ2GoAtL6D2wK84Ung9FEYFEor2w1dXhuDb72pRqpd+e+/tLsOKqnlQec/GmxeFIjIqFPCNoC/Q3r8e0w0I9WxHylUn0650r26CX6j7eiIyLiSCzJ0719KmUnUkisTHx2PFihW4+WbrEEczZHRGhmhNI0FiY2NFLWY/PynUs7vXd6aBwvaM7fDwlKIc5vecj4FhA+EWkR87vgPyD0F887P+MUa1D7z7zbKK/HAkzr7/MM4N7z+Ms+07FKnJuChnU2FqNWHitndNAWTaRtSGDRDVVap8coUAMiF6AvYW7kV6ZTo2b1ppibxQe3qdNyX3rYNvidnuSTGT8I/h/xD7H4khHx79UESIrEhZIVJllg1cBl+cm9zKr8nHj2d+xPrM9WgQkSoS9fp64XNGs+dPjX+qhcl7ZO8+iErugyz9cTRUH4XMeyT2f38aFR99DB+VSYgtDYNG4+e+Y2Hc+IOIEj0ZMxmB4RFY3CcMfSIGoLEsEOG//xOyQfXAoQoYf1yJfzX4YtrSmZg7IBIK+VmxorYE2Pgk6tMO4pe8y9Fo9EJQZS4Sq/bDa9w4+DYZwxJltVq8sfE0fj9VLO7/fVY/JPWJ/PN/Q8ZlUcqVmBI7xSHrlimV56rDuAlKtQrjLpvp6M1gnASnFkGaExAQgKSkJKSmprb6Go1GI5bmdHYtZmet71ynq8PK0ythMBnENg4PH47hEd07vLIoNx3p278V4kdTTGpfePebjeTRziF+uML+w7gGvP8wzrTv8HHMhamSPAEqlZKYMLBaul8fIVXiy1SmiNuLel6EUK9QrEr5Dqd2bUco/JE0evx5P/q3rN+QVZUFP7Ufbht8m6UChYfSA3cMuUN4g7x14C2cKDuBe7bcgwSvBMQExiCnJgcZlec8WuL84kRVu37B/US1u/cPv4+c6hw8sf0JvDTlJWgU58Z8tI6xi69AUfozMJnK0aDLhyGwH6p94gBtLs4EhyLPzw+9dv0EldEEeUAfXBwyFB7lgGxnGSq8qyGPjENZvxcRoXwGqppCqNLKsHDTf/GBUY7veyfjb6O8Mbh2O0wHvkB2WST2llyPfITAt6YYSTlr4BURieC7/478ygZkldUhu6wOx/KqsD2tBHoDRWHJ8I8ZSZg7kAUQhmEYR+FSIgiVqktLS8O1117r6E1xSmi25fvU71HRWGExWZqTMAfdFVcUPxiGYRjG2SJBiiCVx+1RnC5uazzCoTcZUOKVK2ark4OSEeQRhM1bv4O2pgaKsHDEnqc0rs6gw/KU5aJ9WdJlNk1QaQachJBPjn0i0l1Sq1KRXpduSY2hSZxLel2CoWFDLQJKjG8MEgMSce+We5FRlYEvT3yJGwdY+24ERkZjxMWXYvfqb6BUHofBwxdVhp7Q66MRoM1GcNY6yEx6qD1jERA0BajQwRxrUl+tQ3lBHdLgBegfgV/saXjjBDQl2fjbrs8hr5PDeFqN7aYoFDdeikpjLOqU3lCVnUHPM1/BJNfg7WFLcPiTw9AZWnrv9I3yw13TEtEnonMikxmGYZhuKIL885//xPz580UKTF5enihVp1AocOWVXD/dFpuzNyO1QoqS8VZ6i5xZGrx0Nwpz0pCx43ub4ofP2VK3LH4wDMMwzAWoljxBcvT+kBsNCCnKhl6pQo3eA1poUe1bIirLqeQqRPlEoU9REAwoQ31PHyjOppza4tfMX1FcV4xAj0DM6zmv1ddRdMl9I+/DtX2vxR9pf0DmKUO4d7jwDiHRxRb0/F1D78LTO58WEz/josYJkaYp/afMQGVxIVK2b4VCtxue6hNClKhvLINBpoPaKxiDZl6FwIhA+AR5wCdAI9J+jmedwr7jR1Gba4JHrR9KZRFQR4ZC49UAGEwAzTHVQfRRvcxDRHaEFP+EyPytMMjV+GTcjcgw+QMGI1QKOWICPREb5IX4YC9MSAxB7/DOrYjDuDaUMrYpe5NoU5qYPcfsJr0e1Rt/E23f6dNEekx3R6/VYfu360V73OKZIj2GcV+ceo/PyckRgkdpaanIYZ4wYQJ27twp2ow1KWUp54xQIcfipMXw1/h3q25i8YNhGIZhOt8YNbXRH2GVRVAb9KgLShAXRDplFXTqeiQFSiVeS7Iy4F8MlAHY7ZeBm406IY40p9HQKLw+CDI+bZqu0hphXmEYHz4eYWFhbUqvGh05WkSS0OQPpdS8NvU1KOTnKj1Q5Mi4y66CX0gYDq77CbrGalH8wjfYC76BKkT1jsHIhUlQqqTyvuQ78p+D/8Gm/E0AeZkGAgq9GgEVEQisiIKPjz/iC7zg2WCEst4AVWM5NDUZ0FQfhNxQiwp/T+Rf9STm9u2HuCAvIXyE+3mc8w9hmFYwR287AkOF49btKOoqKh29CYyT4NQiyPLlUiglc35K6kvEbIiZ6fHT0cO/h9uIH8mj50ClvvAgi2EYhmGYJpVNKrJF82htAKLLTkGpkKE6up+oVFLlKxl4JgYmitt9P68Wfh418R4oVlVhZ95OTIyZ2KI716StQVlDmYjymB0/u8u6+5aBt2BPwR6RFkORJ3N7WBuRUlnbgdNmIXncRCHgmIwmBMfEobKiUDyvUEhD4PKGclGphvxGqJrezPiZGB89Xgg8FF1LJqwHS3bioMmEvifrMOxANYIKtZAbTSgPUCJ7eAIuv/sdhAbF8K7FtAuFTCGqHZnbdkWhgM/kSZa2OyBXKjBk9iRLm3FvnFoEYS4MlayjGReaeSEov3Zs5NjuI35s/w4oOGz1OIsfDMMwDNMJfiBGHQwyFbIafDCoLFekcNT6xVLRFBR5ZImXxfnGIT81Bbknj0MuV6DfjJk4XrAGq9NWi6oxZr8O86SM2Qvk6j5XQ6XounBzina9qu9V+ODwB/j8+OfiYtJH7dPidWoPT0Ql9bXc9/DxsSrB++j2R4UAEqAJwAOjHsCAkHNlf6m9MHGhqLpHUSe/+fyGL/rmQ24wwVvpiWm9ZuOmPle1KNfLMG2BfjsR3hEOW7cqwjHrdhQUZRbRM9rRm8E4CSyCuDBUb/6HtB9QXC/N1oR5hgkTsaYDEleExQ+GYRiG6WIqMsVNrWckjA0K9KjKF5aklSZ/YbRuFkGivKOw6dO3RDt57AT0HToPP/z6q0jDpSiJsVHnJl4+OfqJSC3pE9QHU+O6vvzmvB7zRKnd7OpsfHnyS9w66NY2v5e288mdT4pKNCSAPD/peeF7Ygu6UL2izxW4PPlyVGmroDPqEKgJtErBYRiGYVwHFkFcGBp8HCs9JtqUc7skeQnUCim/1RUpyE5FJqW92Ir8GDAHyaNmc9oLwzAMw3QG5ZIIUq6OgEbXgLDqEmj9/NFgUEEPHWp8ShHsGYyy1DMoyjgDpUqFIbMvhpeHv5hw+ebUN8JHgzxD6HUkRlCVF+Ivg/4iUku6GjKSJOGD0ll+OvOTqIhHJXVbw2gwoCj3DAxGAz7I/QonSk/AW+WNJ8c/2aoA0hSaZOpufmuM4yCxsbC20GL4a4/fjBmT0Qh9gVQdShkRIdLHujtGvQGFGZIPUnhCFKfEuDksgrgoNHOxIXOD5f6liZcixDMErgiLHwzDMAxjZyqkSI98WTiiyvKgkgN14UmQkT+ATz0MSj1ifWJwYO2P4nV9JkyBl58kAFBUBE3E5FTn4J7N9wgfsn2F+8RzV/a50uIjYg+GhA0RRqm78nfhnUPv4OnxT7caoWE0GpC+cxW+0e1DimcNNEoNHh37aLfyUWNcSwTZlrfNMo63pwgCoxE1W6V1ByxeRLki6O4YjUYcWi995xk3XwY5OJLLnWERxAWpbKwUMzBGSDXoKQ+2eXk4lxc/Bs5F8shZHPnBMAzDMF0ogmQYghFdlgOlQo6aCKkSTKN/lbiNrPAWpqIUBUImo2Yo+vSxsY+JCAzyyyAjVIL8M0ggsTc3D7gZB4sO4mjJUaw8tbLVbaCLzh/kp3DYlAdPWQD+b/T/oV9wP7tvL8OYCdLYLgVtDxRBVArJvfAJdL/vzNiGRRAXrClOJ/hafa24nxiQKMrEuZ74QYanR6weZ/GDYRiGYezrCXKyIRgxpUegkstQ4xUF6IFy73zxnOpQoSUKxNPXr4VPxpvT3sS23G2izOeQ0CF2jQBpSqRPJG4ffDte2/+a8AahsdGIiBEtPEDeOvQWjioK4OUTiPtG3ofh4cMdsr0MY07nooqOjoDKYPvNnOlWfwilWoUJV8xx9GYwTgKLIC7G2oy1yK3JFW0y8rJ7+NyfgMUPhuk6DAYDdDoddzFz3lBg2kcaGhqES35bUalUULhJCUW3QdcAVOdTERgcrfbDiLJcKDzkqNR5gdxRczVn4FVpgr6gAiq1FwZMtX2xRCVzZ8TPgDNAF5NHSo5gY9ZGPLPrGdw04CZRNpdKj54sO4n/HPqPSCWmMdM9w+8RlW0YhmEY94RFEBfiQNEBS86tUqYULuWuUJZNiB/bvwUKj1o9btT4wZcMTznthWH+VJWogoICVFRUcC8yF9xXSAiprq5udxWxgIAARJB5notXH2POUpkjbrQKbxhqdPBtrIUuIAo6KKFQAlmy00jIlGaqEwYPs3iBODt3DL0D9fp6bM/bjvcPv4/Pjn8GtVwtKroQfho/PDjyQQwMHejoTWUYhmEcCIsgLkJeTZ5wPjdzUc+LHFZbvK2w+MEwdvidnRVAwsLC4OXlxRepzHlFEL1eD6VS2eb9hN5TV1eHoqIicT8yMpJ7uDtQkSFuKjVRiC3LgUopR33sIMhkcmhCZZAbjAjNl0PhoUCf8ZPhKqjkKjww6gExXlqRskKk6TSgASqFCpNjJuPK3pcjd8cGHMAhDJy6FEqV61bUY7pHivvvOb+L9qSYSUJ0tBcmvR41W6RqTj6TJ4v0mO6OXqvDzlW/ifaYhdNEegzjvnT/Pb4bUKerEydzg8kg7o8MHync0F1R/PAbMA9JI2ew4SnDdFIKjFkACQ4O5j5lOl0EITw9PcUtCSG0r3FqTDegJFXc5MkjEFuSBZVChpqQXuIxY1AdgnMBtUmJwMgohPd0jM9HR6F0l/m95mNej3kifVhn1CHaJ1qk7uh1WqRXSj4nDOMMlDaUOmzd+hLHrdtR1JRKJs4MwyKIk0NO5t+e/haV2kpxP8YnBrMSzjm0OxMFWaclw1MWPxjGLpg9QCgChGG6EvM+RvsciyDdgJJT4ua0MQqxpfuhVshRpQwRpqjVfiUI3iOlwvQePd5lo8uoTG6cX5zVY3K5ArEjL7a0GcbRgt24qHGWtn1XLof3+PGWtjtAXlgDp53tbzf5zkzrsAji5GzK2oQzlWdE20flgyXJS+waLtcWWPxgGMfiqhcpjOvA+1j3FEGOVAZgakUh5H7eqGlUAwog33ACvuWASqNCz6HWFVZcHblCgaiEZEdvBsNYhA+KUnIEMrkc6hjHrNtRyJUKRCfHO3ozGCfBua6mGStOlJ7Atrxtoi2HHJclXQY/tXWJOkeSn5mCrJ3fA4XHbKa9JI+ayfm2DMPYZMqUKRgyZAhee+21btFDGRkZ6NGjBw4cOCC+F8M4LQ1VojKM0WRCWZ4OMhihjUoGFAp4+6tRceY0fAEE9UiAl3+Ao7eWYRiGYTodFkGclJL6EqxOW225PzNhJuL9nEO9ZPGDYRjGmtjYWOTn5yMkJIS7hnFuik+Km1pNGMJKCqGQy9AQM0A8FhjtBcWuctFOHiGFjXcnTEYjSgqyRDskIk7MhjOMw/ZHkwnF9cWiHeoZateIO+ERVSStWxlm33U7CqqOVpIleQKFxIVzSoybwyKIE9JoaMTXKV+LW2JA8ACMjhjtxOJHAPwGzkXyyBkc+cEwjMNMYmkQ56g8X/LJoBKyDOP0FBwWN4WeiYgtzRJ+ICWaaMAAGLwK4VVFofIyDBgxCd0Ng0GPM398K9qBC++CUs7VYRgH7o8mA7bkSBVaLk28FEqZHS/LDAbUbN4smgGLFwFuUB3GqDdg/y/Sd55x82WQq1kEdWf4r+9kkDK7OnW1iAQhwrzChMu5IxVaEj92ff0cslY/bSWAkPjhM+JKjLzpZfQfN48FEIZh2j0rc//99yMoKEgICI8//rjluVdeeQUDBw6Et7e3iLL461//ipqaGsvzn3zyCQICAvDDDz+gX79+0Gg0yMrKQkJCAp5++mlcd9118PHxQXx8vHhNcXExFixYIB4bNGgQ9u7da7Ut3377Lfr37y8+hz7j5ZdftnqeHvv3v/+Nm266Cb6+voiLi8P7779vlQ5Dx+mDBw9aHjt27Bguvvhi+Pn5ifdMnDgRaWlpvJcwjuXsefyUPhZxJVmQK9WoaJQqABWW7Be3pmh/ePpQUkz3Q+kdJBaGcQYozd1Rqe4Kfz+xuBOefn5iYRgWQZyM7XnbcaLshGh7KDywNGkp1Aq104kfviOvYvGDYZg/xaeffipEjl27duGFF17Ak08+ifXr14vnKKLjjTfeEEICve63334TgklT6urq8Pzzz+O///2veB2VbyVeffVVjB8/XvhzXHTRRbj22muFKHLNNddg//796NWrl7hPojOxb98+LF26FFdccQWOHDkixJhHHnlECC1NIWFkxIgR4nNJlLn99tuRkpJi87vl5uZi0qRJQlShbad1kIBCJWoZxmHQPp8vRYKcOWOAwmhAfWQ/QKGEl78aJaelc71vn4Ru+UdSqtQYPu9GsVCbYRy6P8qVmJ0wWyz2LnogUyrhN2eOWKjtDijVKky++iKxUJtxb9xjr3cRqArMxqyNlvsLExci2DPY7tuRl5GC7J3fAUXHrR4n8cN/0DwkjZjOgweGcVLe3pSKqgapdK498fNQ4Y6pie16D0VkPPbYY6Ldu3dvvPXWW9i4cSNmzpyJv//975bXmaM7brvtNvznP/+xPE7lWun+4MGDrT533rx5+Mtf/iLajz76KN555x2MHDkSS5YsEY898MADGDt2LAoLC0UECkWdTJ8+XQgfRFJSEo4fP44XX3wRN9xwg9Xnkvhh/gwSWzZt2oTk5JbVJt5++234+/tj+fLlUKlUls9lGIdSmgY0VMAg10CbJkWc6nuNoPI/8A+pR9qpChjlQNxA698UwzAMw3QnWARxEiobK/HtqW9hgjQzOTlmMpKD7FvGjcUPhnF9SACpqneNaAMSQZoSGRmJoqIi0d6wYQOeffZZnDx5ElVVVSKCoqGhQUR/eHl5ideo1eoWn9H8c8PDw8UtpdY0f4zWRSLIiRMnRKpMUyiShCrXkNcI+X00/1xKfaH3mre3OZQWQ+kvZgGEYZyCnN3iptS/H3oWnoFSLkeZZzSgBXQNadAZ9agIAxKCezl6SxmGYRimy2ARxAnQGXVYkbICdfo6cT8xIFGIIPYUP7J2fAtZsZSGY4YjPxjG9aCIDFdZb3OBgIQF8gkhfw3y0qB0k2eeeUZ4hmzbtg0333wztFqtRQTx9PS06ZfU9HPNz9t6jNbVGdtrC9o2hnE6sneJm9PV0QioPQ2TbzCqGlSAzISS7KPQG/UojQJ6+vdEd0Sv0+LY1u9Eu//ERRzV6kSQ4EzRffaEjt+0ThLYHWGqTb+3A0UHRHto2FC7psSY9HrU7Zc8gLyGDWt3Soyj+64j6LU6HNm8R7QHThnpsJQYV+w7e0OTT0qlsks9MVkEcQLWpq9FXm2eaAdqArGo9yK7GKE2FT+aro3FD4ZxXdqbkuKMkH8GDRLIg8M8QFixYkWXra9v3774448/rB6j+5S+Yo4CaS8UNUJeJjTQ4WgQxinQ1gHZUiTImZM6xAKoThwvysT6BFYhL60IBiWgjAtBgEcAuisNpbmO3gSmGWR6nZOTY/Fpshe0PjrXVFdXO6QAAa3fUy8J5ll1WfbdBvruZycU5FlZIiXOlfquI9A2ayIkU9SsnGyHbbcr9p0joAkvihCmqN+ugEUQB7OvcB/2F0lKLJXGWpq8FJ5KT8eIHx7k+XERkoZP49kRhmEcRmJiohAP3nzzTcyfP18IEu+++26Xre/ee+8VniFPPfUULr/8cuzYsUP4kzT1H2kvd955p9h+Mlt96KGHhD/Izp07MWrUKJseIgzT5WRtBwxa6Hwi4XlMMvRtjBgIysJVyDJFVGp5ONAzxPWF1NaQyxWIHjrb0macIwKEBBC64AkNDbXrRSFdjFKqZVfPOJ9v/fS7I1Ryld2/u+ls5I1M1f51O7rvOtzfjWf7W2Pf/nb1vrN3/1DUL1X1S09PF55xXRExwyKIA8mtycUv6b9Y7lMp3AjviC5bX176SWTt/I7FD4ZhnBoyOiWzUqr8QgICVVkhfxCq6NIVDBs2TESakIkqCSE080CVapqaoraX4OBgURXmvvvuw+TJk0VEyZAhQ4TXCMM4hFO/ipuM+iSEVO+DzisYtQYfyORGVBSehNagFakwYwO6sQiiUCAmcYCjN4NpAgnedNFDAoi90wid4WLUEw5MnfwT/e0MfdcRnCFV1VX7zt5/J4qizczMFIKIh4dHp6+DRRAHUaurFT4gBpNB3B8VMQqDQlsa/HUGLH4wDONsbN68ucVjq1atsrT/8Y9/iKUpVOrWDAkUtkQK8hNpTvMQa6o20/yxxYsXi6U1bH0umZ+e7zMpJWbdunWtfibD2I36ciB9i2imHjWKy66KftNFKoy3XzHKsmtQr9ChKgToF9yP/zCM3eGLQYZhmtLVfinsxuIAjCYjvjn1Daq0VeJ+nG8cZsbP7PT15J45gZ1fPYPsH5+xMj01egTCd9TVGHnjy+g3Zg6nvjAMwzBMd+bot4BRD71fEpRHTsIEGbRBktihbzgpDBoLovSQKRRICuy+pZxNRiPKinLFQm2GaU2Qqaio6NLOCQkJEaH+9NujpamI/uGHH4oUgF69emHZsmVdYhgr0mH0emmxsxeLQ/tbqxOL+TtTxCalqfbr1w/9+/fH/fff327TdFfDXv2dYWPyyAz1/7Rp0xAQ4Dj/KRZBHMDGrI3IqJJ2DB+VDy5LuqxTHaHN4kfOmn9DVnzShvjxEosfDMMwDOMuhqiHlotmypkoqLT1KIocBpPMA3J5LaqKU6E1alEYD/QK6AUPZeeHHTsLBoMep7csFwu1GcbR0ISoeVKUoAv1Rx55BFu3bkVqaioKCwvx/vvvd8m6DVVVYnEbTCbUVlSJhdpEYGAgli9fjuPHjwtT9u3bt+Ozzz5z9JZ2e1599VUh8jkSFkHszLHSY9iet/1s58uxNGkpfNW+XS5++I2+hsUPhmEYhnE39n4k0mGMnlEo3yaNDaqTZ4jZQC+fTHG/MVyDRm8ZBoYMRHdH4eEjFsb5oNnhBp2hy5e2RD689NJLGDp0qKgS9sUXX1gev/rqqzFixAiR7njRRRehoKBAPE6z3jSr/dhjj2H48OHC4Pvnn3+2vO+HH34QlcjofRRtYEYuk4vFzDfffINLLrkEERER4jd622234auvvkJXYJLJ0GDSoUHf0KWLM/W3TK4QixlaZ8+eUklw8p0g767zRTD8aS8QraHLF2fqb1scO3ZMpD8/+OCDcCTsCWJHiuuK8UPqD5b7sxNmI9aPitT9efEjexcZnp5sVu0lEAGDL0LvYVM55YVhGIZh3I38Q8B+aVYzp2gA9DXbkR/cB0plAEzGRlQWHhLPnY6UZoNHhI9Ad0apUmPE/L84ejOYVmjUGzHv9a1d3j8/3z0RHqrzVwciAeLAgQM4c+aMuCgkU2vyfnrttdeEiSvx3HPP4fHHH7dUL6usrBQXgU888QTWrl2Lu+++G/PmzUNRURFuvPFGEd1BaRcU2VFaWirWEaCxTgfIyspCfHy85T6tkx7rbGjdBl9PXPljxwzHTVRWiq61ZfTf+c09V85fecEIM7v0t1wOv5DW0y/ogp9EqDVr1qArMOiM+PqZPSIK5WzXtbs0cVu4/OGRUKodv3/bglK7KMWLUr7IMN6RsAhiJxoNjfg65WsRckoMChmEkREj/9RnsvjBMAzDMIxNik4Aa/4BmAxo9BmLgm/2ioF3aZ9LEKiUw9MrFRXVDVAF+yE3KBeeSi/0Ce7DnckwAG655RbRDxQlQBXKfv/9d3GR+OWXX+Lzzz9HQ0ODWMj7wAxFEixatEi0x44di7S0NNGm8uh08UgXiMTNN9+Mu+66i/vZifq7qqoK8+fPF1EMJAp0d25xUH+TgEKfQVEjXRVx01ZYBLEDFJa06vQqlDZIqli4Vzgu7nlxh52whfix81vISlJaRH4EDr4YvYdPg0LJf1qGYRiG6fY0VAGVOYCuHtDVSh4gBUfOmqHqYAxMRvqGOtQ1aHG850x4eQZALm9EdbFU3ah2YCDFxWN4+HCo5CpHfxvGjdEo5SJKwx7raS80Zt+2bRveeOMN7NixA2FhYSIFgEqrWz5Xo7GM7WmW22AwtPpZrREXF2e5uCToQpEe6wo0Co2I0ujqMq+0Hmftb6K6uhpz5szBggULcM8996CrUKjkIkqjq0vk0nqctb+3bNkiIpveeust0QckPpH4smfPHksEir1gTxA7sC13G06WS3m4HgoPXJ58OVSK9g80cs8cw84vn5Y8P0pSrMQP/9HXYtRNr6DP6FksgDAMwzBMd6e6EPjpXuCDacCKa4Hvb5UiP359GDi8XAggprgJyDsWh9JT6aj0joA+egI0SgU0Hodh0GsRFBOLXZpT4uMmxnT9xaejMej1OLLlO7FQm3Eu6OKJ0lS6emnLhefHH39sESEozH/ixIkoLy+Hr68vgoODodVq8d5777Xpe9Gs+eHDh3HypHQt8NFHH4n308VwjbZGLGYfByrVTheflJpBj1EqwhVXXIHOhj7bWFMLVb1eiBSUrtJVizP1d21FtVjM/V1TUyMEEFr+9a9/oSuhfqA0la5enKW/bUHryszMFOsl0cXPz0+07S2AEBwu0MWkVaRhU/Ym0aacuUW9FyHQI7Dd4kf2zu8gKzllHfnhGYTAQRdx5AfDMAzDuBNVecDKG4G6Eum+dyig9gFUnoDKC/AOgTFhJgqW/468bVtQI1Pj2MDrEeOphqd3ESryjopc9MApQ1GSvQveKm8RCdLdMZmMqCtKt7QZpjVolpuMI2tra8XsOM1WR0dH43//+x+Sk5PFheKMGTOQm5t7wU6kCzy6MLz00kuhVqvFBTe9nzCnyXvD25KeQCkD5NFATJkyBX/5S9f42Jh05gtVad3dvr+FMenZ70wiiEyG119/Hbt37xbr/e6778RTS5YswcMPP4zujMFO+7czIzM5ujh0F0NhNv7+/sLMhdSmzoDqR5MJDIUKyeWtB9NUNFTg/SPvo15fL+5PjZ2KSTGTOiR+WK2fxQ+Xpq37D8NcaP8hpZ3K6fXo0UPkajLM+fgzIbiUG9zavtYV51lXxNwPNJtGLvpdhl4LrLgOKD0NBPUE5jwHBFuXGmw4dQo5L7yMkpOnUWNQYufwvyLSLxReno0w1P8EbV0N+k+ZgV/DT2J3wW7M7zUftw66Fd39vGg0GJCdekS0YxMHQu5gY77OwNXHFOc7tnQ1XZ2W0Jb1aw3SRblaobbrNtC6TWcFAZm6/et2dN91uL/rG0Vb7XkutcMR2+Fqfecsx4aKigpR1rgzxhscCdJF6Iw6rDi1wiKAJAUmYWJ020JNOfKDYRiGYRib7P1QEkA8g2C65C2cafBG+vFC1DbqIDudAu+tG+F9YBcadQaUe4fjyIDrEOHtD0+NETL9JiGABEZGIWT8YOzeJlWOmdtjrlt0Noke8clDHL0ZDCOgC2CNsv1+GZ21bpnGMet2aH978YQRI8EiSBcpfD+f+Rn5tfnifpBHEBYmLryg2nde8YMMT4dNZb8PhmEYJ4dKv3399df49ddf4exQNFFSUpIoC+gOjvjdIg3GXPJ28F14alU2MnLLMCjzEEam7kFYVaF4rlauxvHeF0MXNhgxnh7wUDdCjk2orSyCp58/Zi67E6+m/Ee8dnz0eMT6xjr0azEMwzCMPXG9uDkXYF/hPhw867pOTutLk5bCU+nZ6utzUo9i55dPIWfNc1apLyR++I+5DqNufBl9Rs1kAYRhGMYFwjcfeeQRPPbYY5bHKM+YBAZKkfD29saQIUNECbrm4jm5sEdGRsLT01Pk4p4+fdrqNWVlZbj66qtFCCh9FpWhI1O380F5vq+99prVev75z3+Kz9i8ebPI36X7DzzwQKf1AdOF7HgbMGhR4j8Ay7b4IHTLWvzj51ex4OgGBMm8UBE9GenDbkfa+IfgEz8a4T6e8PMvhKFhDWrLC+Hp64dZf7kLxxpTRRqMXCbH1X2udps/mcloRGVZsViozTAO3R8pLcKoF4u93QlEOoxeLy3d2xnBur91erG4y3dmWocjQTqZ7OpsrM1Ya7l/Sa9LEO4d3qr4kbPrO8hKT3PkB8MwDjPH+nHNT3jj/Y9RUVWNAD9f/O3WGzH/4otECTR7RSPQxbgj6Ox1U0QFCQxmUzsiKChImKz16dNHrGvNmjW48cYbRQ7/7NmzxWteeOEFYU726aefivxXElLouePHj1tyYUkAyc/Px/r166HT6cRn3Hrrrfjyyy/b/Lem1//888/YtGkThg8fbvnce++9F8eOHUP//v07rS+YTobK3p5aC63BhKeyx+GK7R8jwqBBXexsFPrEQ+btA7m3N9RyOVQmEzw8SwHjEVTmZYi3UwrMjGV3oNETeHPTm+IxilKN9XOfKBCDQY+TG6VImuEL74JS7pjjDsOYqdJWidtATfuKJnQGhipp3YpA+6/bIVB1mPJK0fQLCRTGqIz7wpEgnQiVuFp5aiUMJqlu8ujI0RgQMqDF68iUa+cXTyL35+eFAGLG6BnMkR8Mw9iNwsJCDJ8wDXe9swanE5eibPw/xC3dp8fp+a6A3O7vvPNO/P3vf0dISIhFCDh69Cjmzp0LHx8fhIeH49prr0VJSYnV+/72t7/h/vvvF8JCREQEHn/8cavPpvrzCxYsEJ9BYsTSpUutvge9niIx/vvf/1qZbVG6IpWDu/jii+Hl5YW+fftix44dSE1NFeulCI5x48YhLS3tvN9t+fLlmD9/fovvS67p9Jm9evXC3XffjUGDBonycATNSFG0BpXno22n5z777DPk5eVh1apV4jUnTpzA2rVrxXaPHj0aEyZMwJtvvinWR6+7EI2NjaIvfvvtN/z+++8WAYQgkzESbeizGCeFohZ+fwlGE7CxdhAmb9oElc8I5MfMRU3kQCjDI+AXG4zIRBOCI09BblqFqsIfUVWcAZlcjsEz52L+Pf8Hk48aT+x4ApWNlUjwS8DVfd0nCsSMXOUhFoZxBuRn/zkEEgHcTAig4yEtDMN7QSdhNBnx7elvUa2tFvfjfeMxM26mTfEj7+cXWoofY6/H6Js47YVhGPtAUQGzFy5FUf8roBiyAApPyWWbbuk+PU7P0+u6Aop4oKiIP/74A++++65w/J42bZoo2bZ3715xwU/iBV24N38fCRK7du0S0RNPPvmkiIwwV0kgEYHSRrZs2SIeP3PmDC6//HKrzyBh49tvvxVpKgcPSqmLxFNPPYXrrrtOPEZRG1dddZUoTfjQQw+JbSKxgsSb80HCxvm8NegzNm7ciJSUFEyaJFULI/fzgoICkQJjhqqMkNhBQgxBt5QC0/Sz6fVUDYL64nxQysxFF10kokooBYbK3zVn1KhR2Lp163k/h3Egp36BqfAoCquBmm0GVEXMQqN/HDTREegzNRrJoytg0v6IzAOfIe/kH2ioroBK44E+4yfjsn89heEXLURGTSbu3XwvMioz4K/xx8NjHhYVKdwJpUqNkQvvEAu1GcaRkPge4BEgFntXCaH1KQMDxeIuFUpI/KAIEFpYCGE4HaaTWJ+5HhlVUsipr9oXlyVdBoVcYRE/cnd9byPtJRiBQy5G0rCp3aJMG8MwrgOlwJT6J0MdEmfzeXq81D8JP/30My65xDqyoTPo3bu3EDHMPP3000IA+fe//215jOrOx8bG4tSpU8K8k6AoCbPfBn3GW2+9JUSFmTNnitsjR44IUYHeR1BEBaV47NmzByNHjrSkwNDjVNu+KZReYhZdyCNj7NixlrQUgiI46DWtQUIOlW2Liopq8Rw9Hh0dLSIyKM3oP//5j9hmggQQgqJfmkL3zc/RLaXPNIXK61FEjPk1rUHijq+vrxBBKOrDFrTNmZmZ5/0cxkHUlgLbXkNNnQ6HdvREbeBkGOnCqWcoIhILcPL3FdA1NoiXKpRKxPYfhJ5DRyCm30Ao1WoU1BbgfwffwbqMdSJSNdQrFI+PfRwR3hH8J2UYhmHcEo4E6QSOlhzFzvydoq2QKbAkaQl81D5ti/wYOYMFEIZh7A55gCB56vlflDQVr733UZesv2k6BnHo0CHhU0FpLOaFojGIpikoJII0hYxEi4qKLCkjJH6YBRCiX79+IoKCnjMTHx/fQgBp/tlmQWLgwIFWj5HxadXZPOrm1NdLJdHNKTZNIRGCIkxIjHnmmWdwzz33iKgMezBr1izU1tZaCUzNITPWuro6u2wP0840mPWPor6yGCd3BqDQdy4MHgHwjDCgsX4NDm35EZW1ZdD6K6Ga2Bte101AybhAbNek4O2j7+DOjXdi2a/L8HP6z0IAoTTd16e+jjg/2+InwzBSlASJ2l0JpYJmZEiTp02hxyiFkqIBKXXTHXBkf1OUJfUzLTRhQtGfNFnRnXFkf2/evFmMN8x9Tot57GRvOBLkT1JUV4Qf0n6w3J+dMBsorMDOHz6CrDTVOvLDK0SK/Bg6hYUPhmEcCpmgmlNgWkPh5Y/KKinFr7OhlJbmKRvkpfH888+3eC0JHWZUKlWLkzmlwfyZddv6bHN4sK3HWltfcHCweE15eXmL5yhtJTExUbTppE+izLPPPisGu+RtQlD6T9PvSvfNg2B6jVnsMaPX60Xqj/n9rTF9+nTcddddIlWI0pvIgLU59Dm2hCHGgVD1gh1vovHMH0j9wxPHPa+BVu0Lo8cJ5BYdRr2xHloPILMfUB5RDsiyABuWNVQBZlDoIFGpbmDoOVHPHTHo9Tix82fR7jtmHlfdYxwKpUeSnyDhrfIW5w/ysqLISIoeJEPtrly3sbZWtMlQ2R1SYug711ZKYxovPx/xnQcPHiwmJ+hcT+f2xYsXi0jNf/zjH47e3G5LcnKyVSqyo3AJEeTtt9/Giy++KEJ+aWclMzjKX7Y3pFRdd/212LBtLQYMGIRjKUcw6NrhmDR7EhRKBWKNQdBv+Al5ZWksfjAM49RQFZji+qrzCiGGukr4+/naZXuGDRsmfDqopCuleXQEMh7Nzs4WizkahFJAaMaDIkK6GvI4ofXQOin64nzQYMs820QGrSRkUDqPWfSgaBPy+rj99tvFfUrNoe+xb98+SxQNmZzS55B3yIWg7fnhhx+EEELQebQpZEpL6UiMk6CrBzY9g5q9PyJldwSOei9FvaIB9cYNqG0ohkluRFEcUDc0BLGB0eir8oFKrhJim1KmhFKuhJ/aDwn+CUIAoTZDF0FG1OaftrQZJxT+9FJqV5ei9LigIehLL72En376SUTRUQomVdEi6JY8nSitks4zH374oTh+06w3Hb8pbZIqgJGIQYLzvHnzxPvo+EtplnSxPWfOHMt6tEatuPWGJM5TiiMZX9sjUtDY2AiTVgsoFO0WQYSIotfDqFRe8L0yjeaCr7FLf1OJ3EbtuX1NJhNG6GZoHXSt11WCkFSiVytuSZA1GQ1dsi7yO3KK/nZynF4E+frrr0XYMBnn0UCPHPQpP5v+QM3zo7sSOhhdtGQ2gib6I+rheIT5R6KsrhJ5+dlYvWo5pvdOxgytP+RN5A+O/GAYxlmhMrhUBQZDpItim5zahL//9Sa7bM8dd9yBDz74AFdeeaWl+gsZmFLFEqqI0pZyvWQUSukrdBKncwVFSvz1r3/F5MmTz2tW2pnQ+YnMUanyjRmK+KD1U2UYEj6oRO3nn3+Od955RzxPgxV6Pc3+kc+JuUQu+XQsXLjQIvDQwGLZsmXifEglcsmk9YorrrDpQdJa/1C1GapUQ4Mw8lMxQ6ao5B3SnWjvBMrKlStFv9Ngj/4OFJVkHuDZDYMOSN2Aui1vIXd3GVLKZiLXrwca9UegNeSjwaMODV4m+E4fjHum3iIqvLjDDG5nIZcrENZvgqXNOBkkgLwr/X26lNu2ASrP876EflcHDhwQ5tp0/KYKWiTS07nFHDX33HPPiYpjdEwm6MKQ0iqfeOIJYe5NF4x0DKEoPvKTouMsCeXvv/8+SktLxXu8lOcuwu2NTKFA5g03dvgYYoIJMqtpX9v0WPU9ZDbSRO3e3zIZNN5n+7vJd6ZjPk0QUOotmYjTuKErIAHk8/v/Jtp0Du6qY/e1L7wBlVrjFPu3LaifaeKLxnX0vq7qb5cXQV555RUx6DOb0dEfgpQrMsx78MEH7bINpAqSABL1jzh4RHuIUla1plr4yTWICPVCYIABySfyoejhL1xWWPxgGMbZmX/xRXj8uZdRVJJl0xxVW5KFsMpTuOgi+1wE0oU8VYqhmQSKWiCxgLw76MKfZrfbAp3UV69eLVI/qPIKvY/e3zzqoSu5+eabxYCCBguU003QTAud5HNyckQuLHmd/O9//7OqWkPCD73u1ltvFREfNBNIg4ym/iJffPGFED4ovYW+G4Xt2kptOR9Tp04VsziUemQWQnbu3Cm297LLLkN3ob0TKNu3bxcCHAlWVCb5yy+/FALU/v37MWBAy1L3nUZDFUwVWajPOYHSPVtReTQTBWVByDcMQJVKDb2mEAbtNuhVOjRoGqAcEI1rr7wbyeFdH9nUHSET+h79Lxw5xTC33HKL6ISePXuK8wmVFqeLRDo2kIhN/lC0kPeBGTpeL1q0yBK9Z/azomMsXTyaIxLpPEHnKTpneVBUigOgdcs9PJxGRLVbf3u3FL9oPeRLRmm511xzjagcRxMM3Zlb7NDftiDxg8ZCND6iWxJRaB3NKwHC3UUQCsWh0F8qT2iGBn40m2UuG2gPKAWGIkBIACHC6jzgZ6pEmIikNGBonRo+GhNO5JRg7BX3secHwzBODynw61atEGVwqQoMmaCSBwilwFAECAkg9HxbIjDaS2thvjT7ToOP9ryPIhuaEhcXJ4SQ1qBZDVqaQ4JAU2gw0Pwx8u9o/lhzaBBAM0mUU2w+d1GEBy3ngwZnVO6Xltag6BgaoLQHW8Zk9D1osGeGBIL77rtPCDTdhfZOoLz++utCMKN+ICgqhkosk0hkngVrK989+CA8VSqRbmE0SGkXYr8x0GKEySADVZ42mmiRw2hSQC+TwQA9TKYAmNAAyLNgotfIDWjw0kLZNwwXL7gBw3qP66QeYhgnhAQBitKwx3raCR2jKcqPhGe6BiExlVIAHn30UctrNE3SPujc2VqJeWcRHihNhaI0OpzaodeL9NW2pMO4Qn+TITuJHzTh0BUiCKWpUJSGOR2Gqnl1VTqMs/a3n9+51MyYmBgx+UARJCyCNKOkpER0sK2ygSdPnrTZuTR72NTV1+ziT3nT7TXPM0MeIJQCQxEgYXWeiNPrYJDLYYQMSfUKKIwarA7RY8Nrf6DkBclwq6PrYro/tG+IXEreR5g/uf+Y2+alvdBJbu/Wjfjp55/x+nsfC7NU8gq5+6834qJ588RJriOf6+5Q6d8ff/zRKfvOvE3mW5psoEgHSsc53/aa9zFb51JnO5Z1ZAKFHqfIkaZQ5Ehzka0t443C4hJ4NDPwvSAm8Z8UYC4zQOulAHr4IWZQX0wdtwhRQbFO2deudl40GY2orZH+Tt4+fpC1McrMmXH1MYXVeYwesFdkRLNjYfPjHwmmJJiTkEwXaa+++qoowU6VvkiQpt/+e++9Z3lv889pejtmzBgcPnxYGGJTJCD5LNBxSlwMk1J61sDYevNsb1enYjRCRseqDvwO6DJXptNB3sZj3YW+h936W6+3RIURlHZLUafkZUGv+f7770VabVf1u0WgkMlbGL13Js7S36Zm25Gfny+u4+mcXF1dLSJTb7rpJpvba2vc0ZnHOaeOBOkIFMpKuUrNKS4uFmE9HYFMUMMDpJxrvbceqCqBHDr4GzxQ5BWGg2TML5eh/wBTC/d+hmkO/YAp9Jx+2G0N82cYW/sPicR0n2ZjaOko8+bOFYutWR6m/dDsBhmaOlv/mfeZpjM1dAwyR0acb3vpOdrXKM+3+cCNBjKuPoFCviG2Xk+Pt3e8IZOrIJOrxUWCGNbJpAsGyp6nlFkTLQoZoFQAGjXgq4Yq3Af+MeEICY9EZFgPhPtGnrso0qPbjy3sdV7U63VI2/SpaPeaej2Uyq67CLEXrj6mIH+jzjiPddYxsel2kVk0pSlSZBkd1+mYQKkCdKFHF4rTpk0TIf1Nt93WbWBgoPBJID8mMtCmlE+qJkbrKKsvE6/zV/mLbaBS5VSqlS5C6e9K5pRXXXWVKK3e2d/dVFkpfXd/ad2d1XcdwS79rdWhqkQqDesdSCKoDBs2bBARfzTpQ++ldZCA3pX7Ymf3nbP2t97Gb5q8t0hcoQgieo7Seq+99lqb/W1r3EG/ic5CZnLGqaqzkIpErr3ffPONxRyOuP7660XOtK2QZ1szM3QAoZKFTUNw2kNwjJ+IBFH6SJpRdJ03AmR+OK4pgEkudZ++Wo+8f2eiNEeaYWCY1qAfNIlyZDzkigMWxnn2HzpGkopPRppNvSMY5nwDn47MPtEkQnp6ukgTar6v0XmWBkE0OOnoebYzycvLQ3R0tPD5oLzlpr4rW7ZsEVV3mkMDt08//VSE5pqhlCYSOahUsS1aG2/QgC0gIKDTv1d3xl7nRTImPLBGSm8aevFtHQobdzZcfUxBxxZHnsc6ekzsDCj2pbJRuqjz1/i3yWS081ZugqFCEgQUdLzqwMW4I/uuI9Alb3Wp9J19gwMcmpbkan3nCGyNO+j6nwSWzhhvOHUkCA1KqBQglQ00iyB0sKf7ZA5nC8pXoqU5dGLo6MlhxoQ52LnxdwQskGaJcr1q4aWMgklvghFSWE7lxmLMmjTPJU9AjIMMqf7EPsm4N033H2qbF4Y5H03d6Nu7v5j3MVvHLWc7jpHJGs3qNRcv6D6V+rMFPd6e13fVeMOdscd5Ua3xwOjF5yo3dRdceUzhyPPYnzkmdgYkegR6BNp9vdLKZVAGBbls33UE2k7/0I5/587CFfvOEdgad3TmMc7pj5aUo0tlE2mGhnKNKMSYQnfMZmf24LNPP0fZ1ko05NpOp6HHy7dV4pOPpRBLhmEYe+LEAX1MN8GV9rGmEyhmzBMoTSNDmkKPN309Qcaorb2eYRiGYRjXxakjQQgqIUhhfuROS7m5Q4YMEWUDm+fudiXkmP/TynWiTG7gBH/4Tw8FAqUUGIoAIQGEnu9OzvoMwzg/5lBKyiHm4w/TldA+1nSfc4UJFEqdpXLFo0aNEhVwmk6gXHfddSJlhnw9iLvvvhuTJ0/Gyy+/LKr7LF++HHv37hV5zgzDMAzDdC+cXgQhKPWltfQXe0ElBUuyKnDDjdfj13//jKAB/sg7milSYD7J+pQvQBiGsTsU8k/eA2bTRPJQ4tBKpjNKGjZ9DwkgtI/RvtYVJZMdMYGSlZVlFVY7btw4UX74X//6F/7v//5PlGumyjBUOYfpPlBliJQ960U7eeRMUaKScQ5cKdqssxDHV70kMHsp7Xv+FlU3zorbcjcZO9B3rq+qFW1PP2+3+M6ujLGLK17x0b8d0Ezr18tXiD8KDQipvKQr5l8yDNN9MHsWdPfqEcyfx1xqzpyD3x5IADmfP4arTaBs3ry5xWNLliwRC9N9MZmMqM45LrVHTHf05jBno8voeGQ2d7W3ENBeYbiz11+tlaprydXtPy7/2XUbzlb2UnTgnODovut4iWzpO8tUcoeVyHbFvrN3/5DxPx0TaLxCKa5dAYsgDMMwLgydQCMjI4UoS27jDNMa5lJz5KzeHgGfLlJcJQKEYc6HXK5AcNIYS5txPHRsofKcVIqTqsS4ijDcKeuHCXqDVBq0TFFm9+owprNlSWVlZe2uDuPovuuw+KCVxknKynKHbbcr9p0joOjmuLi4Lgs4YBGEYRimmwwk+UKVOR806CJBg0rNcRQj447IFQokDh7v6M1gmuHj4yNS0Owt5HdUGGa473i/61poPNvVkTIsgjAMwzAMwzAM41ZCPgvD3HeOgPc754BlT4ZhGIZhGMYtaKivFQvDOAONhkaxOAJjY6NY3ImG2nqxMAyLIAzDMAzDMEy3R6/T4tCad8VCbYZx6P5o1OOHtB/EQm17Qn4glatWi8XsDdLdIT+QzZ+tEovZG4RxX5TuUnKrqqqqU8OYqqurOa+a4f2HsTt8/GGcbd8xn1/dscRla+MN9hdwzuMaCR+1dQ2Wv5NS1TVVB+wJnxNct+9I+KirqTu3P8rtd1lGwkeVuURuVRVk7SwX7ei+6wgkfNTWN+lvtcoh2+GKfecsdOZ4Q2bq5qMWcpuOjY119GYwDMMwTLcmOztbVHlwV86cOYNevXo5ejMYhmEYpluTlpaGnj17/qnP6PaRIFFRUWJg5uvr22kOs6RCkbBCn+vn59cpn8m4D7z/MLz/MN3p2ENzKTSrRedbdyYoKEjcZmVlwd/f39Gb41LweZH7jvc714J/s9x3jqCyslKUzTWfb/8M3V4EoTCjrpqZokEkiyAM7z+MI+DjD+NM+w5f9EvjDXNf8NjAefZNd4H7jvuO9zvXgn+zHacz0og4EYlhGIZhGIZhGIZhGLeARRCGYRiGYRiGYRiGYdwCFkE6gEajwWOPPSZuGYb3H8ae8PGH4X3HOeHfJvcd73euBf9mue94v3Pf32y3rw7DMAzDMAzDMAzDMAxDcCQIwzAMwzAMwzAMwzBuAYsgDMMwDMMwDMMwDMO4BSyCMAzDMAzDMAzDMAzjFrAI0k5uuOEGyGSyFsstt9zSNX8hpltgMBgwbtw4LFq0yOrxyspKxMbG4uGHH3bYtjEM4x7nroULFzp6M7o1b7/9NhISEuDh4YHRo0dj9+7djt4kp+fxxx9vMZ7q06ePozfLKfn9998xf/58REVFiX5atWqV1fNk8ffoo48iMjISnp6emDFjBk6fPu2w7XWlvrM1tp8zZw7cnWeffRYjR46Er68vwsLCxDkkJSXF6jUNDQ244447EBwcDB8fHyxevBiFhYVwd9rSd1OmTGmx3912220O22Zn4p133sGgQYPg5+cnlrFjx+KXX37p1P2ORZAOQAfG/Px8q+WVV17pyEcxboJCocAnn3yCtWvX4osvvrA8ftdddyEoKEg4HTPuia2L02+++UZcSL388suWx2688Ub861//wpgxY1qcJN99911x8qR9rPlnT5w4sYu/AcMwX3/9Ne655x5xLN+/fz8GDx6M2bNno6ioiDvnAvTv399qPLVt2zbuMxvU1taK/YrENlu88MILeOONN8T5YNeuXfD29hb7IF0suDsX6jtbY/uvvvoK7s6WLVvEhebOnTuxfv166HQ6zJo1S/SnmX/84x/48ccfsXLlSvH6vLy8FhN+7khb+o5YtmyZ1X5Hv2MGiImJwXPPPYd9+/Zh7969mDZtGhYsWIBjx4513n5H1WGYtnP99debFixYwF3GdIjXX3/dFBgYaMrLyzOtWrXKpFKpTAcPHuTedGOaH1M++OADk1qtNn300UeWx/R6vSkkJMS0a9cu04MPPmhKTk62+oylS5eaYmNjxWc1JT4+3vToo4/a4Vswzg6fu7qWUaNGme644w7LfYPBYIqKijI9++yzXbxm1+axxx4zDR482NGb4XLQ8P3777+33DcajaaIiAjTiy++aHmsoqLCpNFoTF999ZWDttI1+o7g42PbKCoqEv23ZcsWyz5G49iVK1daXnPixAnxmh07dnTq36279R0xefJk09133+3Q7XIl6Prpv//9b6ftdxwJwjB2hCI/aDbi2muvxa233ipCV+k+wxA0A0D7yPLly0Xkh5nt27dDpVKJ0MqpU6eKkMqCggLL86SCP/jgg9i8ebPlsfT0dGRmZorXMwzTdWi1WjFbRekHZuRyubi/Y8cO7voLQCkblKbQs2dPXH311cjKyuI+ayd0vKdzQtN90N/fX6Rl8T7YNuj8SWkLycnJuP3221FaWsr7YTMohZugCGaCjnsU4dB0v6N0tri4ON7vLtB3Zig6PCQkBAMGDMBDDz2Euro63u9sWArQuJiiaCgtprP2OxZBGMaOUMoC5blt3LgR4eHh4sKVYYgHHngATz31FNasWYNLL73UqlN++OEHkc9M+8/48eOFILJp0ybx3PHjx1FfX4+bb75ZDNpoMEzQ85RSQycMhmG6jpKSEjFIo2N6U+h+U7GSaQldpJtTRencSMcvSuGrrq7m7moH5v2M98GOQakwn332mRibPf/882JiYe7cueJ3zUgYjUb8/e9/F2MQumA373dqtRoBAQFW3cTHvgv3HXHVVVfhf//7nxivkQDy+eef45prruFd7ixHjhwRfh8ajUakgX///ffo169fp+13yja/kmGYTuGjjz6Cl5eXGOzl5OQIIz3GvSGzp9WrV4sBGOU9Noeee/XVV0Wb8rxHjRolZq2uvPJKcTthwgRxkiDzXbrfo0cPcUsCCD3OMAzjjNCFphkywSNRJD4+HitWrBDCLsPYgyuuuMLSHjhwoNgXe/XqJc6j06dP5z8CIPwtjh49yp49ndh3FBHedL8jU2Pa39LS0sT+5+4kJyfj4MGDIoqGvPKuv/56IVB2FhwJwjB2hNIa6GKWZvvpQpYGeVKKKuPO0ICLxDAyVaypqbF67sSJE8LwqelAjBzFzakvdEv3icmTJ1s9zqkwDNP1UCgzmV83d6an+xEREfwnaAc0s5eUlITU1FTut3Zg3s94H+wcKDWLfte8H0rceeedYtxKEQtkWNl0v6N0wIqKCqv+42PfhfvOFiQCE7zfSVC0R2JiIoYPHy6q7ZB9wOuvv95p+x2LIAxjJyjPj6p1UK4pXZx++OGHooQiObkz7k10dLQQLXJzc0VYbtNQcEqFmTlzpkhtMUP7z6lTp8Tr6X0kfjQVQWgWITs722ZUCcMwnT9Qo0EaRXI1DX+m+5yO1j5IBKbjF82IMm2Hov9o8N90H6yqqhJVYngfbD8UpUvppe6+H9IkHV3EUxrCb7/9JvazptBxj9Jzm+535FlGvj7uvt9dqO9sQVEPhLvvd61B59XGxsZO2+84HYZh7ATl+9FBkUo+ETTz/9JLL+Gf//ynCAnmtBj3hkLAKcyPBA4SQihHnurLUypM05BJgtJe6MLrP//5jyh/SCcEgoxTi4uLRcqVOW2GYcxQSKl5kGUmODgYsbGx3El/EiqPS6G6I0aMEL+71157TZi4NTU4ZlpC5z/yO6LjH0W8UTQcRdVQqh/TUiBqOkNMKbX0eyajRTIEJM+Bp59+Gr179xYXXI888ogwnG1egt0dOV/f0fLEE09g8eLFQkgiEe7+++8XM9BUYtjd0zi+/PJLMQ6h8YjZb4FMdz09PcUtRTTT8Y/60c/PT5i704XomDFj4M5cqO9oP6Pn582bJ87Dhw8fFmVfJ02aJKKD3Z2HHnpIXBvRsY0mBqmvaJJv3bp1nbffdVEVm24Ll9FiOsLmzZtNCoXCtHXr1hbPzZo1yzRt2jRR4o5xP5ofU7Kzs02JiYmmsWPHmjIzM0UZsOLi4hbvmzRpksnX19c0Z84cq8enTp0qHqf9imGa7md0ym++3HzzzdxJncSbb75piouLEyWuqWTuzp07uW8vwOWXX26KjIwUfRYdHS3up6amcr/ZYNOmTTZ/w+bS6DSGeOSRR0zh4eGiNO706dNNKSkp3JcX6Lu6ujpxvgwNDRXnWyotv2zZMlNBQYHb952tPqPl448/tvRNfX296a9//asoX+rl5WW69NJLTfn5+dx3F+i7rKwsMY4LCgoSv1ca9913332myspKt+874qabbhK/RTo30G+Tjme//vqrqTP3Oxn9ryuVHIZhGKZ1KEWK8hpXrVpleYzSXCgihNRvCovcv39/i/c9/vjjYvaKIouosowZeoyeo/xJrj7EMAzDMAzDMNawCMIwDOOkXHLJJaLyC4XmMgzDMAzDMAzz52FjVIZhGCeFBBDOjWcYhmEYhmGYzoMjQRiGYRiGYRiGYRiGcQs4EoRhGIZhGIZhGIZhGLeARRCGYRiGYRiGYRiGYdwCFkEYhmEYhmEYhmEYhnELWARhGIZhGIZhGIZhGMYtYBGEYRiGYRiGYRiGYRi3gEUQhmFcihtuuAELFy509GYwDMMwjNtgMplw6623IigoCDKZDAcPHnT0JjktWq0WiYmJ2L59u93XPWbMGHz77bd2Xy/DuBosgjAM41K8/vrr+OSTT9r1HhqwrVq1qsu2iWEYhmG6M2vXrhXn3jVr1iA/Px8DBgxw9CY5Le+++y569OiBcePGiT6jMcj5loyMDDz++OMYMmRIi8+i59ojOv3rX//Cgw8+CKPR2AXfjGG6DyyCMAzjUvj7+yMgIMDRm8EwDMMwbkNaWhoiIyPFhX1ERASUSqXNCAh3hyJm3nrrLdx8883i/uWXXy5EI/MyduxYLFu2zOqx2NjYTlv/3LlzUV1djV9++aXTPpNhuiMsgjAM0yFqa2tx3XXXwcfHRwyMXn75ZUyZMgV///vfW30PzWa888474iTt6emJnj174ptvvrF6zZEjRzBt2jTxfHBwsAi/rampaTUdhtb5t7/9Dffff78I06XBGc2omElISBC3l156qVi/+T7DMAzDMBeGzrt33XUXsrKyrM6jdP698847xXk/JCQEs2fPFo8fPXpUnOdpfBAeHo5rr70WJSUl7Ro/2IrgpAmQppGg2dnZWLp0qXiczv8LFiwQkRPNxwsvvfSSWA+NKe644w7odDrLaxobG/HAAw8IIUKj0Yg0lg8//FCIGdSm9zaFIjJo21JTU2321b59+4RgdNFFF4n7NJahcYl5UavV8PLysnpMoVC0eTek72QrmmTz5s3iefqsefPmYfny5W3+TIZxR1gEYRimQ9x3333YsmULVq9ejV9//VWcgPfv33/B9z3yyCNYvHgxDh06hKuvvhpXXHEFTpw4YRkY0SAqMDAQe/bswcqVK7FhwwYxyDofn376Kby9vbFr1y688MILePLJJ7F+/XrxHH0O8fHHH4sZF/N9hmEYhmHaloZK59WYmJgW51E6/9KF/R9//CHSQCoqKsRExtChQ7F3716RRlNYWCjEij87fmgKCRk0XvD19cXWrVvF+klUmTNnjlVEyqZNm4QoQbe0rSSiNBVSSIz56quv8MYbb4ixyHvvvSc+h4SFm266SYwdmkL3J02aJAQSW9C2JCUlie3qqr9F0yiSu+++G2FhYejTp4/lNaNGjRLbwTDMeTAxDMO0k+rqapNarTatWLHC8lhpaanJ09PTdPfdd7f6Pjrk3HbbbVaPjR492nT77beL9vvvv28KDAw01dTUWJ7/6aefTHK53FRQUCDuX3/99aYFCxZYnp88ebJpwoQJVp85cuRI0wMPPGC13u+//57/zgzDMAzTAV599VVTfHy81WN0/h06dKjVY0899ZRp1qxZVo9lZ2eL83BKSkqbxw+2ztv+/v6mjz/+WLQ///xzU3JyssloNFqeb2xsFJ+zbt06y3iBtlmv11tes2TJEtPll18u2rQ9tJ7169fb/M65ubkmhUJh2rVrl7iv1WpNISEhpk8++aTVfqLvMG3atFafpz6zNU567LHHxFjH29vbavHy8hLbeODAgRbv+fbbb00eHh6mbdu2WT2+evVq8VkGg6HV7WAYd4cjQRiGaTc0q0IzLaNHj7Y8RqGoycnJov3vf/9bzKSYFwqhNUP5sE2h++ZIELodPHiwiOowM378eGHwlZKS0ur2DBo0yOo+hb0WFRXxX5ZhGIZhupDhw4db3acoT4q6aDoGMEcp0NjhQuOHtkLroZQUirgwr4c+p6GhQazDTP/+/a3STZqODyi1hZ6bPHmyzXVERUWJtJaPPvpI3P/xxx9F+sySJUta3a76+np4eHigI1Af0DY1XX7++Webrz1w4IBIMyL/ERonNYVScGjcRNvKMIxtWroaMQzD/Eluu+02q9BXGkh0JSqVyuo+hbGyMzrDMAzDdC1NJy0I8vCaP38+nn/++RavJQGiNS+N5tB5XAoIOUdTLw9aDwkwX3zxRYv3hoaGtml8QGLBhbjllluE2PDqq6+KVBgyOiVPj9YgbxTyNusIlFbUPM3GlgFtQUEBLrnkErFtZgPWppSVlYm/S1u+H8O4KxwJwjBMu+nVq5cYWJAHh5ny8nKcOnVKtGk2hk7k5qXpSXznzp1Wn0X3+/btK9p0S7M75A1ihvJ85XJ5u2eJmkLbajAYOvx+hmEYhmEuzLBhw3Ds2DFhntp0HEALXZhfaPzQVMggzwszp0+fRl1dndV66DHyw2i+Hqoi1xYGDhwoBBHyJ2kNMhml7SZTd/I3IZ+Q80FeKCdPnmwh4HQWFOlCBrAUXfPKK6/YfA0Z09J2MAzTOiyCMAzTbijslGYfyNzst99+EydcciwnseJCkNkphZbSgOexxx7D7t27LcanZJRKYaTXX3+9+EwKqSVHepqFIYf5jkKDsY0bN4rZExpsMQzDMAzT+VD1FYpEuPLKK4WBKqWmrFu3DjfeeKOYjGjr+IHMVSnVg9I+yGCVIkybRnXQeIGiLkgQIBPQ9PR0YbBK1eJycnLaPDag8QYJG1SJxvwZK1assLyG0mVo+x566CH07t27RUpvc6ZOnSqiVEgI6gr+8pe/iKo4ZORaXFwsxjW0NDWDpf6YNWtWl6yfYboLLIIwDNMhXnzxRUycOFGEvc6YMQMTJkxokRtsiyeeeEKUbiMfj88++0y4svfr1088RyGmNFiiAdTIkSNx2WWXYfr06WIg9Geg8ntULYZK4PHsCMMwDMN0DZT+ShGcJHjQhThFW1DpWypjaxY62jJ+oPM2nbPpdVdddRX++c9/WqWhUPv3339HXFwcFi1aJCJJSVyhSAk/P782by9FeNBY469//auIrli2bJlVNCpBn0siAwk5F4LK8F566aU203Q6A4paoQgZGjdRepF52b59u3g+NzdXtNuyrQzjzsjIHdXRG8EwTPdgypQpGDJkCF577TWbz1Mu7vfff4+FCxfafdsYhmEYhnHN8YMjocgKmpChCIy2RKUePnwYM2fOFFEwFPliTx544AER8fr+++/bdb0M42pwJAjDMAzDMAzDMEwTqLoKpdY8/vjjoiJMW9NyKdKVjGEpvcbekEfKU089Zff1MoyrwSIIwzAMwzAMwzBMEyhdNz4+HhUVFXjhhRfa1TfkI0KpQPbm3nvv/VMeagzjLnA6DMMwDMMwDMMwDMMwbgFHgjAMwzAMwzAMwzAM4xawCMIwDMMwDMMwDMMwjFvAIgjDMAzDMAzDMAzDMG4BiyAMwzAMwzAMwzAMw7gFLIIwDMMwDMMwDMMwDOMWsAjCMAzDMAzDMAzDMIxbwCIIwzAMwzAMwzAMwzBuAYsgDMMwDMMwDMMwDMO4BSyCMAzDMAzDMAzDMAwDd+D/AWERiy41TzxsAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1100x400 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(11, 4))\n",
+    "\n",
+    "q_labels = [\"Γ\", \"X\", \"K/W\", \"L\"]\n",
+    "q_index = np.arange(out_ase.q_points.shape[0])\n",
+    "for b in range(out_ase.harmonic_frequencies.shape[1]):\n",
+    "    ax1.plot(q_index, out_ase.harmonic_frequencies[:, b],\n",
+    "             color=f\"C{b}\", lw=2, alpha=0.6,\n",
+    "             label=\"harmonic\" if b == 0 else None)\n",
+    "    ax1.scatter(q_index, out_ase.renormalised_frequencies[:, b],\n",
+    "                color=f\"C{b}\", marker=\"o\", s=50, edgecolor=\"black\", linewidth=0.5,\n",
+    "                label=\"renorm (300 K)\" if b == 0 else None)\n",
+    "ax1.set_xticks(q_index)\n",
+    "ax1.set_xticklabels(q_labels)\n",
+    "ax1.set_xlabel(\"q-point\")\n",
+    "ax1.set_ylabel(\"frequency (THz)\")\n",
+    "ax1.set_title(\"Renormalised phonon bands — Si 2×2×2 (GRACE-1L-OAM, ASE)\")\n",
+    "ax1.legend()\n",
+    "ax1.grid(alpha=0.3)\n",
+    "\n",
+    "# Power spectrum at X (q-index 1).\n",
+    "i_X = 1\n",
+    "for b in range(out_ase.power_spectra.shape[1]):\n",
+    "    ax2.plot(out_ase.frequency_grid, out_ase.power_spectra[i_X, b], label=f\"band {b}\", alpha=0.85)\n",
+    "    ax2.axvline(out_ase.harmonic_frequencies[i_X, b], ls=\":\", color=f\"C{b}\", alpha=0.4)\n",
+    "ax2.set_xlim(0, 30)\n",
+    "ax2.set_xlabel(\"frequency (THz)\")\n",
+    "ax2.set_ylabel(\"power (arb.)\")\n",
+    "ax2.set_title(\"MD-projected power spectrum at X — ASE\\n(dotted lines = harmonic)\")\n",
+    "ax2.legend(ncols=3, fontsize=8)\n",
+    "ax2.grid(alpha=0.3)\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0c2b918",
+   "metadata": {},
+   "source": [
+    "## 3. Section B — LAMMPS-driven workflow with `pair_style grace`\n",
+    "\n",
+    "Same foundation model, different MD driver. Pieces:\n",
+    "- **`LammpsEngine`** from `pyiron_workflow_lammps` wraps the `lmp` binary at\n",
+    "  `/home/liger/lammps/build/lmp` (built from the `grace` branch with ML-PACE/ML-GRACE).\n",
+    "- For trajectory generation we drive LAMMPS directly (its own integrator is much\n",
+    "  faster than per-step ASE subprocess calls) and dump positions+velocities.\n",
+    "- `dynaphopy.interface.iofile.read_lammps_trajectory` parses the dump and\n",
+    "  builds a `dynaphopy.dynamics.Dynamics` object compatible with `Quasiparticle`.\n",
+    "- FC2 is reused from Section A so both halves are fit against the same harmonic reference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2f2203cf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T17:12:43.597297Z",
+     "iopub.status.busy": "2026-05-15T17:12:43.596738Z",
+     "iopub.status.idle": "2026-05-15T17:12:43.621336Z",
+     "shell.execute_reply": "2026-05-15T17:12:43.618199Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Wrote /tmp/pwa-grace-0p7/_dynaphopy_grace_0p7fs/lammps_run/si_222.data (16 atoms)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import subprocess\n",
+    "from pathlib import Path\n",
+    "\n",
+    "lammps_workdir = Path(\"./_dynaphopy_grace_0p7fs/lammps_run\").resolve()\n",
+    "lammps_workdir.mkdir(parents=True, exist_ok=True)\n",
+    "LMP_BIN = \"/home/liger/lammps/build/lmp\"\n",
+    "GRACE_MODEL_DIR = \"/home/liger/.cache/grace/GRACE-1L-OAM\"\n",
+    "\n",
+    "# Write Si 2x2x2 LAMMPS data file.\n",
+    "data_file = lammps_workdir / \"si_222.data\"\n",
+    "from ase.io import write as ase_write\n",
+    "ase_write(str(data_file), si_supercell, format=\"lammps-data\", masses=True)\n",
+    "print(f\"Wrote {data_file} ({len(si_supercell)} atoms)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "367f7933",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T17:12:43.626290Z",
+     "iopub.status.busy": "2026-05-15T17:12:43.625722Z",
+     "iopub.status.idle": "2026-05-15T17:23:04.966525Z",
+     "shell.execute_reply": "2026-05-15T17:23:04.963640Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Running LAMMPS NVT with pair_style grace (GPU)...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "return code: 0\n",
+      "Histogram: 1 0 0 0 0 0 0 0 0 0\n",
+      "FullNghs:         1710 ave        1710 max        1710 min\n",
+      "Histogram: 1 0 0 0 0 0 0 0 0 0\n",
+      "\n",
+      "Total # of neighbors = 1710\n",
+      "Ave neighs/atom = 106.875\n",
+      "Neighbor list builds = 16\n",
+      "Dangerous builds = 0\n",
+      "[GRACE:debug, proc #0]: Data preparation timer: 115 mcs, graph execution time: 11507 mcs, data preparation time fraction: 0.99 %\n",
+      "Total wall time: 0:10:36\n"
+     ]
+    }
+   ],
+   "source": [
+    "# LAMMPS NVT-Langevin input file. Same temperature, thermostat coupling, and\n",
+    "# step count as Section A, written to a dump file for dynaphopy ingestion.\n",
+    "lammps_input = lammps_workdir / \"nvt.in\"\n",
+    "lammps_dump  = lammps_workdir / \"trajectory.lammpstrj\"\n",
+    "lammps_log   = lammps_workdir / \"log.lammps\"\n",
+    "lammps_input.write_text(f\"\"\"\\\n",
+    "units           metal\n",
+    "atom_style      atomic\n",
+    "boundary        p p p\n",
+    "read_data       {data_file}\n",
+    "\n",
+    "pair_style      grace\n",
+    "pair_coeff      * * {GRACE_MODEL_DIR} Si\n",
+    "\n",
+    "neighbor        2.0 bin\n",
+    "neigh_modify    every 1 delay 0 check yes\n",
+    "\n",
+    "# Equilibration: Langevin NVT for 3.5 ps (5000 steps × 0.7 fs).\n",
+    "velocity        all create 300.0 42 dist gaussian\n",
+    "fix             1 all nve\n",
+    "fix             2 all langevin 300.0 300.0 0.1 42\n",
+    "timestep        0.0007                                # ps (= 0.7 fs / 1000)\n",
+    "thermo          500\n",
+    "thermo_style    custom step temp pe etotal\n",
+    "run             5000\n",
+    "\n",
+    "# Production — dump positions and velocities every step for the MD-projection.\n",
+    "unfix 1\n",
+    "unfix 2\n",
+    "fix             1 all nve\n",
+    "fix             2 all langevin 300.0 300.0 0.1 43\n",
+    "reset_timestep  0\n",
+    "dump            1 all custom 1 {lammps_dump} id type xu yu zu vx vy vz\n",
+    "dump_modify     1 sort id\n",
+    "run             50000\n",
+    "\"\"\")\n",
+    "\n",
+    "env = os.environ.copy()\n",
+    "env[\"LD_LIBRARY_PATH\"] = \"/usr/lib/wsl/lib:\" + env.get(\"LD_LIBRARY_PATH\", \"\")\n",
+    "print(\"Running LAMMPS NVT with pair_style grace (GPU)...\")\n",
+    "result = subprocess.run(\n",
+    "    [LMP_BIN, \"-in\", str(lammps_input), \"-log\", str(lammps_log)],\n",
+    "    cwd=str(lammps_workdir),\n",
+    "    env=env,\n",
+    "    capture_output=True, text=True, timeout=3600,\n",
+    ")\n",
+    "print(f\"return code: {result.returncode}\")\n",
+    "tail_lines = result.stdout.splitlines()[-10:]\n",
+    "for line in tail_lines:\n",
+    "    print(line)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "0dd8fc8f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T17:23:04.971257Z",
+     "iopub.status.busy": "2026-05-15T17:23:04.970790Z",
+     "iopub.status.idle": "2026-05-15T17:23:08.794522Z",
+     "shell.execute_reply": "2026-05-15T17:23:08.791207Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Parsed dump: positions (50001, 16, 3), velocities (50001, 16, 3)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Parse the LAMMPS dump and assemble a trajectory_pack compatible with\n",
+    "# _project_with_dynaphopy. We replicate _run_nvt_trajectory's output schema\n",
+    "# from the dump file so the same downstream synthesis node can ingest it.\n",
+    "\n",
+    "from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (\n",
+    "    _multiplier_to_cell_vectors,\n",
+    "    _project_with_dynaphopy,\n",
+    ")\n",
+    "\n",
+    "def read_lammps_custom_dump(dump_path: Path):\n",
+    "    \"\"\"Parse a LAMMPS 'dump custom id type xu yu zu vx vy vz' file.\n",
+    "\n",
+    "    Returns dict with positions (n_step, n_atom, 3), velocities (same shape),\n",
+    "    n_atom, n_steps. Time is reconstructed from the LAMMPS step count.\n",
+    "    \"\"\"\n",
+    "    text = dump_path.read_text().splitlines()\n",
+    "    i = 0\n",
+    "    n_atom = None\n",
+    "    positions_list, velocities_list = [], []\n",
+    "    while i < len(text):\n",
+    "        if text[i].startswith(\"ITEM: TIMESTEP\"):\n",
+    "            i += 2\n",
+    "        elif text[i].startswith(\"ITEM: NUMBER OF ATOMS\"):\n",
+    "            n_atom = int(text[i + 1].strip())\n",
+    "            i += 2\n",
+    "        elif text[i].startswith(\"ITEM: BOX BOUNDS\"):\n",
+    "            i += 4\n",
+    "        elif text[i].startswith(\"ITEM: ATOMS\"):\n",
+    "            header = text[i].split()[2:]\n",
+    "            col = {name: idx for idx, name in enumerate(header)}\n",
+    "            frame_pos = np.zeros((n_atom, 3))\n",
+    "            frame_vel = np.zeros((n_atom, 3))\n",
+    "            for k in range(n_atom):\n",
+    "                row = text[i + 1 + k].split()\n",
+    "                aid = int(row[col[\"id\"]]) - 1\n",
+    "                frame_pos[aid] = [float(row[col[c]]) for c in (\"xu\", \"yu\", \"zu\")]\n",
+    "                frame_vel[aid] = [float(row[col[c]]) for c in (\"vx\", \"vy\", \"vz\")]\n",
+    "            positions_list.append(frame_pos)\n",
+    "            velocities_list.append(frame_vel)\n",
+    "            i += 1 + n_atom\n",
+    "        else:\n",
+    "            i += 1\n",
+    "    pos = np.stack(positions_list, axis=0)\n",
+    "    vel = np.stack(velocities_list, axis=0)\n",
+    "    return pos, vel\n",
+    "\n",
+    "lammps_pos, lammps_vel = read_lammps_custom_dump(lammps_dump)\n",
+    "print(f\"Parsed dump: positions {lammps_pos.shape}, velocities {lammps_vel.shape}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "3a241a7e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T17:23:08.798675Z",
+     "iopub.status.busy": "2026-05-15T17:23:08.798194Z",
+     "iopub.status.idle": "2026-05-15T17:23:31.199550Z",
+     "shell.execute_reply": "2026-05-15T17:23:31.196292Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LAMMPS production ⟨T⟩: 319.8 K  (target 300 K)\n",
+      "LAMMPS production σ_T: 62.8 K\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No velocity provided! calculating it from coordinates...\n",
+      "MD cell size relation: [2 2 2]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Using 50001 steps\n",
+      "Calculating phonon projection power spectra\n",
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Harmonic frequencies (THz):\n",
+      "[2.52669885e-07 3.29447212e-07 4.08406407e-07 2.41045897e+01\n",
+      " 2.41045897e+01 2.41045897e+01]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Peak # 1\n",
+      "----------------------------------------------\n",
+      "Width                             0.480659 THz\n",
+      "Position                         38.698635 THz\n",
+      "Area (<K>)    (Lorentzian)        0.047176 eV\n",
+      "Area (<K>)    (Total)             2.481152 eV\n",
+      "<|dQ/dt|^2>                       0.094352 eV\n",
+      "Base line                         0.060886 eV * ps\n",
+      "Maximum height                    0.062484 eV * ps\n",
+      "Fitting global error              0.221383\n",
+      "Frequency shift                  38.698635 THz\n",
+      "\n",
+      "Peak # 2\n",
+      "----------------------------------------------\n",
+      "Width                             0.480659 THz\n",
+      "Position                         38.698635 THz\n",
+      "Area (<K>)    (Lorentzian)        0.047176 eV\n",
+      "Area (<K>)    (Total)             2.481152 eV\n",
+      "<|dQ/dt|^2>                       0.094352 eV\n",
+      "Base line                         0.060886 eV * ps\n",
+      "Maximum height                    0.062484 eV * ps\n",
+      "Fitting global error              0.221383\n",
+      "Frequency shift                  38.698635 THz\n",
+      "\n",
+      "Peak # 3\n",
+      "----------------------------------------------\n",
+      "Width                             0.480659 THz\n",
+      "Position                         38.698635 THz\n",
+      "Area (<K>)    (Lorentzian)        0.047176 eV\n",
+      "Area (<K>)    (Total)             2.481152 eV\n",
+      "<|dQ/dt|^2>                       0.094352 eV\n",
+      "Base line                         0.060886 eV * ps\n",
+      "Maximum height                    0.062484 eV * ps\n",
+      "Fitting global error              0.221383\n",
+      "Frequency shift                  38.698635 THz\n",
+      "\n",
+      "Peak # 4\n",
+      "----------------------------------------------\n",
+      "Width                             2.969823 THz\n",
+      "Position                         13.251222 THz\n",
+      "Area (<K>)    (Lorentzian)        0.254490 eV\n",
+      "Area (<K>)    (Total)             2.442553 eV\n",
+      "<|dQ/dt|^2>                       0.508980 eV\n",
+      "Base line                         0.055023 eV * ps\n",
+      "Maximum height                    0.054553 eV * ps\n",
+      "Fitting global error              0.275387\n",
+      "Frequency shift                 -10.853367 THz\n",
+      "\n",
+      "Peak # 5\n",
+      "----------------------------------------------\n",
+      "Width                             2.969823 THz\n",
+      "Position                         13.251222 THz\n",
+      "Area (<K>)    (Lorentzian)        0.254490 eV\n",
+      "Area (<K>)    (Total)             2.442553 eV\n",
+      "<|dQ/dt|^2>                       0.508980 eV\n",
+      "Base line                         0.055023 eV * ps\n",
+      "Maximum height                    0.054553 eV * ps\n",
+      "Fitting global error              0.275387\n",
+      "Frequency shift                 -10.853367 THz\n",
+      "\n",
+      "Peak # 6\n",
+      "----------------------------------------------\n",
+      "Width                             2.969823 THz\n",
+      "Position                         13.251222 THz\n",
+      "Area (<K>)    (Lorentzian)        0.254490 eV\n",
+      "Area (<K>)    (Total)             2.442553 eV\n",
+      "<|dQ/dt|^2>                       0.508980 eV\n",
+      "Base line                         0.055023 eV * ps\n",
+      "Maximum height                    0.054553 eV * ps\n",
+      "Fitting global error              0.275387\n",
+      "Frequency shift                 -10.853367 THz\n",
+      "Calculating phonon projection power spectra\n",
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: Fitting not successful in peak #1\n",
+      "Warning: Fitting not successful in peak #2\n",
+      "\n",
+      "Peak # 3\n",
+      "----------------------------------------------\n",
+      "Width                             0.579324 THz\n",
+      "Position                         11.228058 THz\n",
+      "Area (<K>)    (Lorentzian)        0.072048 eV\n",
+      "Area (<K>)    (Total)             2.441752 eV\n",
+      "<|dQ/dt|^2>                       0.144096 eV\n",
+      "Base line                         0.059235 eV * ps\n",
+      "Maximum height                    0.079174 eV * ps\n",
+      "Fitting global error              0.155294\n",
+      "Frequency shift                  -5.845675 THz\n",
+      "Warning: Fitting not successful in peak #4\n",
+      "\n",
+      "Peak # 5\n",
+      "----------------------------------------------\n",
+      "Width                             4.327962 THz\n",
+      "Position                         13.590105 THz\n",
+      "Area (<K>)    (Lorentzian)        0.395253 eV\n",
+      "Area (<K>)    (Total)             2.475753 eV\n",
+      "<|dQ/dt|^2>                       0.790507 eV\n",
+      "Base line                         0.052745 eV * ps\n",
+      "Maximum height                    0.058140 eV * ps\n",
+      "Fitting global error              0.260702\n",
+      "Frequency shift                  -9.302785 THz\n",
+      "\n",
+      "Peak # 6\n",
+      "----------------------------------------------\n",
+      "Width                             4.327962 THz\n",
+      "Position                         13.590105 THz\n",
+      "Area (<K>)    (Lorentzian)        0.395253 eV\n",
+      "Area (<K>)    (Total)             2.475753 eV\n",
+      "<|dQ/dt|^2>                       0.790507 eV\n",
+      "Base line                         0.052745 eV * ps\n",
+      "Maximum height                    0.058140 eV * ps\n",
+      "Fitting global error              0.260702\n",
+      "Frequency shift                  -9.302785 THz\n",
+      "Calculating phonon projection power spectra\n",
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 9.0391301   9.0391301  18.66589077 18.66589077 21.78408021 21.78408021]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 9.0391301   9.0391301  18.66589077 18.66589077 21.78408021 21.78408021]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 9.0391301   9.0391301  18.66589077 18.66589077 21.78408021 21.78408021]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Harmonic frequencies (THz):\n",
+      "[ 9.0391301   9.0391301  18.66589077 18.66589077 21.78408021 21.78408021]\n",
+      "Warning: Fitting not successful in peak #1\n",
+      "Warning: Fitting not successful in peak #2\n",
+      "\n",
+      "Peak # 3\n",
+      "----------------------------------------------\n",
+      "Width                             4.962772 THz\n",
+      "Position                         13.375886 THz\n",
+      "Area (<K>)    (Lorentzian)        0.460056 eV\n",
+      "Area (<K>)    (Total)             2.448457 eV\n",
+      "<|dQ/dt|^2>                       0.920112 eV\n",
+      "Base line                         0.050702 eV * ps\n",
+      "Maximum height                    0.059016 eV * ps\n",
+      "Fitting global error              0.248554\n",
+      "Frequency shift                  -5.290004 THz\n",
+      "\n",
+      "Peak # 4\n",
+      "----------------------------------------------\n",
+      "Width                             4.962772 THz\n",
+      "Position                         13.375886 THz\n",
+      "Area (<K>)    (Lorentzian)        0.460056 eV\n",
+      "Area (<K>)    (Total)             2.448457 eV\n",
+      "<|dQ/dt|^2>                       0.920112 eV\n",
+      "Base line                         0.050702 eV * ps\n",
+      "Maximum height                    0.059016 eV * ps\n",
+      "Fitting global error              0.248554\n",
+      "Frequency shift                  -5.290004 THz\n",
+      "\n",
+      "Peak # 5\n",
+      "----------------------------------------------\n",
+      "Width                             5.339973 THz\n",
+      "Position                         14.019335 THz\n",
+      "Area (<K>)    (Lorentzian)        0.497183 eV\n",
+      "Area (<K>)    (Total)             2.484265 eV\n",
+      "<|dQ/dt|^2>                       0.994366 eV\n",
+      "Base line                         0.050806 eV * ps\n",
+      "Maximum height                    0.059273 eV * ps\n",
+      "Fitting global error              0.255852\n",
+      "Frequency shift                  -7.764745 THz\n",
+      "\n",
+      "Peak # 6\n",
+      "----------------------------------------------\n",
+      "Width                             5.339973 THz\n",
+      "Position                         14.019335 THz\n",
+      "Area (<K>)    (Lorentzian)        0.497183 eV\n",
+      "Area (<K>)    (Total)             2.484265 eV\n",
+      "<|dQ/dt|^2>                       0.994366 eV\n",
+      "Base line                         0.050806 eV * ps\n",
+      "Maximum height                    0.059273 eV * ps\n",
+      "Fitting global error              0.255852\n",
+      "Frequency shift                  -7.764745 THz\n",
+      "Calculating phonon projection power spectra\n",
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Projecting into phonon mode\n",
+      "Projecting into wave vector\n",
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Harmonic frequencies (THz):\n",
+      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n",
+      "Warning: Fitting not successful in peak #1\n",
+      "Warning: Fitting not successful in peak #2\n",
+      "\n",
+      "Peak # 3\n",
+      "----------------------------------------------\n",
+      "Width                             0.579324 THz\n",
+      "Position                         11.228058 THz\n",
+      "Area (<K>)    (Lorentzian)        0.072048 eV\n",
+      "Area (<K>)    (Total)             2.441752 eV\n",
+      "<|dQ/dt|^2>                       0.144096 eV\n",
+      "Base line                         0.059235 eV * ps\n",
+      "Maximum height                    0.079174 eV * ps\n",
+      "Fitting global error              0.155294\n",
+      "Frequency shift                  -5.845675 THz\n",
+      "Warning: Fitting not successful in peak #4\n",
+      "\n",
+      "Peak # 5\n",
+      "----------------------------------------------\n",
+      "Width                             4.327962 THz\n",
+      "Position                         13.590105 THz\n",
+      "Area (<K>)    (Lorentzian)        0.395253 eV\n",
+      "Area (<K>)    (Total)             2.475753 eV\n",
+      "<|dQ/dt|^2>                       0.790507 eV\n",
+      "Base line                         0.052745 eV * ps\n",
+      "Maximum height                    0.058140 eV * ps\n",
+      "Fitting global error              0.260702\n",
+      "Frequency shift                  -9.302785 THz\n",
+      "\n",
+      "Peak # 6\n",
+      "----------------------------------------------\n",
+      "Width                             4.327962 THz\n",
+      "Position                         13.590105 THz\n",
+      "Area (<K>)    (Lorentzian)        0.395253 eV\n",
+      "Area (<K>)    (Total)             2.475753 eV\n",
+      "<|dQ/dt|^2>                       0.790507 eV\n",
+      "Base line                         0.052745 eV * ps\n",
+      "Maximum height                    0.058140 eV * ps\n",
+      "Fitting global error              0.260702\n",
+      "Frequency shift                  -9.302785 THz\n",
+      "LAMMPS converged: True\n",
+      "renormalised freqs (THz): [ 0.          0.          0.         13.25122221 13.25122221 13.25122221]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Build the trajectory_pack and feed into _project_with_dynaphopy.\n",
+    "# Reuses Section A's FC2 (identical primitive + FC2 supercell), so both halves\n",
+    "# share the same harmonic reference and we're isolating MD-driver differences.\n",
+    "\n",
+    "time_step_fs = 0.7\n",
+    "n_steps = lammps_pos.shape[0]\n",
+    "# ⟨T⟩ and σ_T are read directly from LAMMPS' thermo output (log.lammps);\n",
+    "# velocity-units bookkeeping is left to LAMMPS' own thermostat.\n",
+    "\n",
+    "log_text = lammps_log.read_text()\n",
+    "# LAMMPS thermo header is \" Step  Temp  PotEng  TotEng\" (note leading whitespace).\n",
+    "# Walk the log block-by-block: every header line opens a thermo block, the next\n",
+    "# whitespace-only block of numeric lines is the data. Production = second block.\n",
+    "prod_temps = []\n",
+    "blocks: list[list[float]] = []\n",
+    "current: list[float] = []\n",
+    "in_block = False\n",
+    "for raw in log_text.splitlines():\n",
+    "    line = raw.strip()\n",
+    "    if line.startswith(\"Step\") and \"Temp\" in line:\n",
+    "        if current:\n",
+    "            blocks.append(current)\n",
+    "            current = []\n",
+    "        in_block = True\n",
+    "        continue\n",
+    "    if in_block:\n",
+    "        toks = line.split()\n",
+    "        if len(toks) >= 2 and toks[0].isdigit():\n",
+    "            try:\n",
+    "                current.append(float(toks[1]))\n",
+    "            except ValueError:\n",
+    "                pass\n",
+    "        elif line.startswith(\"Loop\") or line.startswith(\"ERROR\"):\n",
+    "            blocks.append(current)\n",
+    "            current = []\n",
+    "            in_block = False\n",
+    "if current:\n",
+    "    blocks.append(current)\n",
+    "\n",
+    "prod_temps = blocks[1] if len(blocks) >= 2 else (blocks[0] if blocks else [])\n",
+    "md_T_mean = float(np.mean(prod_temps)) if prod_temps else float(\"nan\")\n",
+    "md_T_std  = float(np.std(prod_temps))  if prod_temps else float(\"nan\")\n",
+    "print(f\"LAMMPS production ⟨T⟩: {md_T_mean:.1f} K  (target 300 K)\")\n",
+    "print(f\"LAMMPS production σ_T: {md_T_std:.1f} K\")\n",
+    "\n",
+    "from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (\n",
+    "    _multiplier_to_cell_vectors,\n",
+    "    _project_with_dynaphopy,\n",
+    ")\n",
+    "\n",
+    "trajectory_pack_lammps = {\n",
+    "    \"positions\": lammps_pos,\n",
+    "    \"velocities\": lammps_vel,            # carried for reference; not used downstream\n",
+    "    \"time\": np.arange(n_steps) * time_step_fs,                                # fs\n",
+    "    \"supercell\": _multiplier_to_cell_vectors(si_prim.cell, fc2_multiplier),   # 3x3 cell vectors\n",
+    "    \"n_md_steps\": n_steps,\n",
+    "    \"time_step_fs\": time_step_fs,\n",
+    "    \"md_temperature_mean\": md_T_mean,\n",
+    "    \"md_temperature_std\": md_T_std,\n",
+    "}\n",
+    "\n",
+    "# Reuse FC2 from Section A's macro output (keep_handles=True kept the phonopy view).\n",
+    "fc2_reused = np.asarray(out_ase.phonopy.force_constants)\n",
+    "\n",
+    "# Project via the macro's _project_with_dynaphopy node directly (now unit-clean\n",
+    "# upstream — `velocity=None` is set inside the node). Same physics as Section A's\n",
+    "# projection step, fed a LAMMPS-generated trajectory.\n",
+    "out_lammps = _project_with_dynaphopy.node_function(\n",
+    "    structure=si_prim,\n",
+    "    fc2_array=fc2_reused,\n",
+    "    resolved_fc2_supercell=fc2_multiplier,\n",
+    "    trajectory_pack=trajectory_pack_lammps,\n",
+    "    resolved_q_points=np.array(\n",
+    "        [[0.0, 0.0, 0.0], [0.5, 0.0, 0.0], [0.5, 0.5, 0.0], [0.5, 0.5, 0.5]]\n",
+    "    ),\n",
+    "    temperature=300.0,\n",
+    "    power_spectra=True,\n",
+    "    keep_handles=False,\n",
+    ")\n",
+    "print(f\"LAMMPS converged: {out_lammps.converged}\")\n",
+    "print(f\"renormalised freqs (THz): {out_lammps.renormalised_frequencies[0]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7344b780",
+   "metadata": {},
+   "source": [
+    "## 4. Side-by-side comparison — renormalised phonon bands\n",
+    "\n",
+    "Both halves share the same FC2 (from Section A), the same primitive, the\n",
+    "same supercell, the same target T=300 K, and the same production step count\n",
+    "(30 000). Differences in the renormalised frequencies isolate **MD-driver\n",
+    "differences** (ASE Langevin vs LAMMPS Langevin) and the underlying\n",
+    "trajectory sampling."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "6cc4f420",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T17:23:31.203513Z",
+     "iopub.status.busy": "2026-05-15T17:23:31.203168Z",
+     "iopub.status.idle": "2026-05-15T17:23:31.564263Z",
+     "shell.execute_reply": "2026-05-15T17:23:31.560116Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAGGCAYAAADmRxfNAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQAApRdJREFUeJztnQd4FNX6xr9N7w0IIdRQpRcLxYagUhQL9gqIvV271y72ivq3XwvqtV67oogVEGwI0pXeAySE9J7s/p/3bGYzu9lNttf39zBsdnZ25szslPOerxlMJpNJCCGEEEIIIcQDojz5MiGEEEIIIYRQWBBCCCGEEEK8Ai0WhBBCCCGEEI+hsCCEEEIIIYR4DIUFIYQQQgghxGMoLAghhBBCCCEeQ2FBCCGEEEII8RgKC0IIIYQQQojHUFgQQgghhBBCPIbCghAPmT59uvTo0cNqnsFgkHvvvdevxxbbw3a9xYIFC9T6PvroIwlXgnEft23bptr0xhtvSKgTTvviLx577DE56KCDxGg0BrophIQN33zzjaSkpEhhYWGgmxL2UFgQu6AjgA6BNsXExEjnzp1VJ3r37t08aoREOF9++aUcffTRkp2dLUlJSdKzZ08588wz1QPcVf755x+55ZZbZNiwYZKamiqdOnWSE044Qf7880+vtBWddNzTTjrpJOnataskJyfLoEGD5IEHHpCamhqvbMMb+1BWViaPPvqo3HrrrRIVZf14rq2tlWeffVaOOOIIyczMlLi4OMnNzVX79N5770ljY2MLQadNWFdWVpZMmjRJfv31V4fb//vvv9XyCQkJUlJS4nA5HLOnnnpKRo4cKenp6Wr5vn37ytVXXy0bNmxoMdjhaNq7d2+bx+TBBx9U+9ixY8dWB2zwbELH0RN27Nghl19+uRooio+PV+f2KaecIkuWLGn1e/jd0bazzjrL7uf63wPnnD3OO+889bk7+zB27NhWj7M2eTrYdf3118uIESPUuYRrvn///mqdFRUVLZbF+YrzGOdoYmKiOle+++47u+v95Zdf1HmNdebk5Mi1115rd52OjusTTzxhNd9kMslll11mtc8TJ06U3r17y8MPP+z2/hPniHFyORKh3HfffZKXl6ceJL/99pt6OC9evFjWrFmjHibEPtXV1UqMERKO4EF+8803K2Fx2223qQ7Bpk2b5Pvvv5f3339fPcRB9+7d1bUQGxvb6vpeffVVee211+S0006TK6+8UkpLS+Xll1+WUaNGKaFy7LHHetTeqqoqmTFjhlofOo7oMKKDfc8998gPP/wgP/74o8fWPm/sw+uvvy4NDQ1yzjnnWM3HKCtEwbJly2TChAly5513qs4dOuY45ueee646/nfddZfV97CeyZMnK9GBDv8LL7wgxxxzjCxdulQGDx7cYvtvv/226tgVFxcrK97FF1/cYpn9+/er3xdtOfHEE9W20Rlev369+u3/85//SF1dndV3XnzxRbsd5oyMjDaPCfYVbRo+fLjMnz9ffAXEA44VwH4PGDBAHV8884488kh55pln5JprrmnxPXRiIewgRiC2y8vLlbC0B56ZWBb7pKeyslI+//xzt5+pd9xxh9Vvhd/3//7v/+T2229XnX+NIUOGuLV+/XpxLHAtoa1//fWXPPLII+ocXLRokZUYhtDDOXTddddJnz591HHE8f3pp5+UiNBYsWKFjB8/XrVz9uzZsmvXLnV/2bhxo8ybN8/lNuL3wPWH8xDXg15MQWzcdNNNMmvWLIe/EfECJkLsMGfOHBNOj6VLl1rNv/XWW9X8Dz74IGiPW2VlpV+3N23aNFP37t1Ngeaee+5Rv423+Omnn9T6PvzwQ1O4Eoz7uHXrVtUmXIPBSH19vSktLc103HHH2f183759Lq/zzz//NJWXl1vN279/v6lDhw6mww8/vMXyuC/99ddfDttne+xqa2tNS5YsabHsrFmz1LH+7rvvrOYbjUbT66+/rl7tsWjRItPff//t0T7YY8iQIabzzz+/xfwJEyaYoqKiTB9//LHd7+F4vP322y3Ooccff9xquXnz5qn5V1xxRYt1YF979OhhuuGGG0ynnnqqaezYsXa3dcIJJ6i2fPTRRy0+q6mpMd14440t7kmFhYUmd8G+AKwD68I6Hd2Hk5OT3drGgQMHTDk5OaaOHTuaNm3aZPVZVVWV6cgjj1T7bO8c+vHHH1W78BobG2t644037O4Dlpk6dap6XbFihdXn77zzjvrulClT3N4HPbifYTu4v/maJ554Qm3r119/tcz7/fffW5x/1dXVpl69eplGjx5t9f1JkyaZOnXqZCotLbXMe+WVV9T358+f3+q27Z3nV111lZp3xx132L03RUdHm1577TW395e0DV2hiEtgtAJs3ry5hRvA6aefrkbRMJJxyCGHyBdffGHXvQojQzfccIN06NBBuSSceuqpdv0eMbo2cOBAZZKGOfWqq65qYZ6HCRguDRg9O+qoo9TIKUZp9CbS559/Xrlp4LPjjz9edu7cqUY17r//funSpYsy05588sly4MABq3VjBAmuDNg22tCrVy/1Hb3LgSNszc4YxcLIjd7Eftxxx8ny5cutvvf777+r0UC4F6C9GBG2Z4aH1ejQQw9Vxxrtwsios+iP2ZgxY9T+wyr10ksvOXQjgTsCjhW2h9EljI7a8uGHH8rBBx+s1te+fXs5//zzW7jNae4KmA8XA/yN8wCjSLbHFaN4N954o3JdwTHr16+f+j3x29kea7hgfPbZZ2q/sCzOG1dccrBtnDcYGcU5CdcLnCd6fv75ZznjjDOkW7duahtoF1wDMCLv7j7ifMby+L0xejtt2jS7LigYOcUoIX4DbBtuNjhncZ77G4xYw2Xn8MMPt/s5zm1XYyxw3tiOaLdr107db+CeYwusJBi5x6imHpwbM2fOVNPq1ast8+E2hHPdFtx7gO02cM1ddNFF6vyzBaO0GKm/++67PdoHW7Zu3SqrVq1qYdmAZQUj9ZdeeqlMnTrV7ndxv4Urjbv3b22f8XudffbZasIINEaPbe9PX331lTq+sMzYgnPT1i3FU2zj13wB7p+4xh5//HF1P9WD+9mbb76pzmNY8G155513lHUDliD8dnjviNGjR6t77bvvvttiHbjv4/kZami/j/6+BUtFdHS0Omc18OzAeYPzWbu34j4C9yg8K9LS0izLXnjhhepa+t///udSW/71r3+p5z3uD/ZcznBvgtUGz3biOygsiEtoHRn4+GqsXbtWmfvx8Pz3v/8tTz75pOqcoVP16aeftlgHzMkrV65UbghXXHGFMh+jY6gHnXIICXTqsT48xHDzhzCor6+3WraoqEi5CcC3+emnn1Y3eP0NGwIF20QnYeHChcoPHKZodDzhA4qbH9qAjp8edIZwc4MIghkcHQd0JrCPrgL3C7gDYD/QHmwLDyx9hwPuGBBHuNni2Dz00EPqZj1u3Dj5448/LMuhw4TjUFBQoI4TOpxY3t6xdgRcHWCWxj4hWBQdVvwWcMWwBaZurBttxg0bLnG2nRgcKxxXPEzgw3rJJZfIJ598okzeth1ldK7RKUSnC50QiCf8xjBd6zuI6NzDjxsPXJjIISzgfoPfw57QgvkbHSLsD1z3cKxxbjgDhBM6TDgf4N+Lhx06CXrRAOEElxocJ/i6Yx/wioegLc7uI8TBf//7X/VgxYMQHTmIC1uwL/gN8Fvj/EEbIVbhE+5v8HDGuYtrxlaMext09iBSbcExgysDxLm+84tz46233lIi2Z6rj731A9tt4LzFeYTzD4MJGhAyOB8hLp0V8472wZ6fOYAPux4cZ4BzxBf3b/29Ep1qDFhMmTJFDWzAbUePNlh0wQUXuLRdnCcQpPqptRgOf4NjjI4v7mH2gBjAOYF7tP6egDiCjz/+2OK6hlcs01rsCJaBy5g2QIJj8e233yqXMn8BNz3b38PeZC/OAa56+Cw/P1+1G89SXIuHHXaYlfhGzI1eLABtGbg/ac8yrA/CWA8GAvA8x3qcBYM8cP/CPRzPTkfgmadda8RHOGHVIBHsCvX9998rE/TOnTuV6Rtm/fj4ePVeY/z48abBgwcrM7jerD5mzBhTnz59Wqzz2GOPtXIxuP7665V5sqSkRL0vKCgwxcXFmY4//nhTY2OjZbnnnntOfR8uChpHH320mvfSSy/ZNZGivdp6wW233abmDx06VLlMaJxzzjlqm/p9gAnclssuu8yUlJRktZw9Vyhbk316eroy0ToCxwPHCi4P+mODNuTl5Vm5nZxyyimmhIQE0/bt2y3z1q1bp46hM5e0dsyefPJJK1eRYcOGmbKzs011dXVWbkL9+/dXn2s888wzav7q1avVeyyP7w0aNEiZuzXmzp2rlrv77rutjhXm3XfffVZtGj58uOnggw+2vP/ss8/Ucg888IDVcqeffrrJYDBYuStgOfx2+nkrV65U85999tlWj4W2j507dzaVlZVZ5v/vf/9T87GvrZ0PDz/8sGqP/rdwdR8fe+wxy7yGhgbldqF3hSouLrbr1hJI8JuiTXDbgCvDgw8+aFq2bJlX3brgboRje9ddd9n9fPPmzcqFAucn7lH333+/2tYjjzzi9DZwL4JbF46xPTTXT9x7du3apa5zXI/5+fle2Qc9d955p9qWrTsV3JIwX38fA7jWsN/apN8H7bjD1Quf7d271/Tzzz+bDj30ULuuf7iG27VrZ+U+cu6556r7pL22ODpetmiuUPamfv36mVzBl65QGRkZLfbVlmuvvVZtf9WqVZZ5eCZi3saNG9V73ENwb37qqaccuuysWbNG/Y3fAzz//POmlJQU5cLryT644gqlPQPamtAeW+DyZPs72m5n4MCBpnHjxrX47tq1a62e11o7cZ3YcsYZZyj3tNbQjiuuS7zefPPNbR6bhx56SC3rjssmcQ5aLEirYNQWbhxw+4CrEywRGLXCCLc2EoURGoz0YARVG+nASLHmqmDrDgMLgT5QEuZ5jPBu375dvUcgGIL/4DqkDwbDKDhGQDCybGt+x0iuPeC6AjcTDWSm0Eb/9MHVmI9t6tuKUVkNbd/QVoxaw/XLFeDmAjcCjPLYAyM4OFYYtcKx044j3IHgegS3BLgk4TjBLQLWIIyaaiDwDcfbWbDvCGTTjxDhPawgcJHSg2OLz23dKbZs2aJekfUG34PFQB98CDcypM20/b00C44erFNbH/j666+V9QMj83pgdYKWsA3qw3mqd2GAuRvnin6drQGrgz6YD+c63I3QDnvnA34X/D5wr0F77I2sObOP+B1gAdHAPtsGiGK7OP5IjQtLUzCA4Ee4c2gBtQgexUggRtudcftpC5xPuBYwUoyMO/aAeyO2jdFhbBuBmrBoYcTSGTCqiXsNLHKOgojxGYJi8ZvAKosRalizcG54Yx/04LrH+WDrTgULJrCdD6sM7s3apA+I1YAlE5/BxU9zyYLlDOe3HlxP2L4+aBx/w7IMi7RtW1wNfMWoPo6bfpozZ44EC60FXGton2vHQLPyYLQd2Ya0ZXDfa80dCm6auD9p1iBcR7BcwkLkL3AO2P4e9iZ75y3cvvAZXE/xOfoEtpYNWHXwXLZFez5oVh/t1dGytm6mjti3b596hZWkLTRrHe7fxDcwbQ1pFfgr4mKF6RRuMujg6m8C8LVHxwoPdduMJPoHLFLVaug7xPoLXes0aQIDri960LlCZ0L7XAPr1nd89dhuSxMZEEr25us7bnigwswL4aR/mAAcD1eAWwVcXLBddILghoTOLPYHaL7i9txg9NtExwY3W2TZsAXHS98Rbg24mOGBoEe7KcNdAp0oT38vAGEBNyXbBwY6O7br1B97rBNttH3YaxlObM8B2zbaW2dr2B5PCF90FvQxDHA7gischLXtem3PB2f3ER1U2w6j7XHE9YYUpBBVSLmJ3wY+/jh/0GF0BM4TV89TvZjRC3J7oOOJCdcGRDPc4dBJghuNJ1njINqwf+js4dxpLf0m3J3Q6YfvO44FBI8zfPDBB+rahs+3XtjZA373cIODyxVc8mx98D3dh7bQrgF03vS/CdzjEFMEcG7Yi/3CIA4GV+AaiPsYXEXsLYdsUBBAONe0+CnsJzq76CRrriWaawv2y5mMThpw8WzNHczWdQj7qRfy3gDHT98BhojXrlEcY+xTa2ifa78HXLlwv4Ubrz7mDLFHEFLIwuWoowvBic493HfgloP4Ln+CZ5C74BzQ4oAgiDRhhHjBoUOHqvn47fCsskVL7az9ttqro2WdPQcwmIDfAoNjOC9thbMezQXNmzWfiDUUFqRV4BOp+T9ilByjYrgpIrUgHpZaESf43zsaMddGc/Q3dHvYBuU6S2s3H0fbaqsNeGjALx43UXRa8JBFRwk3T9zEXC1eBYsORgzhJw+/VHRW0FlEHALiQ7T1YT58S+2B423vBuxrvP17OVpfMLXRFnTG4M8PCx1+fwgmCDNYuBB8bXs+eHsfYb1Dhx2jhBilh4hHLAs6i7AaOOo8O7LktQUErrNF7XCN4NhgQlpZBLpCaOD6cRVYDRGgjCBm7KfWcW7NNx6dXiQkQFAorjNcY62lesZoK0QZRpYdJSzQd25w34MfODqM6ADieGN73toHDcTjYDu2o+c41wDEmj5gHoMU2gAJRKu9EVgIZq0TCKGD8xIxYohD0+7rEIY4jthXewMW6DgiBgkdMa0t8I3XLJfewNYCBGsGritvglgnvfBEKmRt4AADFrA64v5qb/Qc4PfE+a0dI4hNLA+BgMkWCDJHQheCHPFqsMLjd0fMnD/Bfcw2JbC7Aww41xFzg7gRTVjg97RX72rPnj3qFYNG2nL6+bbLasu1BZ6NsLpBwCL+D/ckR8dUG9xxJu6JuAeFBXEaLTAXD6XnnntOPaC0EXfccD3NNa+/4QOIF239ADdCZE7x1nZaA24ncA1Axx83Kw1s311wE4W7ECZYceA2ggc2hIU2CqofDbIHRthws7fNhqMdL2eBSxZGVfVWC62wlatZWPS/FwLNbdukfe7qOuGmYtvJ0lzQ3Flna9jLLoRRSC3vOzpSOD7oNOuDtR0VfHIG7ANqKGAUVT+i7eh3xDmCkWlMaC8EKDo0GG22B4S+u+1z9oFuCzqrOEb2OgptAXGGY4tjgmwwbQkTLREDrhdYkdA5xnt0SBHcbW9EEoIHmaDQTmyjNQGCTj7Wh2QFc+fOVW5v6KwgqQBy8dsb9XV1H/RonXbcY/T1BiAI4JKFjqqjTFzOApe1V155xZK8AuAeB1GB5BK2nS2ci1gWGaMwqARxi2cAzjlvCgvb8xTuQt4Gv4veXUw/IIVjDGEKsWAvSB4CBFnhcK5p38PvAdEIdzNbENgPQeZIWMDCit8SzxlYzPxd8whiANePNwYYIK5w3uuto7g34RqBaNUHcOP60z4HOH7Yd7jT6gPn8ayHe7CjYHp7QKBh0A7HFfuHcwpZuGzB9YXz3NaiTLyIk7EYJMJwVMcCHHbYYSrftxaoi3znWVlZdgMaEYjd1jq1AFotAEwL3p44caJVIPMLL7xgN3gbgWK2OMrj7qhugW3bvvjiC/V+wYIFLQKcbYPi2greRkCubeAlQCDlIYccov5GkDpyfCOA2zZ40/Y4+jJ4G8HutsHbtsfKNiBXC95GDn59UPvXX39tN3jbXnCibQ0OLbAZgXZ6zjrrLLvB2/YC4/Gb2As+dCV4++mnn1bvEbCJ9/oc9Tg3kdPfNjjZ1X1sK3gbQZ36oHjtfME1iGB2f4P2/PLLL3Y/mzx5smr78uXLXQ7evvLKK9WyL7/8cpvLIlAcQdeoD6GvW4P89FjH1Vdf3eI7uEYQoIz7BeoWtAZ+W9STwDWlrx2BoGUE+bZv375FHQtX98FeMDq+ay/HPpI3oC04Z+xx1FFHWd0HHd3/wC233KI+0+qAIPlGz5497a4X1zMCiy+//HLLPNyXUdPh008/bbE87iPermPhj+Bt1BvBPQzBwvgd9ODawzNOX8dix44d6j5km6BBX5cCbf3tt98c/h54tmBfcF56Yx9cCd5GzRXUbmlrQrC1/tzXng326ljoz1vst+3+4lzq3bu3aeTIkVbfx/mEJAz6+++rr76qvo+6K61h77hu2LBB/ZaZmZlWgfb6JBqoF0J8By0WxGUQIAm/XYxkIEAVcRgYCYK/M0y7sDIgmAojQPBLRgCgK2AkAWZijPYgtSNGCDFyhjSbSIXojbSLbYHRSbgXYMQGAcQY/cQoqDuuNRh1R7A7/D5hKsboNEbjUcVUM6EjSB2Ve2G9wGgdXFgQOwJzMkZ+MOqjpZ3EccFoI0YMYf3AyCrSnuJ7MNc7OyINVyyMxMEPGG4zGCFCOtS2qiTbguWxLrQZI7Qw8+P3R4peWD/gR+wqGBmFZQwjrGgjjhtGo5B/HG5Bzvi5uwLyx+Mcxj6g7UhbDBc+nM/aaDK2CZc//Cb4PeBH7UkwNfYRo2uw/GEfERSJ0WPbuAhYShDAj9E7LIMRPrj7oJ1Ir+tvkLwA1wdiPXB9wh0HroNw08KoLlyHHLlnOQLHG9c3Rhjh129rhYGVQW9dgzsa7jNIDKAPekXtCfwmWhppLeUsrkFYcPAZ7l+2CQXw2+pHNzFCjxFpVNLW146A/zbcm3CuIN5Gn2ff1X2wBfuDEVzcG7AferAuHGscW9wjMHKO+5NWeRuxb5jvbK5/tBVWEMSM4P5imyRBA25BOG4YyUd8Bq51pPOF5QbHBecwzk3sF6xocIeBtcq2lgXqGtiLM4H7HOKGWgP3XcQj4bwD2FetRgFccPTWS6Qit1e/ANc37pWtjXajjXCPgyXZtvI2rJe4n2m1UGCN0FJi2wMxdLhOcQ5pCUNswb3SGYsWto/7kjfdw9yJsYB1BecJnmNwB4NVAdc77lmwAOqfy9hn9BHwHId1HvdSWDJxn8M1pQdWexxXHAtcs+gz4LmIcwznvKugbbhG4a6IcxcxTprnA9qCZyRS2RMf4kPRQsLUYqGNrmPCCCvAKM+FF16oRnxQQRQjwCeeeKJVdVZnLRYaSPF40EEHqfVhdBbVYm3THPrKYgEwOjVq1ChTYmKiKTc3V430oRKoqxYLjOIhDR5GOlNTU9WIFP6GBcYWjCKiOitGVpHWF+s988wzTT/88IPVcgsXLlSpS2HZwWgj0vc5W3lbO2YYtUIVVFg/sB0cb2eOlaNRaFRjx2gQ2g0L1nnnnadSdOpxdjQfwHKDVMQ49jgHYM3B72lbDdkbFov33ntPpSLGSBd+b1gi9BYhgJFFpCfFCC5GrC+55BJLWlt3LBagqKjIdMEFF6jRd6Qkxt84B/TrxGgq9g/XAtaL5TDqB6tKIECaZlTGheUMxxi/N1Iw47fH76NPTeysxUJL0eto0qova8A62lq6SNuq3Fo7XEmr6aiyN9i2bVsLq4er+2CP2bNnq/PLXmpjjJzDgoZrFudLTEyMut/iPosRcu1erN9fRymKp0+friwg2miz7f1FD6x0WObzzz+3zEP78F1YXdFe3IdwfV5zzTVW1sTW0s22NqLubGpU2/uwo+XwrHIGHDdc1926dVP3HFznJ510kiU1rAbSq2OZ1oCVA/cTXC9t/R6t3TuQMhvf/eabb0yBrLyN3xXPeDxvcI/EcwPPEfzGFRUVds/Xm266SZ2juEfgXHG0Dzi+SE+PdcJqjvud3oLhiNaOK9aJdiI99O7du9W8F198Ud2rnFk3cR8D/vOlcCGEBBcYyUGgJ4JBCSHBA6xVGF1FFjlkrCIElkqM9OuLpBL30BIvoPAl8R2sY0EIIYQEAcjAg9oAyA7nauY5En5g3BcuSPbcu4hrwH0Y7npwzyK+hRYLQiIMWiwIIYQQ4gtosSCEEEIIIYR4DC0WhBBCCCGEEI+hxYIQQgghhBDiMRQWhBBCCCGEEI+hsCBBCwoDoTAdUu3pA48xRcq+//nnnxKJ4DfH/uM4BBIUpEKRP1+e04T48pzzFLTFW4XZCCHhD4UFIYQQl0GVaYgkR5WFQUVFhdxzzz2qojSqM6PC8bBhw1T15/z8fMty9957r1qXowkVkNvq/GI5VKS2xyuvvGJZl16s224XFbO7deumKkqj0nFtba3bZwYqRWP9SBdKAgfOjRNPPNHp5b/++mt1LuTm5jpM+evp+RYVFSU7d+5s8b2ysjJJTExUy1x99dUtBlq0KTo6Wp2nqOa+YsUKt645e+Bc1bZhWzle4/DDD1efY/32jom2f6hSj8r3qKb9+++/t7pdEl7EBLoBhLjCt99+ywMWAXTv3l2qq6slNjY2oO1AB4H1BOzzzjvvqM4ECndt2rRJevfubfV5fX29HHXUUfLPP//ItGnT5JprrlGdnrVr18q7776rOkXovOl58cUXJSUlpcW20Elpi4SEBPnpp5+UCMnJyWnRVnxeU1Nj97vadiEkdu/eLfPnz5eLLrpInn76aZk7d6507dpV3BEWs2bNUn+7YmXlORcc5zU68z/++KND8eDJ+RYfHy/vvfeeqlmi55NPPmm1beecc45MnjxZGhsb5e+//1bn7bx58+S3335T4sGda87RvmH5888/32o+jskvv/yiPrcH2nDjjTeqv8vLy1UbP/zwQ3VOX3/99TJ79uw2t01CHwoLElLExcUFuglhBTo/GKUNNjDq5ejh5U+cETYNDQ1KfETSubl161bVwUBH6LLLLlMdKYyS6vnss8/kr7/+Up+de+65Vp+hw1VXV9divaeffrq0b9/erTZhJHXp0qXywQcfqNFZjV27dsnPP/+sOlUff/yx3e/abvfuu+9W7b7wwgvljDPOUB03X1NZWalGmAMtpiMZ/Aaff/65PPzww8pihXPAkbDw5HyDOLAnLNCZP+GEExx+b8SIEVadfbThpJNOUgLj5Zdfduuac9S+L774Qvbv3291XaB9HTt2lD59+khxcXGL73Xu3LmFGHn00UdVW1DtGt+74oornGoDCV3oCkVCCtsYC810+7///U8efPBB6dKli+qQjh8/Xo2i2gKT7MSJE1WFW3Sojz76aFmyZInVMhhpue6669SoFUaWsrOz5bjjjpPly5eLv8EI6g033CAdOnRQnQ48rAoLC62WwYMQDyOMRKG9vXr1kvvvv1+NaunBcYP5etmyZWpUC/t/++23W8zsTzzxhDz//PPSs2dP9dnxxx+vzPWo/or14djCTH/yySfLgQMH7LrGDBw4ULUBbbnqqqukpKTEbhvWrVsnxxxzjNoOHkaPPfaYUzEWGIk788wz1fFAW/r16yd33HGH28cXo304B1JTUyUtLU0OPfRQ9fB05O+uP1YYzcaxxv5ifzxpH9px5JFHqt8YbcHviVFGPRgZnTFjhvodsM1OnTqp3yIQ8RrouGRmZqp2olOO97Zs3rzZ0vmxBdcojrc3wTqnTp1q9fsBdODQ1gkTJri0vvPOO08uvvhidc/47rvvXPoufhOcAwBWC81FBK4w2nkFCwmOETpx+M2xPUcxFjjfxowZo9xacF4dfPDB8tFHH7XYruZCgw4mrjOcJ7gmUXXYFtw7DznkEHXccB6jY6q56rQFrmvcI2HJwTZgrUIH0ta69/7776u2atcXXGOeeeYZCVY+/fRTZSmFmDz77LOVcHZkdfDkfENHGy5MuF/or29YSGwFQWuMGzfOIvS9ec3hvoLfFdYGPdhX3N/giuUsOF//+9//SlZWlnpG43lCwhtaLEhY8Mgjjyi/zptuuklKS0tVRxUPar1vJ27akyZNUg86jK5ieYxK4eaMEabDDjtMLXf55ZerhzYe0AMGDJCioiJZvHixMutixMgRMENj286Amyy23xYwZeMhhfais4LOLNqFUTINdL7RSYEAwSv2EyOu8Nd9/PHHrdaHfcExwEMTI0sYfdJA5xAjWtgmhAOOIR4iOD7ohNx6661KrD377LPqOL/++uuW76JDgg4URvcwIrV+/Xo1ioYRPQg3/SgsRrog7vBQxvpxrLFudDrQNkesWrVKdb6xLvjtovOFB+mXX36pHliuguMGdxd0vG677TblboPRPnTC2nq447xBhwPtwAMYv6e77cNDF24L6IigcwYrEo7dEUccodqjdTJPO+00JTbw+2BeQUGB6vDu2LGj1WBfiFOIZWdw1lqAcwW/H6w0cM/QfmsIM707G3jrrbfkzjvvdKrDak+wxsTEOOUKBfC7QRDjuKOzrHWGIH7csQRccMEF8p///Ee5YGJwwVkgKnBMcC1gMADHCgwZMsTK0oXfHL8zhENrlkN0xjEyjXsarlF02NH5hZsWxJ0e3KvQIb7yyitVh/7//u//1LmD8wTCBOC8wjUIcYrrFoMQ9913n0UMtQbOT4hxuIzBWgVff1ivcA3t2bNH3aMAzk2cGxjkwXkNcA/F/UA/wm8P3CNsB0bsgWPmTYsrzmsMeMC1CffIf//73+r6xbH25vmGgR0MEGBZHHeAezru37a/Z2toQkL7Xd255uyBYwpxAZGkWRhWrlyp7j+vvvqqute5AvYL18Frr72mBmFwzyVhjImQIGXOnDkY2jBt3brVMu/oo49Wk8ZPP/2klunfv7+ptrbWMv+ZZ55R81evXq3eG41GU58+fUwTJkxQf2tUVVWZ8vLyTMcdd5xlXnp6uumqq65yub1aW5yZ9PvU2r4fe+yxVu29/vrrTdHR0aaSkhKrfbDlsssuMyUlJZlqamos83DcsM6XXnrJalm0BfM7dOhgtd7bbrtNzR86dKipvr7eMv+cc84xxcXFWdZdUFCg3h9//PGmxsZGy3LPPfec+v7rr7/eog1vvfWWZR5+t5ycHNNpp53Wok04DhpHHXWUKTU11bR9+3ar9uuPj7NgP7GukSNHmqqrqx2ub9q0aabu3bu3aFdaWprabz3OtM/2nC4vLzdlZGSYLrnkEqvv7N27V52H2vzi4mL1vccff9zlfdW26czkDH/++ada9rvvvrPsX5cuXUz/+te/rJbDedmvXz+1LI7h9OnTTa+99ppp3759LdZ5zz33OGwT1tEWWP8JJ5xgamhoUOfS/fffr+avW7dOrWPhwoWW47B06dIW2y0sLLS7Xu24n3rqqSZXwTrxXWzDFpxX+Ozf//633c/055y9a7yurs40aNAg07hx46zmY524Fjdt2mSZt3LlSjX/2WeftcybMmWKuj/s3r3bMm/jxo2mmJiYFucB2oI2aeDYJicnmzZs2GC1HPYF96YdO3ao9zgfcJ3gN3EVbNOZ89XesXV0brQFzkvs/yuvvGKZN2bMGNPJJ5/sk/PtpptuMvXu3dvy2aGHHmqaMWOG+hvL6J9B2n1n1qxZ6ru4PyxYsMA0fPhwNf/jjz92+Zpr7Rn24YcfmubOnWsyGAyW3/Pmm2829ezZ03IfHzhwoEvH+amnnlLr/vzzz51qCwldaLEgYQFcRPQ+7hg5Blu2bFEuATA7b9y4UY3iYNReD0bUMGoMM76WzQKWDmTQcCbQTWPo0KFOu0zYBvs5AiPf+lEn7Bd8Vbdv324Z/YSpWQMj0xihxnJwbYCpHe3SwOg6jpU9MCoHFzENLdsPLBsYNdbPx0gWRizhNvX999+rUVS4RuitMJdccolytfrqq6+stonRK70fLn43WIvwWzkC7l+LFi1SI50YIdXjzqgcficcK4xI2sZyOLM+jADrR3fdbR/aAbcSjOzCn1kDrgY4zggO1X5jHCdYjmbOnKmsWM6CUXFXXXnaGtWFpQsju9r+nXXWWSqLzJNPPmlxk0CbcR3BWgNXRViIMOEcwWg6RulxPuqBb7mtuwbcw5wF24YVDOcnrnW0Fe46uB5aO78coQWSO2vxcRVn/c3117g2mo99wn7aAquhNnoOcJ/AMdX2H9/FNWsbyAt3JlgMMULfGnCPwbZxDurPWWwXlmNcB7Cs4D6KmAWce7COuAJ+N7gktQXuP94CViCcm7i2NXBdIhgZx9zeNefJ+QZrB64BWPqwbrw+9NBDrX4Hlmt9LBN+V1iDNIuYO9ecI2CJgSUWxwUWarwi5shdfH0tkeCBwoKEBbadOe0hoAWYQVQAuJw4Am5M+B5cgLAcHhBwm4IPNG6obT3E8F1HgX6+2i8A8zQeanCBgvuT7T7pQTyDoyBj221pIsM2I442X2sDRA5APIEebAfHTPtcAy4Atp1t7Fdr5nXtIW2b4tBdNBcCd9eXl5fnlfZp56XmK22L1slGZwAdCHRy0KkfNWqUSqGJ87ItkQp3F0zeAJ1SdDAgKjS/bgARBFHxww8/qA6J/lzB9YQJ5wE+R+fmueeeU5898MADLVxE3A3e1nfY4P4D1w24msClxV2XEGTUAXAp8jYQ67gWnAEuTzhWGCDRp8C1t1+217F2fWnXK1zo0Gm3zeIF7M2zd87iWnXkNoX1A3Rk0bmFWMF9B+cFOuHOiAx7MQK+BsIYAxwYeNIGn4YPH64GTSCmMMjjzfMN6z7ooIPUdyDCcB07ug9ooA0YANIGwLSYNj2uXnOOgCsXtoX24bgg3s6V+A9/XkskuKCwIGGBo2AyLVBMCypEzAFS4rU2ooKHH0acEMgH32p8B506+C23FgOAB5A9H3F74KHsTABcW/uF0W74O6MDCl9djFRiBB6B5ohbsA2m1I98OrutttrgKt5eXyBo7Ti6gvb7wGJmTyDoLUWwCKG+AgJzkQ71rrvuUtlrICjRSXEEOpHOxv60JVKwLfjRQ1xgsgUjtnphoQf+34hpwUg5BCeWdbaT4woQObgOcLwgfjzpDK1Zs8bpDreroEPoTJwV4r8QXwHRhQQJEIno9CHOxzZw2B/XF85ZxJvYZjTS6Nu3r3pF0gsIIZyrSE6ACW2GGH7zzTdb3QYsgM7EWOCebS89satALMFiAJC5yBacq46EhSfnG5ZFLA4627D6tXU+oG2uDF55es2hfS+99JKKoYPlGzGHwXgtkeCCwoJEBJprADrgztyY8fDGiBsmjMAhaBvm5daEBQIYNfeQtsADyBvVdeEag9E1iB50PPTr9xdawCACtvVWHQgttMMbVhxtvdrDyVO08wHr88aDzt32ae1AJ8yZ44TlYbXAhM4QRDIsBY6KWWlBoY7c31ztfKJjgrYie5gtOAchxtERaU14YfQc++Gt39IecGFBB6p///4OBxKcAYIPuJpRCrhrJbEF7mEYLEAHXT86jU66O+D3w/rsZc2zN88W/HYYfXbmfIXVEmIYEwQJ7qdw0YQobu26QxIAW0unPeAWpGXa8gSc1xBr+L1thRmC4WGRQPC7PWuQJ+cbOu5ItAGxrp1rvsDdaw6JBbDPeM5oAfjugPMF9wZYv3GMSHhDYUEiArg04cYKkzBu5rajXBghgxUBo2S4CepjDfAghi9yW1V4fRFj0RbaQ1DfIUSHHiOb/gIdDHQg8PCFm4PWoUIGEIyUu5LlxBH4bSCckIkK2a/0D3jsu6udOIyqY5QQI/5osz7Owp31uds+dFghduFbDVFqm0lGOy+RiQejmfp24nzGPrR1XnorxgKWD4gHuEcg640tuEbga4789xh9hWsIXGBsXZvQYURmGFvXOW+CNLFanIq7wBqADDijR49WcViuomUrsk257CrYD5w/+hF8ZIiD5crd9eGaxff1cWQQFbAqtAUsuujMQ+jYCi7sK+6tsLRhwEPLVgRw/mpxYW2ds/6OscD2YKXGeWsLfn/c23BuwwrszfMN1zCyaGFftayEnuDtaw7nHfYdWcSQIc0dsG/4Lqz5uM95S3CT4IXCgkQEeKihkwCLA/xSMYKLGzACkBEgi84dghYRWAa/Z3ScIBTwkESgI8zkGBn2d4xFWyC3PbaLmJBrr71W3bQx8uVPtyJ0fJFqEmkr0UmH2wasFxA3GHm0LZjkLnjAYQQN1iO4JSDOAR0sBIfD5UIDxwDuYRhlcwR+bwTBo0OANkJs4jjiwYxOfFuuGp60z7YdcIXAgxffg382jidGR/E9+JrDN3rDhg2qc4tOHdwR0HHDCOC+ffvUd/wRYwHBgOsDv689EPeBtqOThg4axAxGlLE8PsO1hFgUiC90LO2NNCP1sD3XFrje6FMjO2NFc2UkW9suRLlWeRtpUXEPsM3lj/MKIrCt0XJYbfBbwWIE9yAEwiIGx9U4HAhzVCzGtYXzFBZUWIww4u9q2k8NtBtunji/EEAO0YLzTEt00Ro333yzOhcQ44OaGxi0QZD26tWr1XHEOY+OLa4tdCYRN4B7Kjq3SFWNEf22Rq29HWMB0WTPBQguhGgrPkcab3vgOYFrE+e1I2Hh6vmmp63Uu67gzjXXFkg7i8kZcO1o1lMM0EHM4PpBjQ5YWZGemIQ/FBYkYkBxtl9//VUVe8NDFDc+WA4wyqTd8DDKCHM9HroYnYX5Hg9wdJKDsWIoRgQR2ImbNgK40TlGRx6dUHfcN9wFDyx0KnFcr7/+etWJQucaI1TeqiSMTh4qIMONAp1x1JHAAx2dbdsAQWc60siuBGsUMtngnEA7EUyJ9vuqffZAZxGjxmgH4nnQAUBnBiOomgsTXAjgboFATAhHCAu0FcGx+iw2vgQdK1hMHNVzgHhHJxjLYbQa7YIQwbWE2Ax0MnF+YmQW56s9t0FH1xjEvyvCwlW07WL/0NFE5xedMfw2tsGxrpxjGMxA3RGcUxAt6PS5KizQMYf1D+cH/PghWOGWgg68u8ICYgDWCWT7wfmK8wsxWqgzoS/aZg/cIxcuXKiubXQaUTMBAhniCYMLmrUX9yHUAMG9E5YM3GshOHGvcCa2xJtgoAP7ae8eoFmW4K7lCHyGduN462uRBBvuXHPeBKIUgyQY3IE1FecVjh1EpjcsMiQ0MCDnbKAbQQgh3uDrr79WI6mwPKDgHiHeBkHLcIvBKLezqTtDhVNOOUVlmdOylRFCiKv4d9iAEEJ8CEa24RpEUUF8eY5h9DvURYVtDAPEBIQ5LLuEEOIutFgQQgghEQZcuRAjodWagfse3PAQqGsv5SohhDgDYywIIYSQCAPB4HDpQmAtrC/IfoS4CYoKQogn0GJBCCGEEEII8RjGWBBCCCGEEEI8hsKCEEIIIYQQEtoxFqh6i1oByJuNYkIo9oX83PrqkMhQgZzZelBz4KWXXnJqG6hDgOqiyKnMio+EEEIIIYQ4DypToEYKai61VYcmoDEWCB5DakhUvm1oaJDbb79d1qxZo6o1JicnW4QFCu+geI8GCtqgII8z7Nq1SxVpIYQQQgghhLjHzp07pUuXLsFrsfjmm2+s3r/xxhuqEu6yZcvkqKOOshISqNrpDrBUaAfDWTHibWA1KSwsVJWJ/V1xlJBIgtcaIbzWCAknjEHQhywrK1OD9FqfOmTSzZaWlqrXrKwsq/nvvPOOvP3220pcoDw8ihNBbNgDebgxacB0A1JSUtQUqJMCxYiwfQoLQnitERLq8LlGSORca0ajUb06E1IQNMICjb7uuuvk8MMPl0GDBlnmn3vuudK9e3fl17Vq1Sq59dZbZf369So2w1HcxqxZs1rMh9qrqamRQO0bRBO8zigsCOG1Rkiow+caIZFzrZU3DdKHVB2LK664QubNmyeLFy9u1X/rxx9/lPHjx8umTZukV69ebVosNPNNcXExXaEICXOCwWRMSCTAa42QyLnWysrKJDMzUwmctsIKgsJicfXVV8vcuXNl0aJFbQaFjBw5Ur06EhaoIIrJFvwYgexowHwU6DYQEgnwWiOE1xoh4YQhwH1IV7YbUGEBY8k111wjn376qSxYsEDy8vLa/M6KFSvUa6dOnfzQQkIIIYQQQkjQC4urrrpK3n33Xfn8889VpPnevXvV/PT0dFXXYvPmzerzyZMnS7t27VSMxfXXX68yRg0ZMiSQTSeEEEIIIYQEi7B48cUXLbUq9MyZM0emT58ucXFx8v3338vTTz8tlZWVKlbitNNOkzvvvDNALSaEEEIIIYQEpStUa0BI2FbdJoQQQgghhAQfjCQmhBBCCCGEeExQZIUKZ3b8vkIObNgq9UkJUtOntySmJEtsYpzEJcZLQlKCxMTFBrqJhBBCCCGEeAyFhY/Z8uty2b1+ozQ2GmXDDz9LVFy8GOLjxBAfL4bYWImKiZGY2FiJjo2V2Lg4icEUb36NjccUb35NiJM4/J0YL/GJ8RKH90kJ6pXihBBCCCGEBBoKCx9TV1za/MZkEiOK96kCfuUqL7EhLk4adELDmXLptkRFRythokSJmvB3vHqFGIFQgQCJTTCLFFhL4hLiza+YkuIlJoanAiGEEEIIcR/2Jn1M/5OPl44bt0rxjl0SVVUl9dW10mA0SqPRJA2Njeq1sbpaGisqpUFMYoiFyIgTAywbcc4JDWNjo5rqa2rcbqfFcgJh0mQ9wd+atQTv9cLE/JpgEScJifESFRPt9vYJIYQQQkhoQ2HhY7qOGCidh/WXgoICVY5dKiqkfvduqdu9W70ayyssyxohNpTgMEkdBIeYpDE1XUwZ6WJKThNjQoLUNzRIfU2tNNTVS31tnTTU6ab6emmsr1eWEVcxNjRIXUODSHW1h+IEgkTn1tUkTmLiddYTiBG4dSU0iZQExJuYrSgUJ4QQQgghoQmFhb9LsqenS3R6uiQMGKDmNZaVKYGhTVFl5RIXI5KkfamhTGQ/JhFDTLTEdMyR2Nxcie3SWWI7dlTuU3qMRqPU19RLbXWN1FXXKhFifq2TWgiS2jo1r76uTgkTvTiBKGmor5PGunq39q9ZnKh/bhEFa0mTOFHCBO8hSCBWmsSI2YoCcRKnYk7g5hWPeBMlWOIoTgghhBBCAgCFRYCJTktTU0L//i2FRn6+NJaWWZY1NTRaPpOlS0WioyQWQqNzZ4ntnCuxOTmqYx6fFK8md4E4gRhREwRJVY0SJLUQKJowqTGLEfVeZzWBKKmvrxMjLCfubLu+Xmrx3Sq3m28WJTE6caK5dFmsJ81uXSoQvslqYo49MVtRoqKYiZkQQgghxBUoLEJBaOTnWwSFXmhIo9H8WX6+yFJpEhodm4RGZyU0bC0azoBOdUJyoprcxdjQKHU1zcIEr4gvqas1ixIlTmrhzqW5ddVa3LkgYhoa6t0WJxA3yurirjgxGCQ61uzWBVESbWU1aY43geuWxXqSqL0ia1eCxCbEUpwQQgghJKKgsAgVoXHQQep9Y3l5s9DYBaFRaiM09qhJlv7ZLDTgOqUJjbg4v7QbsRIJKUlq8lSc1FRp7lwQKmarCd5DgGhCBeKkAeKkvl5ZUCAs4NYF9yyXMZks4qS2stIDcdIUBK/L2GWxmCDWxJJKuDkoHpYmlbELmbriKE4IIYQQEjpQWIQY0ampEt2vnyT066feNzYFg5unfGksKbEvNP5cJhJlaGnR8JPQCJQ4aUDcR3Wd1DVZTeqqayzCxGw1gfXE7M6Fvxvxqo85qatTGbfcEyfm9bmLISrKLEpsUgnHxsVLdFMwvCVrV5MFpdmdCzEn5uXp1kUIIYQQf0BhEeJEp6TYERo61ym90DCapH7PXjVpQiMmO1vimoRGTKdOEhXEQsMdUJ8jJjVGklI9FCdNVhNMtTrribKawGLSZD2xZOiCO1eTMIFAcUecmIxGsxVG1T3xRJyYg+AtwgRWE8xTgfBN1pIEZOyKVTEnlniTpikmNobihBBCCCFtQmERlkKjryT066veoz5Gfb7OolFc3LwwUtvu3acmWbbcIjTgOgWxEZObG3ZCw21xkhYjSWnJbq8Drlo1CIJXMSeINbGOOVEipclqYhEmFutJvTQ21IvJbXGC4Hv3a5wYUIAxBsIE1pNmdy6La1ecWZhoAkVl6kJgPNy5EuIkISmB1eEJIYSQCIDCIsyJTkmW6L59JaGvWWgYKystNTRU1qkD9oVG9fK/zEKjQwdlzaDQ8Ax0ylPiXA+kt/w0EAj1cOtqijeBe1dNjbKeNNTWW2JPtGB4WDnMIqVeV+OkTgkNV4GgQTFHT8WJxWqC1yZBYsnYFW924TJXiTdbTeI1ty6kEsZnHhw/QgghhPgeCosIIyo5WYkMvdCAwNDERguhsa9ATUpoGJqFhkpvC4tGvPtpbYkLv1tUlLICYJKMVM/EiXLr0mJOmgLitSxdcPGqrZVG/F3XJFKarCYIhsff7hRghDip97Q6PMSJVTA8XuN1mbrMKYara2ulMrtExZnEIhYloVmsMFsXIYSQYMPYVINMc7NWmTTVs7leamtqpHh/kRgH1Etu764S7FBYRDgQGvF9+qgJGKuqLFmnIDYaiw40L2wySUNBgZqq/9IJDS3rVGcKjZARJ5keiJO6erM4qalVbl22wfB1mrVEc+dqem3UMna5Wx2+sVHqUBm+lerwWCu2sT0uTgytpRLW6pw0BcdH6+NPIFK01MJNwfFmS0pzSmEVGB/D2ychhEQylgQxltjLuqZCxM1FiJvrfWGgDhknm2Iw4UmAeQ2tFybWnmvxsXEUFiT0iEpKkvjevdVkKzTw2rC/yL7QWLHCLDTat2/OOpXbSaISEgK3M8Q34qQpA5U3RmYQd2KuDq/VNjHHm6gsXU3vtTonWpYus1uXe+JEn0rYkyKMmgUF1hNz5i6zMDFbU8xphs1uXma3r2aRolWMN1tRmLmLEEICaB1Q8Y4YEGt+5mgDY7Di62Mdm7NFmuMe3U3M4i71rYiPYIJDbsQ1oVFdbVWwr4XQKCxUU7PQaKcTGrkUGkSJE606fEpWmmfV4ZvcucziBBm7aqSooEgSExLMVeB1D4Rmly5tlMj9IoyqDY2NavLEvcslK4oSJ+ZijeYAerObF60ohBCJdOuAso5jEEpvKXdgHahvcG9gystE4V4fg3u9llbeNrW8+b4fHRMtVbU10r1vnoQCFBbEJaISEyW+Vy81WQmNJrGhhIZ2wSqhsV9N1StWNgsNzXUKQiPR/ereJHJxVB0egiOtoECys7OdSpHbml+rSh+sN2Or0StNrJiLL1qEipuB8f6wojQ/rDRLCq0ohBD/YHGfVQlHatu0Dmhp2jW3IcT2wTLgb+tA2yncY5rvtcp9Vru3xloEgXKhxUBQQmxTralmt1pYrlGry9ljWFBQIO2zsyUUoLAg3hUaNTUtLRr2hMbKVeYT0NaiQaFBAmQ98QTc+M2V4rWAeE2gND1ELTEnoWRFabKcaMHyMTFtWlHg2qU9QNVDFBNjUQgJSesA0qOre1rT/Uy5rDZlH2zTOqB7DWrrAOape1iTOGhyW42zKj6Le5v5FWKARWdbh8KCeBXEVMT37KmmZqGxRyc09lvdZCA8MGlCI7pdlqVgnxIaSe4XtiPEX+BBExUXpR5WntQ7AUqgNBVeNJv8mx7eTlhRGm0e6J5ZUTyrHO+SFUUXKG+JR4FwYSwKIR5bB7TOvxZQrO4hVgMcwWwdaB7gaNU6EKe5hzZlCtSJAVesA8RzKCyIH4RGnpqAESMdu3WuU4WFVkIDWaiqMa1abS00mtynKDRIuIMHYEJMSzcvX1lRzL7JdSrFsDmlsFmYhIQVRV9RHqmILdm8aEUh4WcdaBE31uQ2FLTWAcSO6dODx8Y5ZR1QAiExXrkb0ToQelBYEL+CuhcthIYSGU4KjaxMS8E+ZdFI9mx0mJBwxddWFC2DV4PeJSJUrCgx5g6PtVBp24pizohmdvFixyey0RctbRYFzXEDrVkH9NcDXhGvFczWAQgEq2vCkjyC1gHSEgoLEnihkZenJk1oNOzZYynYp4SGUSc0DhSrqWb1GvU+OhNCI9ciNig0CAluK4ptZ0zrhLVpRdGlGva0M4bv1uH7rdRE8ZYVxX5nrDmYUyvgSFcN/2C24tXqrAMtRbJdQRCs1gEbkdy6daC5Pg9FMvEVFBYk6IRGXI8eagJG3NCbsk5BbKBmhpXQKC5WU82atdZCI9ccpxGdQosGIUFZpNFDnLGiOOoghoIVxV4HEfMj0YrijHVAs5L5UpD6wjqgfnenBakudqBpHgUpCTYoLEhQExUXZxEayZrQ2GMOBndKaGRkNGed6pwr0SkpAdwbQkgoWFHsurSgcnwIWFHsurS42mn1UsCrW+JPZxnwivjzIq2Kvzgbd6EIE3+EaFBYkNATGt27qwlCw4QRqr17LVmn6vftsxYaJSVqqlnbJDTS0yW2iyY0YNGg0CAkkvG6FcXKzcYceOtPNxt0wBtU9rBan3ekKyoqJT4uTgX3txBaDQ0eBf17DVfd1ZoSANimTqZ1gBDnoLAgIY0BQqNbNzWJrdCACxWERmPzSFdjaamaatausxYaTVmnolNTA7YvhJAwsKKkJKkpEIHBqCjsLysKZA+2jY65QbyPXtREx2jB9S4G2OM1LpbWAUL8CIUFCX+hsW+ftUWjVaGRpnOdotAghIS2FcWZVKZKmHjDitKGdUATBkwJTEj4QmFBwl9odO2qJmCCnzSExi5NaOy1ERplaqpZ97d6H52Wai000tICti+EEOIqqHwekxLjHSuKrvhabXWNFB8oluxOHSUhKVG5DtE6QAihsCARhSE2VuK6dFFTC6EB16m9e6yFRlm5NJb9IzV//2MtNLSCfWlpYjD4whGAEEKCzIqi3IziRSRVCQ1DUoxkZbenqxEhxAKFBYlo7AuNAovrVMO+vWJqaHQoNKJSU5oL9lFoEEIIISSCobAgpIXQ6KwmYIJ/8r59TQX78qVh7x4roWEsr5Daf9arCUSlpFgX7EtPp0WDEEIIIREBhQUhrWCIibHEV7QQGvkQGnvFVN+cdcVYUSG16zeoyUpoqIJ9uaquBl2nCCGEEBKOUFgQ4qnQKChoLtjXltBITrYu2EehQQghhJAwgcKCEE+FBgK5c3Ml6dBDxdTYaBEaatqzx1poVFZK7YYNagJRSUnNQqNLZwoNQgghhIQsFBaEeBFDdLTEduqkJjnkEGuhgaxT+RAazdVojVVVUrtxo5qshUZTwb7MTLpOEUIIISQkoLAgxF9CA65TEBqFhc0WjTaFRqJ1HQ0KDUIIIYQEKRQWhPhbaOTkqEkOPlhMKDplKzTq6izLG6uqpXbjJjVZhEZTDQ0lNLKyaNEghBBCSFBAYUFIADFERUlsx45qkhEjnBMamzarCUQlJjRbNHJzJbpdOwoNQgghhAQECgtCgl5o7NcJjXxroVFd01Jo6C0aFBqEEEII8RMUFoQEvdDIVpOMGG4WGvs1oYFg8Hwx1dZaC43NW9Skvp8Qr4SGVhk8un17WjQIIYQQEn7C4uGHH5ZPPvlE/vnnH0lMTJQxY8bIo48+Kv369bMsU1NTIzfeeKO8//77UltbKxMmTJAXXnhBOmJEl5BIFBrZ2WqS4W0LDVNNrdRt2aomW6ERk5srMRAaUVEB3CNCCCGEhAsBFRYLFy6Uq666Sg499FBpaGiQ22+/XY4//nhZt26dJCcnq2Wuv/56+eqrr+TDDz+U9PR0ufrqq2Xq1KmyZMmSQDadkKAVGo1FRZaCfUpo1LQiNOLNQkNLb0uhQQghhBB3MZhMJpMECYWFhZKdna0Ex1FHHSWlpaXSoUMHeffdd+X0009Xy8C60b9/f/n1119l1KhRba6zrKxMCRKsKy0tTQKB0WiUgoICtW9RHB0mfgSXdyMsGqih0SQ29ELDFiU0kB63yXUqpkNoWTR4rRHCa42QcMIYBH1IV/rSQRVjgQaDrKws9bps2TKpr6+XY4891rLMQQcdJN26dXNaWBASyRgMBonp0EFNiUOHmoVGk0VDCwZHXIYG3Kjqtm1Tk/p+XJwuGDxXrSeUhAYhhBBC/EdMMCmy6667Tg4//HAZNGiQmrd3716Ji4uTjIwMq2URX4HP7IE4DEx6laWtH1MgwHbRoQvU9gnRE5WVJfGYBg82C40DB3QxGrvFZCM0arduVZNFaHTqJDGa61SQCQ1ea4TwWiMknDAGQR/SlW0HjbBArMWaNWtk8eLFHgeEz5o1y66bFQLBA/WDwBqDE4OuUCQoQcG+nBwxIfNUSYkY9+0T4969atILDamsFCkuFlm3zvw+NkaisjtKdE6OROXkiKFdlioCGCh4rRHCa42QcMIYBH3I8vLy0BIWCMieO3euLFq0SLp06WKZn5OTI3V1dVJSUmJltdi3b5/6zB633Xab3HDDDVYWi65du6pYjUDGWMAlBW2gsCBBDzKuNWVmUxaN4mJl0WhoyjplrKqyXr6kxDz9848YYmMlRsVo5CoXqpjsbL8KDV5rhPBaIyScMAZBHzIhISE0hAU6Lddcc418+umnsmDBAsnLy7P6/OCDD5bY2Fj54Ycf5LTTTlPz1q9fLzt27JDRo0fbXWd8fLyabMGPEchOPU6KQLeBEHdA7Yu49u1FtBiNkhKp39UUo7F7t7XQaGiQhp071VSN8z42VmI75TQHg/tBaPBaI8Q/8FojJDKutSgXthsTaPcnZHz6/PPPJTU11RI3gchz1LXA68yZM5UFAgHdsDhAiEBUMHCbkAAFg2dmqilx8KBmoQFrhiY04C7VhKm+Xup27FST+n5sjDnrVFNAeEzHjgF1nSKEEEKI9wiosHjxxRfV69ixY63mz5kzR6ZPn67+fuqpp5RSgsVCXyCPEBJkQmPQQCeERkMLoRGTk2OuDA7XKQiNmKDw0CSEEEJIKNex8AWsY0FI4FCZLEpLzcX6mjJPGSsqHC5viImWmBxzjIaqDu6i0AiGfN+ERAK81giJnGutLFTrWBBCws+iEZ2RIYmYBg60CA0EgWtiw1jeLDRMDY1Sv2uXmqr0QkOrpZFDiwYhhBASrFBYEEL8LjQwJQwYYBYaZWWWquCtCQ3RhEZHLRg8V2Jh0YiN5S9ICCGEBAEUFoSQwAqN9HQ1QWiAxiahoU2NZeXWQqNpviI6SmI1odGls0R36BCoXSGEEEIiHgoLQkhQEZ2WpqaE/v2thUa+OSC8sbSseeFGo3l+fr7I0qViijIIyvkVp6WpbFOqKrghSgzR5leJihJDlEG9qvnq72iRKIN5WTVf97daXvuuzTLIZmVvvvo7unk7WIdB97d+3fr5+BvrtDefEEKI06jwYVSLbqpabfnbiL8b7c83GUUaG+3PV3/rX/XzzevUzzfp/25sRINafFdbX/M6jFbfNal2mtT3a8rKpPrwMZI8YkTQnwUUFoSQ0BIa5eXWFg0boWGqrJTGRnNBobBAiQwIlibRAcFiJZJ0wkgvdPB3tB1hpP1tK4ysRFK0HQGmE2n25uPvpnXa/a5eVDmcbwif342QIEJ1lm072+hE23actQ5wo7mT26Jz7Wi+vsNuO1/rXNvrdOPvpnXa7Zi32mFv6pib7HfMwwWTyaSea8ZqDJsFPxQWhJCQIjo1VaIPOkgSDjqoWWg0WTPqdu0WQ2ODGOLixCAm3UMohB8yqgOAUSuj+a2EOVZCR29tsi+AHIkqvQByJKo8EkD6ZSzbsmO9guXM1gKlXx8JGFrnusXotaVzbTPSbDWSbaczrv3tToe9tdFwb3XMSYgNJkU137NQfTs2NLrsodFKQghpTWj06ycJ/fqptHz1BQXSziYtn7VpW2d+tjuCZ9OBaKOTYW3Otp2vPdhd7WS0MlKnPm+jkxHKaC4A0hj+QspeB8KO+17LZXTWK1cFUCvue45cAvXue/g9ak11Ut1YK8UHDkhCbYUkRieIsjPZuJvYvR6cdg1x5lrSjVLbdq6tRrIdjXqH9dkVXrRmfW26Hty3vtpcJ866yNobTIhu6c7q9CCDA/dXPNcaCwokKTtbQgEKC0JI2GOJX8CNXSLQ5cHHo6yuuj/o1+mZ+0OIj8TaWKPULH9uXkzSYGxonky6v1vMr29632j5dl1dvWyNQ1Y2g8RERUtMVIzERMVKjEH3t3ptmgy6v6NixBD2V2MEWvba6rCrdbYtYFt0zOkiGTJQWBBCSBihHsDaQ1l1+SJHSDkWOq0LoJaiynmf8lYDNt12XbEdcW9bSEEkNJoa7QsDTRQ0CYf6pvmNxgavCRkIDrPoqHVqeZyX0U0CI7aF8LAvSKIx+uzojFajxTZJGhiLRIjfobAghBASFkLKEEZiqd5YL9UN1VLTUCM1jTXq1fy+WmrqqqWmHlOVeq3F1FCjrB9iihKDMVbEFCMGJbhMYoB6gI+2ei/mV5Op+XO1TNO8Jhch83fwHt8TiTVES3xUnMRJrMRFxUqsREtVZaXEJMVLvalB6qReao11Um9qFBN+iCiDmOA6hb8N+Nv8O5ma3L/wXv1tmSfN79Xot+5z9V2TSFSjxMcmqilBTUnm17hESYhJlMQYvCZIQnSCesX72KhYjnYT4kcoLAghhBAfigRYB6obm0SCJhCaxEJtY22zgGgSEXhvhGXElSd5jPOFIuOi4yydb9UBjzZ3yOOj45s7500ddLzHfFgLbP2+CwoKJNsmnqnR2Ni8T401UttQa7Xvav/17xtrpK6xzum2N0ijVJoqROowtb18lCHKvE/RCRIfE2+1v/p91B8L5aZF1xtC3ILCghBCCHESWBJaEwQtLQw1ykXJV6ATrB+htx2xtxIQTSIB3/EVECBJUUmSFJvk9HcgRqyOn4PjaXltqFG/gzNAoFXWV6rJ6X0wRLd9PHXHFRMsI4QQCgtCCCERCiwJrggEvMd3fIVTHVrde4zAh0OHFmIkOSpZkmOTnf4OhAWsIc4IElcFHpZzVYwEm8AjJFDwrCaEEBLy2Lrg2HM70s931QXHVfQuOLaCwJ7bEV1wXAOCKjYuVlIkxS2XtBYuWg4EirMuaVh3hbFCKuorXHZJUy5aepcsG/es1lzSCAk2KCwIIYQEFejMaZ07Z3z00QH0pUiAvz06/i06gLadQAYNBy34DWOjY9WUFpfmeRC9jUjVn5sqU5kT4JxV560Lpy7ESAvBahMzYvs3RC4h/oLCghBCiM9AJwuWBHtuKo5cWNDZQvpUX4B0pfZGiB26sMQkSFxUHIN5I1SMoCOPKT0+3enzvc5Y18KFzuH7JvHs7PmuiZFSKXVuH8S8D6251NmzpjF4nbgLhQUhhBCvd5r0o7i+EgkAnaC2Ok36+VieI7jEV6BDjnMMk7NiBBY6TXxbxfy0Ir6xnDPg2sOymEprnRcjLdz1KL6Jk1BYEEJIBOLIzcPWrcPWBclZNw930Lt5wKpg5eLhwOWDIoGEOlo8DiZ33AUdXa/6a9oVd0GIESyPqaS2xCV3wbauV7oLhj8UFoQQEkZpUFuLQ/CoVoIbwbWO4hAYmEqI52IEKX1dTevbVoID28+cTeuLAYeqhio1ubIPrVoabcUJ0/qGBBQWhBASZCDDTFuuELbBo75Mg+pKKk3tb6bSJCS4cKfGiP5e5O2UzO7UGNHfi5xJycx7kf+hsCCEEB9ir/iX7aihu6OEnrpdWPlRc5SQEGKnI58Sl+J0Wl9nradaTInmcuXLtL6tWU9tY7C0eyHT+roPhQUhhHjRr9n2IeqPNKit+TWzVgIhJBA1RlLjUt2qMWJvsMWTeC8Infq6eimvK3e5xogjlyzGezmGwoIQEpHoM7E4IxBcycTiDlomltbiEGxH15gGlRASqTVGtAx1rdUYsX3valrfsroy79UYibF+H64Z6igsCCFhAx4iBdUFUlVaJbVGc4pFb+SO91atBJXpiLnjCSHE72l9nampo3fR8keNkXgHNXX0f8dHxUtFXYVkNGZIQlSCBDsUFoSQkAcPjNX7V8uS3UukvKJckkuSvVrgiSNRhBAS2uCZoHXafWXZrnYxra/23dbS+uL5VllZKYfJYTK221gJa2FRW1sr8fHx3msNIYS4ERz98+6fZV3ROqd8buk7SwghxFc1Rhqb0vp6OxbPFUEUMsJi3rx58v7778vPP/8sO3fuFKPRKMnJyTJ8+HA5/vjjZcaMGZKbm+u71hJCiA6MDn277VvZXbHbMi8vNU96ZPeQxFj76QeZ7YMQQkgwpfVttJM9UHtfXV8t+6L2SYfEDuEjLD799FO59dZbpby8XCZPnqz+hoBITEyUAwcOyJo1a+T777+X+++/X6ZPn65eO3QIjQNACAlNimuK5eutX0tprdmfNdoQLUd3PVoy6jMkOztboqLCLyiOEEJIeIqR5KhkSY5NbvEZBvELYgskOz1bwkZYPPbYY/LUU0/JpEmT7D6szzzzTPW6e/duefbZZ+Xtt9+W66+/3vutJYQQEdlZtlPmb59vMR8nxSTJxLyJkp2YLQUFBTxGhBBCSLAKi19//dWplXXu3FkeeeQRT9tECCFtBmlrmTraJ7aXSXmTVM50jOwQQgghJDC47CuwaNEiuyOC9fX16jNCCPEF8EFduGuhLN692CIq8tLz5NTepzpdiIkQQgghQSQsxo4dK0OHDpXffvvNaj5iLY455hhvto0QQhQIYJu7Za7K/KQxouMImdhjoiqqRAghhJDA41Z049lnny3jx4+XN954w2q+s+XVCSHElSDtTzZ+Ysn8hCDt8d3Gy6hOo7xaq4IQQgghfq5jgQf5bbfdJkceeaRceOGFsmrVKnnyySctnxFCiK+DtHOSc3iQCSGEkFAXFppVYurUqZKXlycnn3yyrFu3Tp555hlftI8QEoG0FaRNCCGEkODDo0TvKIz3xx9/SElJiXKNIoQQT2GQNiGEEBIhwmLatGmqMJ5GTk6OLFy4UAmLbt26ebt9hJAIgkHahBBCSAS5Qs2ZM6fFvPj4eHnzzTe91SZCSARir5L22K5jpV9Wv0A3jRBCCCHeFBYI0naGIUOGOLtKQghRMEibEEIIiSBhMWzYMJX1SQve1jJA4b02H6+NjY2+ay0hJKxgkDYhhBASgcJi69atVp2BQYMGyddffy3du3f3VdsIIWEepP3z7p+tit6hkvax3Y5l0TtCCCEknIWFrYCAdaJLly4UFoQQt4K0v932raXonVZJe2TOSNbDIYQQQiIleJsQQjyBQdqEEEJIeOJRHQtPWbRokUyZMkVyc3PVKOVnn31m9fn06dPVfP00ceLEgLWXEOJ5kPbHGz+2ZH5CJe2Te5/MzE+EEEJIpFsstABud6msrJShQ4fKRRddpCp52wNCQp/iFqltCSGhBYO0CSGEkPAnxpUq23ohUV1drawNcXFxVsstX77c6Y1PmjRJTa0BIYEifISQ0A3SXrx7sawtWmuZxyBtQgghJIKFxSmnnGL1/uSTTxZ/sGDBAsnOzpbMzEwZN26cPPDAA9KuXTuHy9fW1qpJo6ysTL0ajUY1BQJsFyO2gdo+IYEM0v5u+3fWQdrZI+SwnMPUQIW3rwlea4T4B15rhETOtWZ0YdtOC4sZM2aoLFBRUf4Ly4AbFFyk8vLyZPPmzXL77bcrC8evv/4q0dHRdr/z8MMPy6xZs1rMLywslJqaGgnUD1JaWqpODH8eP0ICSWldqfy450cpry+3VNIenT1a8qLz1PXoC3itEeIfeK0REjnXWnm5+TnuDAaTVvGuDdCR37Nnj7Ie+AKMXn766actLCN6tmzZIr169ZLvv/9exo8f77TFomvXrlJcXCxpaWkSqJMCHakOHTpQWJCIYGf5Tvl2+7dS11in3ifGJMrEHhMlJ9m3bo281gjxD7zWCImca62srEx5DkHgtNWXdtpi4aT+8Ck9e/aU9u3by6ZNmxwKC8Rk2Avwxo8RSGsBhFOg20CIv4O0cd63T2wvk/ImSWpcql9+AF5rhPgHXmuERMa1FuXCdmP8mQXKU3bt2iVFRUXSqVOngLaDENISBmkTQgghkY1LwuKuu+6SpKSkVpeZPXu20+urqKhQ1geNrVu3yooVKyQrK0tNiJU47bTTVFYoxFjccsst0rt3b5kwYYIrzSaE+BhW0iaEEEKIS8Ji9erVLdLLemLR+PPPP+WYY46xvL/hhhvU67Rp0+TFF1+UVatWyZtvviklJSWqiN7xxx8v999/P2tZEBJEsJI2IZHJjh07fBZ3SQiJAGGB4Gpv3kTGjh3bauzG/PnzvbYtQohvKmnP3z7fKkgb8RS+DtImhASWP/74Q67717/k/559Vg477DD+HIQQRVSoxFcQQoIHDAisKlwlc7fMtYgKBGmf3vd0igpCIoBLp18kI3t2lUumzQh0UwghoSgsgiErFCEkOIK0F+1apKppI/OTVkn71N6n+i3zEyEkcPz+++9SV14iB3XKltqyYlm6dCl/DkKIa8Jizpw5kp6e7uzihJAwDdKGlWJt0VrLvBEdR6gaFbHRsRIsft+EEN8x84JpMmlgL/U3Xi86/0IebkJ8yI4Qeq45JSx+++03FVBtrz6ELVVVVbJ2bXOngxASPkHan2z8RHZX7LZU0h7fbbyM6jQqaFwl4fd97TXXqMQQhBDfWSu6ZGWo93il1YIQ3/FHiD3XnBIWF1xwgUrx+uGHH0plZaXdZdatWye33367qoy9bNkyb7czJKmurpazzzhDOrdrL+efdZZ6xXvMJyTUgrQ/3vixlNaWWoK0T+59svTL6ifBBP2+CfG9tWLyoN5W8/CeVgtCfEOoPdecEhYQDSeccILceeedkpGRIQMHDpTjjjtOpkyZIkcccYSqhj1ixAhVh+Lbb7+VCy+kWXTBggXSpUO2lP6zVq4Ye6icdvBA9Yr3mI/PCQl2QilIm37fhPjnGuvaZK3QwHtaLQjx3TUXSvFMBpOLUdkwxSxevFi2b9+uRt4hKoYPH67qUaCoXbBRVlamYkNKS0slLS3NL9vEcYF4uOiIEZKTnoqUWmJonyOm/XvRU5O9peXy+uLlsquwQBITE/3SJkLCvZL2oL4HyXE9OkjfQYNlw5rV8v32/bJ6/d+BbhYhYQOusWO7tzcLC4NBknK7SlX+TvVc23mgRH7YUcRrjpAwfK650pd2qY4FOOSQQ9REHDPjwgvlsLyuZlEhIiVV1fLjstUyrkOKZCQmqPmH5nWRi6bPkPc+eJ+HkgQdoVZJu9nvu0+z3/fqjWp059BDDw108wgJeXCN1ZbBWmHtBqUBsVGzehOvOUIi/LnmdFYo4jw/ffudjO7Vpfn9P1vkkB5d5Kf1WyzzxvTqKj9+8w0PKwk6QiFI25aLzr/Art/39PPOD1ibCAknLrrgQjlhsH1RoYHPZ5x3gd/aREg4c1GIPtcoLHwAvMuS4+Ms1oqK2lrlH1dRU6veA3zO2iAk2AiVIG09L774olSXFNn1+64u3i8vvfRSwNpGSDiwZs0a2bZ9m6zLL5Jv126W+Ws2y7drt8hf2/eqV/P7zerzrdu3quUJIZH5XKOw8AEY1a2sNQe6/vj3ZjmmX0/1N15//Gez+hufB+voL4k8QilI2zae6fabbpSThvW3+znm33bjDczERogH9OzZU9KSY2VC5y0yPH2zrN+8WUYXFctB5RXqdf3mTTIiY7Mc33mLWg7LE0Ii87lGYeEDjjn+OPl18y5lnSivrbXK913eZLX4ZfNOGTdxoi82T0jEVNKePHmyZKcmtxjV0cB8fH7iCSf6vW2EhAtJSUmSlhAlN45JkG82ijyRkytnZmTKkckp6vWJnM4yb4PITWMS1HJYnhASmc81l4O3t2zZwtGINpjz1lsqK1RBWamMO8hcnVQD779e9Y9sKyqTXX8sd/XwExLRQdq2rPzjD7lwzPBWl5k0uJ+89ctvfmsTIeFIdGy8fLupQqKqouUHU6XcUlIq/Tq0l/X5+TIhNkaiqqPku811Eh2bEuimEhLSrAzx55rLwqJ3795y9NFHy8yZM+X000+XhIQE37QshEEK2Rtu+7e89vRsu/5xxVU1ctMdtzPVLAl4kPbXW7+2xFMgSHts17FBHU+hB37ctQ31snHffjUBQ1SUdG2MkZ0bN4vJaLQsi+Ww/KBBgwLYYkJCl6nnXyIznn5MGgwJsj2ng8zo3VU65PWSwqwE+XXTTtm9tVqmf1IjM2+4LNBNJSRkWRMGzzWXXaGWL18uQ4YMkRtuuEFycnLksssuU+XGiTUvPPV0q/5xzz35FA8ZCRihGKRtC/y4o6OipVNGmvTskGWe2mdKTnqKetXm4XMsR79vQtznmHHjpUYS5MIjDpZjB/S0JCjBK95jPj7HcoSQyH2uuSwshg0bJs8884zk5+fL66+/Lnv27FHVt6GYZs+eLYWFhRLpfPHFF5IYZWjVPy4xSmTu3Ll+bxuJbEI1SNse8OOOjhbZXVwhPdpnqal7+yzJTktVr9q8XcXlYogxL08IcY/zzzxdDuvZzVKfyRZVn6lnVzn39Kk8xIRE8HPN7eDtmJgYmTp1qnz44Yfy6KOPyqZNm+Smm26Srl27yoUXXqgER6RyxUUz5cShfVtdBp9fNv0iv7WJkFAO0nbEJVdcJb9v3aGq2dsD8//YulOuuPIav7eNkHAB7hb1tQ1W9ZnsgfpMdbUNTDdLSAQ/1wwmN4sp/Pnnn8pi8f7770tycrJMmzZNxV3s2rVLZs2apcp/B4OLlCtlyL3BggUL5IQJE+Tw3s3mKfjHde/bT7ZvWG/lH7dk0xb5av58GTt2rM/bRSKbUA/SdkRdXZ1075gudfXRcmheVxnTu5vZ73vrZvll0w51842PbZTt+0olLs7sukEIcY2qqirp0amT3DrxyOaZBoMk5XaVqvydMIVaZj/6zc+ybc+eoBxJJSQUqAvC55orfWmXg7fh7jRnzhxZv369Son11ltvqdeoKLPxIy8vT9544w3p0aOHRCLDhw+Xq6+7rkXxu8zMTMnoZV1BcbjBoJYnxJeEepB2a+Cm+t3PS+XEsYfKroJN8sLOfBl0oFrWrFwp7eOrJC0hVuYuWEpRQYgHQCSYjCZVf0mLrbAHPjcaTRQVhETwcy3GnWqAF110kUyfPl06depkd5ns7Gx57bXXJBKBooNrmB6j0SgFBQXquGgCjBB/BWnP3z7fEk+BIO1JeZNCLp6iNRDftSG/VB64/z755O1XJCXBIO0zE2Tq+dfInXfdHbQ3X0JCCWNDvarPhEBtR/y6eacYm+41hJDIfK657QoVKvjbFcoeFBbE3+CyXr1/tSzZvcQST4EgbYiKUI2ncAZea4T4hj4d2klZda3K/qQCuG1coeD3/dbiZZKaGC+bCov4MxASRs81V/rSLrcQblAI2LYF8958801XV0cI8TLhGKRNCAksZ156qYyNj5P/Ll4u36/brNyeAF7xHvOPjo+Vcy+7nD8VIRGMy8Li4Ycflvbt27eYDyX10EMPeatdhBA3g7SRSnZt0VqrIO2JPSZKbHQsjykhxC3uuWeW/NZQL8+3ayc99uyXOT/9IZ8vW6te8R7zf29okDvvvodHmJAIxuUYix07dqgAbVu6d++uPiOEBIZwDtImhAQW+HR/teRXOeHw0TI5MUHezsqWuKx2UpedLW+XHZAbSorU58Hs+00ICUKLBSwTq1atajF/5cqV0q5dO2+1ixASYZW0CSHBH1C6sbBIOlx8qcwsL5H7SorUK95jPj4nhEQ2LlsszjnnHLn22mslNTVVjjrqKDVv4cKF8q9//UvOPvtsX7SREOKASA3SJoQEBlgk7nvgQbn3vvsDHlBKCAkDYXH//ffLtm3bZPz48ar6thaxjmrbjLEgxL9B2gjQ1sdTIEj72G7HMp6CEEIIIcEvLDBa8cEHHyiBAfenxMREGTx4sIqxIIT4h5qGGpm/bX7YVdImhBBCSAQJC42+ffuqiRDiXxik3TolJSXKPYMQQggJB0pC6LnmsrBobGyUN954Q3744QflXwk3KD0//vijN9tHCImwStqesGvXLrnkskvk3bffla5duwa6OYQQQkhEPddcjrhCkDYmCAxkgBg6dKjVRAjxTZD2qsJVqkaFJioQpH1639MpKpoGPL787DM58YgxkhprkhOOGKPeYz4hhBASajSG6HPNYEKPxQVQHO+tt96SyZMnSyjgShnycC7HTkIXBmm3zr59++TcCRNlRHGxnJqQILEDBkj9unXyaW2NLM/IlHfnfyMdO3b0069FSGTA5xohkfNcK3OhLx3lTvB27969PWkfIcSFIG1W0nYMRm5w872utFQuSkyUjOhoNR+vFyUkqvn4PNhHeAghhJBweK65LCxuvPFGeeaZZ5RrBiHEt0HaKHqnZX6KMkTJ+G7jZVSnUcz81MTXX34ph5SWSu/4eLvHEPMPLi2ReV99xVOVEEJI0PN1iD/XXA7eXrx4sfz0008yb948GThwoMTGxlp9/sknn3izfYREJAzSdo43/+//5MamejqOOCU6RmY/84yceNJJXvltCCGEEF/xZog/11wWFhkZGXLqqaf6pjWERDispO0aFaWlFjOxIzJjYqSipMSj34UQQgjxBxUh/lxzWVjMmTPHNy0hJMJhkLbrpKSnS0lZeas34eKGBknJyPDotyGEEEL8QUqIP9fcSlHU0NAg33//vbz88stSXl6u5uXn50tFRYW320dIRMAgbfc44dxz5b9lrY/a/Le8RE48/3w3t0AIIYT4jxNC/LnmsrDYvn27DB48WE4++WS56qqrpLCwUM1/9NFH5aabbvJFGwkJaxik7T7zl3wvX0ZXyKbaWrufY/6X0ZUy/+dvPdgKIYQQ4h/mh/hzza0CeYcccogUFxdLYmKiZT7iLlCNmxDiWpA2Mj+V1pZaKmmf0vsU6ZfVj4fRiTzf87+ZLzGjOsqV5fvk/0r2K/MwwCveY37sqI7yzbxv1PKEEEJIsLIvDJ5rLsdY/Pzzz/LLL7+oehZ6evToIbt3m9NiEkJah0HanpOVlSVff/K1OpaN1zfK77/+Kvd99JHkGET2ZqTLcRfPlHdHj5bo6GiVnhfLE0IIIcFKVhg812LcqbZpryjHrl27JDU11VvtIiRsYZC2d0Cq69GjR1veH3nkkXLDTTexyj0hhJCQJDYMnmsut/D444+Xp59+2vIeiglB2/fcc49MnjzZpXUtWrRIpkyZIrm5uWo9n332mdXnUGx33323dOrUSbldHXvssbJx40ZXm0xI0MAgbUIIIYSEKy4LiyeffFKWLFkiAwYMkJqaGjn33HMtblAI4HaFyspKGTp0qDz//PN2P3/sscfk//7v/+Sll16S33//XZKTk2XChAlqu4SEGgzSJoQQQkg447IrVJcuXWTlypXy/vvvy6pVq5S1YubMmXLeeedZBXM7w6RJk9RkD1grYBm58847VQYq8NZbb0nHjh2VZePss892temEBAxW0iaEEEJIuBPj1pdiYuR8H+fP3bp1q+zdu1e5P2mkp6fLyJEj5ddff6WwICEdpD0xb6KkxaUFunmEEEIIIYETFrAatMaFF14o3gCiAsBCoQfvtc/sUVtbqyaNsrIyS9A5pkCA7aKDGajtkwAGaecvlnVF6yzzeqT1kGO7HSux0bE8H3wArzVC/AOvNUIi51ozurDtGHfqWOipr6+XqqoqlX42KSnJa8LCXR5++GGZNWtWi/ko5Beo2Az8IKWlperECIWIfuI5tY21snDvQtlb3SyCB2UOkuFJw6W4qJiH2EfwWiPEP/BaIyRyrrXy8nLfCQsUxrMFmZquuOIKufnmm8Vb5OTkqFcU/0BWKA28HzZsmMPv3XbbbXLDDTdYWSy6du0qHTp0kLS0tICdFMh6hTZQWERGkPZ3W7+T8qhylXAgyhAlY7uMZdE7P8BrjRD/wGuNkMi51hISEnwbY2FLnz595JFHHlFxF//88483Vil5eXlKXKCatyYkIBKQHQoixhHx8fFqsgU/RiA79TgpAt0G4t8gbfzmqKQ9KW+S5CSbhTLxPbzWCPEPvNYIiYxrLcqF7XpFWKgVxcRIfn6+S99BRqlNmzZZBWyvWLFCVRLs1q2bXHfddfLAAw8o4QKhcdddd6maF6eccoq3mk2Iz4K02yW0k0k9JzFImxBCCCERgcvC4osvvmjRodqzZ48899xzcvjhh7u0rj///FOOOeYYy3vNhWnatGnyxhtvyC233KJqXVx66aVSUlIiRxxxhHzzzTcumWQI8TWspE0IIYQQImIwQRl4YA7R/L7GjRuniufp4yGCAbhPIU0tAl8CGWMRSuXYiWuVtOdvmy+7K3Zb5o3oOEJG5oxU1wbxL7zWCOG1Rkg4YQyCPqQrfWmXLRZMmUpIc5D211u/ltLaUvUeQdrHdD2GQdqEEEIIiUi8FmNBSCTBStqEEEIIIR4KC30q17aYPXu2q6snJKhhkDYhJJIxGY1SU10pFaUHpKSoSFKTEyUpOVUMdPMlhLgjLP766y81oTBev3791LwNGzZIdHS0jBgxwrIc/ctJuMEgbUJIuFNbUyWVZcVSVVYsNZUlUlNRLPWVpdJQVSqN1aViqi0TaWzAKIvU1ddL8e+xIjGxYohPk+jEdIlJSpfY5HSJT86QxJRMSUzNkJT0LIlPSAr0rhFCglFYTJkyRVJTU+XNN9+UzMxMS9G8GTNmyJFHHik33nijL9pJSEBhkDYhJNRpqK9TogFTdUWJ1FYUS11VqTRUlijRYKwpE2modX3FjQ1iqjogDZiKRGpQqdd2mZh4iUpoFh9xyRkSD+GRkiHJaZlqiomN89KeEkIChctZoTp37izffvutDBw40Gr+mjVr5Pjjj3e5loWvYVYo4ikM0g4dgiF7BiGBwNjYKBXlJVJVXizV5cVSC+FQWSL1VSXSWFUmpppSMdVVebQNQ3ScGBLTlECAOKisqJT4qAYlSEzVZWJqrPNs/XFJYkhIl+ikNIlNypD4pHSJTzWLj6S0LElJzZCo6GiPtkFIqGEM96xQWHlhYWGL+ZhXXt5ijIKQkIZB2oSQYIhrqK4qb3JROiA1FSVSp0SD2UXJCNFQW4kF3d9IVLQY4lMlSlkUMiQuKU1ZFBJS0iUxNcvszhSfaImlsO3soI21tdUq9gLWkBolbmARKZOGqhKz+IBFxNjoeD/rqtRkLNsj9SLSQgYZDGKIT5EoiI9EWD3Mlo+EJuGRlJohSclpjPcgJIC4LCxOPfVU5faEmhWHHXaYmvf777/LzTffLFOnTvVFGwnxOwzSJoT45V7jhQ55m9jpkCMOAjEQ3uqQ47sJiclqEunqgUCqUPEb9ldgElNNuTRiKtkldV4QSISQAAuLl156SW666SY599xzVQC3WklMjMycOVMef/xxLzePEP/DIG1CiLeor6tVoqGqvESqyw9IbWWp1FeWSEN1UzC011yI0iQagdNB7EKEznxSSrqaJLeHcy5dmKpKnXfpMjaKqRoxIyXSeGC7IGKkvBWXLhyvWMR7QGilmkUWxEdsXLx3d56QCMFlYZGUlCQvvPCCEhGbN29W83r16iXJyRilICT8grSHZw+XUZ1GMdMZIcSKxoYGcye4rEiNvptH4IulvqpMGqtKlaXBVF/t2VGzF/Tc1AkOx6BnCKC0jHZq8lUQOoScqWK/GCv2S4OI2P2FYhPNx12JtTSJS840Z7qCdSetnRJr0TEsBUaILW5fFXv27FHTUUcdJYmJicp1hClmSSjDIG1CiN5tp7KiVCrhsgNrAzqvlU0j59VlYoS1oQ5xDS7lP2nptqPckxAMjZFzpml1Bgip9HYd1eRx2lxH1FeLEVP5PsfxHnHJOvGRoVzM4F6WkIpMV1mSnJJOlysScbgsLIqKiuTMM8+Un376SQmJjRs3Ss+ePZUrFNLPIvaCkFCDQdqERF6Rt8pyzde/VGVRqq8qlgZNNMDX36O4higxJKRKtKXjma58/THqnZyaKcnpWSoegb7+vgF1MzBlZXdu/RyAm1pFsbI21VZAOBYra1Ojim0pdxwQj3iP2gppxFSar+I9KjFAZeccUPEeiXC7ypT4lHRLsDnOA54DRCJdWFx//fUSGxsrO3bskP79+1vmn3XWWaoqN4UFCckg7fwl6m/QLqGdTOo5SdLiWk+pRggJTjwerXYCQzxGq83WBjVanWLOTpSYmilJEA4p6UER10DsA0GXmJyqJpHuDuM9qirLrK1WEKCIj1HB5mWtW61MRjE1xdJAosI5q8J2meiYFsUFE2D1SIb4MLu6sbggCWthgRoW8+fPly5duljN79Onj2zfvt2bbSPEpzBIm5DQw+Jfr4Khi63962vM1ga3irzZ86+HaEAGpSSIBnMV6SRkFkrLpH99BABhiN8aU6txNhCx5QekutxcO0QfZ6PiPVqLs3G2uGBiurJ+xSQj05XZ+gURm6zcrsIrzoZEmLCorKxUAdy2HDhwQOLjmUWBhAYM0iYk+MAIsRbXoC/yBksDJq8VedO5p6igXGVpMIsGdNLi4hO8tk8kvEEAd3pWBzU5oq62xmxB0zKDKbc7c7yOU8UFG2rFWF6gpvpC+8HmLYoLqsrmzRa0YMkMRsIfl4XFkUceKW+99Zbcf//96j3iLFAo57HHHpNjjjnGF20kxKswSJsQ/2NVw6Ac9RoO2NQwKGuqYeCdIm/I5GMOqDWLBlXDoMmthHENxJ9AqMZ16CSZHTo5rmVSU6UsHxAe5pgfXS0T5b5X7mFxwaimWibmqumI+VHFBZtS7EJQJyal8tog/hcWEBDjx4+XP//8U+rq6uSWW26RtWvXKovFkiVLPG8RIT6EQdqE+AYEwloVeVMuIU3+5egYea3IG1yUMswpQDEiq7mEpGWy6jIJSVRxwaQUNUmO4+KCiPeAKEfCgeqmuCHtGmu7uKBRXYNwF0RxwVqHWcrM9T1UccGmLGUJTTVRUN/DXACREC8Ki0GDBsmGDRvkueeek9TUVKmoqFAVt6+66irp1Mm+Gick0DBImxDPirxpdQNqmjLo6Iu8mesGeFjkLTZRDPAjx2hqorlDgww6qmhZU+pO1g0gkSw+VDxFakbbxQWV8CixKS7YVFelreKCKitWscPighIT11xXBZZBCA+VuMAs7jGxuGBk45KwQKXtiRMnqurbd9xxh+9aRYgXYZA2Ia4WebPpjHhc5A2dkeZ6Dfoib5obBjsjhPi5uGBTJXi4JGoZ09oqLogBBBQWxASXK9wZyuwNEtjU9zCLDxYXjARcEhZIM7tq1SrftYYQL8MgbRLJaEXeVNAoRjHhnqQCR71d5E1Ll2l2UULGGtWJQNBoehbTZRISYsUFlVtjU4pduDWa0zWb7xtIotBqvEd9tZraLC6YaJ2uORHxUGlNgw0sLhg5rlDnn3++vPbaa/LII4/4pkWEeAkGaZNwpjng84BVkbeGanNAtNeKvMWnKNFgTr2aYVXkLSktgwGfhIRpcUHpaF1WoPXigkixW+p6ccGS3faLC6pEDClNiRjgdmXOcpWQkq5cI1PSzAMWTMQQBsKioaFBXn/9dfn+++/l4IMPluRk60Ce2bNne7N9hLgFg7RJqIMUlRWlRcpXGqlX9UXe4K6AYE2vF3mDywKqAafAPckc18AUlYQQd4oLmq2lcLkyiw8ra6kKNoecaCXeQysueMA8y15xQdy/LJmumooLJlqCzdsxdXQoCIs1a9bIiBEj1N8I4taD1LOEBBIGaZOQLPKmMijp/Jy9VuQt1VLRV6WWTNGJhtR0FtUihPgEDEikpmepydnigmrwpMrsdmUWH20XFzRWFqmpzeKCuvsgLK7mTHK8DwZMWCCuAtmgoqKi5KeffvJJQwjxFAZpk2Ar8qaCoZuEg6XIW21Z6yN1zqCN1FkVeUMwNEfqCCHhWFywqbK5vrigSmNd7nxxwaZgc3uWW0O82eqBSUuxS8utD4XF8OHDZc+ePZKdnS09e/aUpUuXSrt2jrMOEOJvGKRNAlbkDQ+5SrN5X9Vr8FqRtzQr32JzkbdM+hYTQiIGV4sLQnyYC29iKnOuuGBtpZrqyvaoeI8qJ2LN4pLgNgqLB2PN3BIWGRkZsnXrViUstm3bpiptExIsMEibeAsVkKhEQ3NAoteLvFmyoeiKvDEbCiGE+LS4oDnFbrFNccES5XLlTHHBBkzF0mpxwegmtytVXFCXHQ8ptSOluKBTwuK0006To48+WhXAQxzFIYccItHR0XaX3bJli7fbSIhDGKRNPCryptyTmoMJvVbkTR8MrawNWWZrQ2oGi7wRQkigigtKnsN4DxVsjrTcqO+BLHuwfGBQyYXigg2YkLLXYXHB5no+sEiHY3FBp4TFf/7zH1Vde9OmTXLttdfKJZdcoqpuExLIIO01+9fI4vzF6m/QLqGdTOo5SdLi0vjDRCAYldq/Z7vkb9soB7ab1IiUloEE2UW8U+RNX68hPB8KhBASifEebRUX1AanVF0gq+KCTg5ONaC4YKGaWi0uqBucQrwHsl3V1IskJ8a1GgwfclmhUHEbLFu2TP71r39RWJCAwSBtohcT+3ZtloLNK6Uqf50SEHX19VIbG6vcjpzGnhm7KYAv0szYhBBCWoKBo4z2OWpqq7hglc6dFrEeLhcXLNvbXFzQZFLPtbr9I2X4ceeFX7rZOXPm+KYlhDgBg7QJsi7t3blJCreslGqICfjGtkZT4F1zrvPmwDtV4TUtk0XeCCGEeK24YLtWigsiAUhVWYlUNmUMVOLDiQQgeG6FAi4LC0ICBYO0I1tM7Nm+QQq3rpQaiAl7vq5R0RLTrodEJXaQDp26SVJ6Fou8EUIICap4jyRUD09Jl/ZtFBfUUpZXlx2QAwX5ktGpp4QCFBYkJGCQduSBYLr8bX9L0dbVUrPnb/sxElHREtuhl2R2HyKdew2SuIQkKSgoUBnsUHeHEEIICeXigkaj0fJcCwUoLEhQwyDtyKtInb91nezfulpq9/5jv/p0dIzEdegtWT0GS26vwcrsrMFU2IQQQkjgoLAgQQuDtCMDZNrI37JWiratkrq9G+xWUTVEx0lcxz7SrscQ6dRzoCqaRAghhJDggsKCBCUM0g5v6mprZPfm1XJg2xqpK1gPv6eWC8XESUJOP8nqMVRy8/ozlSshhBAS5FBYkKCDQdrhW9U6f/MaObB9ldQXbLKfci82UYmJ9nmDpVOP/hITGxeIphJCCCHEDSgsSFDBIO3woqaqQnZvWiXF21dL/f4tdsUECgIl5A6QDj2HSE63fqxMTQghhIQoFBYkKGCQdvhQVVGqxETJ9tXSULTNbj5uQ3yyJOb2lw55wySnWx+VBYMQQgghoQ2FBQk4DNIOfSrLS2T3xpVSumO1NBzYriqF2mJISJXE3AGS3XOIdOzSm2KCEEIICTMoLEhAYZB26FJeekDyN66Q0p1rpLF4p30xkZguyZ0HSnavoZKdm6eKAxFCCCEkPKGwIAGDQdqhR2nxftmz8S8p27lWGkt22V3GkJQpyZ0HSU7vodI+pxvFBCGEEBIhUFiQgMAg7dChtGif5G9aIWU71oixbI/dZaKS20lyl4GS03uYtMvuQjFBCCGERCAUFsSvMEg7NCgu3CN7Nq2Q8p1rxFi+z+4yUanZktJlkHTqPVSysjv7vY2EEEIICS6CWljce++9MmvWLKt5/fr1k3/++SdgbSLuwyDt4MVkNEpRwW7Zu3mFVO5aK8aK/XaXi0rLkdSugyS39zDJaJ/j93YSQgghJHgJamEBBg4cKN9//73lfUxM0DeZ2IFB2kEqJvbuVGKiYtdaMVUdsLtcdEZnSesKy8QwSc/q4Pd2EkIIISQ0CPpeOoRETg5HRkMZBmkHl5go3LNd9jVZJkzVJS0XMhgkJqOLpHYzWybSMtoFoqkh7e7X0NAgjY12KosT4iWio6PV89FgMPCYEkKChqAXFhs3bpTc3FxJSEiQ0aNHy8MPPyzdunVzuHxtba2aNMrKytSr0WhUUyDAdtHZCNT2A8nO8p3y7fZvpa6xTr1PjEmUiT0mSk5yTkQej0CJiX27N0vhllVStXudSI35mrDCYJDozG6S3s1smUhJy7B8FEq/U6Cvtbq6Otm7d69UVVUFZPskskhKSlIDb3FxcRF3rRESKRiD4FpzZdsGE1obpMybN08qKipUXMWePXtUvMXu3btlzZo1kpqa6nRcBtiwYYPD7/jjByktLZX09HSJipA8/jit1peul6X7l4pJzKdYZlymHNPpGEmJTQl088Ieo7FRDuzZLqW7/5H6wo1iqKtsuZDBIIaMrpKU00/ade0niclpEuoE8lrDOV9UVKQ6ee3bt5fY2Fi/bp9EFvX19bJ//34lZtu1a+d3y0UkPtcICQTGILjWysvLpW/fvqodaWlpoSssbCkpKZHu3bvL7NmzZebMmU5bLLp27SrFxcVtHgxfnhSFhYXSoUOHiLgBqyDt/MWyrmidZV6PtB5ybLdjJTaanS2fHfeGBtm3c6MUbl0lNfl/i9gTE1HREtM+TzLg5tRriCQmB0Zsh+O1VlNTI9u2bVP3KIwkE+JrYBnbvn275OXlSXx8vF8PeKQ91wgJFMYguNbQl87MzHRKWAS9K5SejIwMpZg2bdrkcBncXO3dYPFjBPLmh9GkQLfB30Ha2gja8OzhMqrTKPoC+0hM5G/7W/ZvWSk1e9eL1Fc3f6iNYEZFS2yHXpLZfYh07j1YEhKTJZwJ1LWG7WHb8H2n3zvxB9q5pp3z/iZSnmuEBBpDgK81V7YbUsICblGbN2+WCy64INBNIXZgkLZ/aKivk/yt62T/1tVSu/cfkYZmC52F6BiJy+4jWd1hmRgs8QkcQSeEEEKIbwlqYXHTTTfJlClTlGtBfn6+3HPPPWqE5pxzzgl004gNrKTtW+rraiV/y1op2rZK6vZuEFNTMLweQ3ScxHXsI+16DJFOPQdKXHwCz1PSgh49esjTTz8tp5xySsgdnUmTJqlnwpVXXhnophBCCAk1YbFr1y4lIhAQCd+yI444Qn777Tf1NwkOWEnbd9TV1sjuzavlAMREwUb4PbVcKCZOEnL6SVaPoZKb119i4/zrZ02IvxN6EEIICV6CWli8//77gW4CaQVW0vY+NdWVkr95jRzYvkrqCzaJGO3UQohNVGKifd5g6dSjv8TE+j/VJCHISsTMV4QQQvQw4oq4HaQ9d8tcWVu01jIPQdqoUcHMTy4ey6oK2bzqF/nzy5flr/fvk32/fyj1CMTWiQpDbKIkdj9Yuh0zQw479x4Zfvz50rXPUIoK4hZIvz1q1CiVgvvoo4+WnTt3qvm33HKLcj3F/AEDBsiHH35o+c6CBQtUAo0XX3xR1RIaM2aMvPHGGzJs2DC5++67VYpd1FT44IMPZMmSJTJo0CCVHhEZ/PQ50L/99lsZPny4+mzEiBHy/fffWz6bPn26XHLJJXL22WerNiDVOLarMXbsWOXGpbFs2TIZN26cZGVlKUv2NddcwzOCEEICCIUFcStI++ONH6vMT+okMkTJ+G7jZXTuaGbDcZKqilLZuOJnWfr5C0pMFCz9ROrh7qQXE/HJkpR3iHQfd7Ecdt69MuzYc6Rzz4ESHRPUhkYSArz99tvy3nvvqRSGycnJctddd6n5Q4cOlaVLl6rU3hALSJSxdetWq1zmK1eulH/++UcWLlyo5qGuEEQFCgM++OCDcumll8ozzzyjPv/7779l7ty58tlnn6llkdHv5JNPVtuDi+vtt98uJ510ktU2IEwuv/xy1QZsH2LDHqhpBFFx+umnqxg8pF0988wzfXzkCCGEtAZ7KMQlGKTtPhVlxZK/aZWU7lgtDQe2I0ClxTKGhFRJyh0o2b2GSnbnnhIVHc0zNIR59/cdUlVnJzbGByTFxci5I7s5tSyCn1H7AJx33nnyyCOPWP7WgNUA83/55RfLsrA8YJ6+TgcsBddee636GzFxF198sbJSoGgbgEVk+fLlMnXqVCUaYHXA3wCi4D//+Y8SORAZYPLkyWoZMGPGDIsI0danF0cHH3ywVSD3kUce6daxI4QQ4h0oLIhTMEjbPcpLD0j+xhVSunONNBbvtC8mEtMluXOTmMjNEwNzwocNEBXlNf4RFq4AlyUNWCxgiQBPPfWUvPrqqypxBvKmI8U3qjtrwD0J7lB6OnbsaPlbExy287AegPUiK5Wenj17qvmO2gbQPlthAQtFnz593D4GhBBCvA+FBXErSBuVtI/rfhzjKexQWrxf9mz8S8ogJkrM7mK2GJIyJbnzIMnpPVTa53SjmAhTYEUIlW0tXrxY7r33Xvnxxx9VDAQKIiF+AoMKGp4WZ+rSpYvajh5UKz/qqKNcXhdiQRCvQQghJHigsCBOV9LWYCXtlpQW7ZP8TSukbMcaMZbtsXsso5LbSXLXQZLTa5i0y+5MMREBOOuaFAyUlZWpOkFwbYLLEwKzET/hTc466yx54IEH5PPPP5cTTjhBvvjiC1m0aJG88MILLq8LbltY10svvaRcphobG1UwN92hCCEkcFBYEIewknbrHCjYLXs3r5LynWvEWL7P7jJRqdmS0mWQdOo9VLKyO/NsI0HLxIkTVczD4MGDJT4+XgVOH3744V7dRu/eveWTTz6R2267Ta0fblCffvqpenXH+vHDDz+oQqr//ve/JS4uTsV4UFgQQkjgMJj0du4wBKNwSGtYWloqaWlpAWkDRv8KCgokOzvbY1cCf8Eg7ZaYjEYpUmJihVTuWivGimbfcz1RaTmS2nWQ5PYeJhntm/3FSXhfazU1NSq7EQKdExJY9ZyE9zkXis81QkIRYxBca670pWmxIFYwSNuOmNi7U4mJil1rxVR1wO4ZE53RWdK6wjIxTNKzWBmeEEIIIZEHhQWxwCDtZjFRkL9VCrasUpYJU3VJy7PEYJCYjC6S2s1smUjLsM5YQwghhBASaVBYEEWkB2lDTOzbtVkKNq+Uqvx1Yqopa7mQwSDRmd0ko/tgye09VFLSMgPRVEIIIYSQoITCgkRskLaxsVH27twkhVtWSjXERK05174VhiiJaddDiYnOvYdIUkp6IJpKCCGEEBL0UFhEOJEWpN3Y0CB7d6yXwq2rpQZioq6q5UJR0RLbLs8iJhKTUwPRVEIIIYSQkILCIkKJpCBtiIn8bX/L/i0rpWbvepH6avtiokMvyew+RDr3HiwJieaKv4QQQgghxDkoLCKQSAjSbqivk/yt62T/1tVSu/cfkYbalgtFx0hcdh/J6jFEcnsOlPiEpEA0lRBCCCEkLKCwiDDCOUi7vq5W8reslaJtq6Ru7wYxNbl36TFEx0lcxz7SrscQ6dRzoMTFs94AIYQQQog3oLCIIMIxSLu2pkqJiQMQEwUb4ffUcqGYOEnI6SdZPYZKbl5/iY2LD0RTCSFe5LfffpPrrrtOvfqDd955R77++mv1SgghxD4slxlBQdofb/zYIioQpH1K71NCUlTUVFfKljW/y59fvSLL35sle3/9QOr2/G0tKmITJaHrMOly9DQ59Nx7ZfiEadK93zCKCkLChFtvvVXuuOOOFvMvuugiZX39+++/W3z25JNPSt++fSU1NVU6dOggxx57rGzbtk19tmDBAvW9lJQUq2n27Nnq83POOUf++OMP+euvv/ywd4QQEprQYhHmhEuQdk1VhezauFJKdqyR+v1bkCu2xTKGuCRJ6NRfOvQcIjnd+kl0DE9vEjo0NjbKl3O/kv/7zxwpKSuXjLRUufbSGTLlxBMkOjraJ9vEPcFoNPps/fZoaGiQGA+vzTVr1sj69etl8uTJVvPLy8vlf//7n2RlZclrr70mTzzxhOWzt99+W5599lmZO3euDBo0SEpKSuTbb7+1cgFNT09X8+0RFRUl5513nrzwwgvyyiuveNR+QggJV2ixCPMg7UW7FsnPu3+2iAoEaU/tMzUkREVVRalsXPGzLP38Bfnr/fuk8M9PpR7uTjpRYYhPlqS8Q6T7uIvlsHPvkWHHniOdew6kqCAhxb59++TgI8bJNS/OlY29z5QDh1+vXvEe8/G5t+jRo4c8/PDDMmrUKElKSpJ169ZJQUGB6jR36tRJcnNzlYtRbW2tZSQ/IyNDXn31Venatau0a9dObrnlFqt1otPev39/tdwRRxwhy5cvt3w2duxYtfzxxx8vycnJMm/ePEsbDj30UDVv0qRJcuDAAbnyyivVOvr06SO//PKLw3344osv5KijjmohiD744AO1vkcffVT++9//Sn19veUzuEyNHz9eiQqA7Zx55pnSvXt3p48dvv/ll186vTwhhEQaFBZhHKQ9d8tcq8xPCNJGjYpgzvxUUVYsG5YvlKWfPScr//eA7F/2uTTAQmEyWpYxJKRKcs9RknfcZXLYOXfL0HFnS27eQRLlx1FXQrxpqZhwyplSMPBsiR52skQnmkU/XvEe8/E5lvMWb7zxhrz55ptSUVGhXINOOukkycnJkc2bN8vq1atl5cqV8sADD1hZAiBANm7cKIsXL5bnn39eCQ6waNEiueKKK+Tll1+WwsJCOf3002XixIlSWlpqtT2sD9uD+5EmAj755BPJz8+XnTt3KqGDz4qKiuTcc8+Vyy+/3GH7V6xYIQcddFCL+bBSQCCdffbZUllZaSUCDj/8cGXNePDBB2XJkiVSU1Pj8nEbMGCAEnl79uxx+buEEBIJUFiEaZA24im0zE8I0h7fbbyMzh0dlJmfykqK5J8/f5A/Pv0/Wf3RQ1L015fSULQNfhqWZQyJ6ZLSe4z0nHCFjDznLhlyzOmS060PxQQJeeD+VJTeT+Lad7P7OeYXpfeVr7762mvbhBDo16+fGvFftWqVEgyPP/64smDAInH77bfLu+++a1keFk8Ig4SEBGWZGDNmjCxbtkx9BsvA+eefrywIsbGxytqRmZkpX331leX7EAqHHXaYuv8kJiZa2gALCNyP4NKE7U6dOlW16ayzzlLuTnV1LTO7geLiYklLs7a6QvjAKjFt2jQVG3HqqacqoaGBGIk5c+YoS8gJJ5ygtnfJJZcoAaIBMQRLhn764YcfLJ9r28T2CSGEtIRO6GFGqFTSLi3eL3s2/iVlO9dIY0lz6ls9hqRMSekySDr2Girtc7qJIYo6mIQfiKmQfme2vlDfY+Tpl1+Xk06a4pVtduvWLGIQvIy4AsQl6IWE3kKCDjVEhwbcjWDFALt27VLuTnry8vLUfHvb0+jYsaPlb6zb9j3aUFVVJXFxcS2+C+FSVlZmNQ8iYujQoWoCEBiwnOzevVs6d+6s5sGaggnrhtUC1g1YMB566KE2YyyAtk1snxBCSEsoLMKEUAjSLi3aJ/mbVkjZjjViLLPvShCV0l6SuwyUnF7DpF12Z4oJEvYgUFtzf3JEdFK6lJaZO/LeAIHIGrAaZGdnu+3e06VLF0tmJQ28x3x72/MGw4YNU+5QGoilgOUErlZw6dKLI7hh2WaPguUEsSAQGXD9chZYRSCAEItCCCGkJRQWYUAwV9I+ULBb9mxaKRW71oqx3H4AalRqtrJMdOo9VLKyzSOLhEQKyP5UWF3WqrhorCqV9LRUn2wfAdQQF3feeadK4Qo3oh07dqhONIKq2wJuUFOmTFGvI0eOlBdffFHFSdhmbPImJ554osrwBOEA1ykEc8OaALEB9yUNZHB6/fXXlWsXBAasMkcffbRaBq5Wn3/+ucycOdPp7f7444/KjYoQQoh9KCxCnGCrpG0yGqWoYLfs3bxCKiEmKvbbXS4qrZOkdRsknXoNlYz2weWmRYg/QUpZZH+SYSc7XmjDT3LdlRf5ZPvomCMFK0QF4ifQQYfr0mWXXebU99FRRycfHXRYPZB1CZmf9B18bzNkyBCVOQrbgciAGxRiKGwDuq+99loVO/LTTz+p9qCOxYwZM5SFA5YHfEef4QoxFhBWenAc8D2k5UVxvPfff99n+0UIIaGOwaT5zYQpeEjCbxYPDNtgP3+BBxLSOcLdwJsuAcFSSVuJib07lZiAZcJUdcDuctEZnSWtKywTwyQ9q4Nf20giA19da86ALENbt25V8QUIcnYWjLojpSyyP9kL4K7bv0Oy174vyxb/6Nd6E8HOr7/+Ktdff73fKm8jmB0B6cFUedvdcy7UrzVCIgljEFxrrvSlabEIUQIdpA0xUZC/VQo2r5TK3evEVG0n4NFgkJiMLpLabZDk9h4maRnt/NI2QkIJiIX5n/1PpZRF9icEaiOmAu5PsFRkl25Qn1NUWDN69Gi/iQotsxUmQgghjqGwCDECGaQNMbFv12YlJqry14mpxjori0VMZHWXdCUmhkpKGrOnENIWcMuBRQIpZZH9CYHaiKmA+9MJJ0ymqCCEEBISUFiEEIEI0jY2NsrenZukcMtKqYaYqK1ouZAhSmLa9ZCM7oOlc+8hkpSS7pO2EBLOwCKBdLLeSilLCCGE+BsKixDBn0HajQ0NsnfHeinculpqICbqqlouFBUtse3yLGIiMdk3GWsIIYQQQkhoQGERAvgjSBtiIn/b37J/y0qp2btepL7avpjI7i2Z3SAmBktCYrLXtk8IIYQQQkIbCosIDtJuqK+T/K3rZP/W1VK79x+RhtqWC0XHSFx2H8nqMURyew6U+ITm6ruEEEIIIYRoUFhEWJB2fV2t5G9eI0XbVkndvo1iahIsegzRcRLXsY+06zFEOvUcKHHx/k1jSAghhBBCQg8KiwgI0q6tqZL8LWvlAMREwUb4PbVcKCZO4nP6S/u8wZKbN0BiYuM83Q1CCCGEEBJBUFiEaZB2TXWlskwc2L5K6gs2Ib1Ty4ViEyUhp5+07zlUOnXvRzFBCAkZUMPiuuuu82stC39SXl4uw4YNk99//13at28f6OYQQohTsFxmkAVpf7zxY4uoQJD2+G7jZXTuaKdERU1VhWxauUT+/OIl+ev9+2Tf7x9KPQKxdaLCEJckid0Plm7HzJDDzr1Hhh9/vnTtPZiigpAgAlVWSevceuutcscdd1jejx07Vp5++ulWv/PWW2+pe+mLL77Y4jPMT05OVhVm9Zxwwgnqs88++0y9X7BggXp/xBFHWC1XW1sr7dq1U5+VlJgLht57770SExMjKSkpqlrt4MGD5b333rN8Z968eXLYYYepiraZmZly6KGHytdff60+S01NlQsvvFAefPBBngqEkJCBFosQD9KuqiiV3ZtWScn21dJQtA1V7FosY4hPlsTcgdKh51DJ6dpboqKjfbYfhBDP2Llzpxw0YJCs/3utdOnSxaeHE/FbRqPRrwX4GhoaVGfbE9asWSPr16+XyZMnu/S91157TbKystTrFVdc0eLzrl27ygcffCCXXHKJer9nzx5lMUABQz3o9G/btk02btwoffr0UfM+//xzyc7OlgMHDlgte+KJJypRguP80Ucfqerdw4cPl9jYWDnjjDPk7bfflilTpkh9fb3aVlRU83jftGnTlNUC4iIpiYkzCCHBDy0WAQYP9tWFq2Xu1rkWUYEg7dP6nuZQVFSUFcuG5Qtl6WfPycr/PSD7l30uDfu3WIkKQ0KqJPccJXnHXSYjz71Hho47U3J79KOoICTIufmu+yTh8PPl5jvv88n6e/ToIQ8//LCMGjVKdVbXrVunLCTnnXeedOrUSXJzc5WLEUbgtRH6jIwMefXVV1XHG6Pyt9xyi9U60Tnu37+/Wg4j+cuXL7eyJGD5448/XlkEMEqvtQEj9Jg3adIk1SG/8sor1TrQWf/ll18c7sMXX3whRx11lEuCCCJg0aJF8vrrr6v2rVy5ssUyM2bMkDlz5lhZOM4880xJSLBOYIHO/wUXXGC1LP7G9x2B72Bd2L+1a9fKX3/9pQTLKaecovYD2zj66KPlyCOPtHwHxwnHe+HChU7vJyGEBBIKiwAHaS/atUh+3v2zJfMTgrSn9pnaIvNTWUmR/PPnD7L0k2dk9UcPSdFfXzZZKMzfA4bEdEnpPUZ6TrhCRp5zlww55nTJ6dZHDLoRMEJIcFsrfl+7RVKHTZbf1m6WXbt2+WQ7b7zxhrz55ptSUVEhffv2lZNOOklycnJk8+bNsnr1atXpfuCBB6z8/SFA0DlfvHixPP/880pwAHTWMfr/8ssvS2FhoZx++ukyceJEKS0ttdoe1oftHXvssWoeLAOffPKJ5Ofnq/2G0MFnRUVFalT/8ssvd9j+FStWyEEHHeTSPkNQwFJw8sknq847rBa2HHfccaot//zzT5tiYfr06Up4NDY2yu7du+XPP/9U63YElnv//feVq9WQIUPk4IMPVvuOY/fNN9+0sHRoDBgwQO0vIYSEAuxxBjBIe+6WuVaZnxCkDfcnLfNT6YFC+eeP7+SPj5+StR8/LMUr50lD8U5rMZGUKal9j5Q+k66RkWffIYOPniodu/SimCAkRK0VNQOmqL/x6iurBTqz/fr1UyPlq1atUoLh8ccfVxYMjJDffvvt8u6771qWx8AHhAFG1WGZGDNmjCxbtkx99t///lfOP/98ZUGAew+sHYgX+Oqrryzfh1BALAHiDxITEy1tgAUE8QVwacJ2p06dqtp01llnKXenurqW6bBBcXGxillwFnTqIaTgWgQQu/DOO+9YrDJ6qwI+g6CAxQQuW7Cq2APHr3v37vLtt9+qdaPN8fHxLZbDcYCVAtaJJ598UsVYwCKTl5cnS5YsUWLr4osvlg4dOihhs2XLFqvvYz+xv4QQEgowxsJP4CE5bty4Nitpl+zfK3s2r5SyHWvEWLbH7rqiUtpLcpeBktNrmLTL7kwRQYiDay0UrRXx409R7+M79ZHffvhSWS28HWvRrVs3y9+IFUCwMWIP9EICnXF951bv4w/3JVgxANoHdyc96DTrrS367Wno4xawbtv3aENVVZXExbVMfQ3hYhtk3RoIiN6/f78SOACxDddcc418+umncvbZZ7ewRGB/4B7WmmsTwOewhMDCow/Ktg3+1gK/bRkxYoQSZgDWossuu0yJNL0bGPZz0KBBEozs2LFDxZUQQnzLmhB6roWExQJmd/iaYrRs5MiR8scff0goUF1dLWecebqk5yTL7XfeLuk5KXLy9JPkg3UfWEQFgrTHZoyShn82y+//e1z+/vwJKVnzXQtREZWaLWn9x0m/KdfLyLP+LYMOnyLtc7pSVBCi48svv5S7br/darQ8FK0VGr6yWugDhGE1QOcQ4kKb4MaEkXRngOiBONGD93oxpN+eN0BAs+au5Axwe0LwNLIyweUL7l8IlrbnDgVrQs+ePZXFBp381oCVAm5MsMLAtckTevXqJf/617+UK5oeuKBhf4MNPIevu/Zq5QJGCPEdX4bYcy3ohQX8cG+44Qa55557VMDd0KFDZcKECUGfjhH+x+27ZchvDYskbkCSZB6dKclHp8nanNXywJP3yab1f0tt/m7psWanFH//tpT9/aMYy/dZrSMqrZNkDDpO+p98k4w88xYZOGayZGV3Dtg+ERLs3DhzupyRkSE3zLhQQtJa0cmcYUhDWS18GGsB4OoDcXHnnXcqKwQsBdu3b1dB1s6AzjfciuDWg4xPzz77rIqTcDVjkysg09LPP/9sZVUB2H5NTY1lgqvTvn371AMZ8RCIVdAmPKx/+OGHFqJIiwlBwLRtNihbkB3qp59+kv/9738u7wPa/8ILL6g4C7B371555ZVXlJuZBn4HWFrgZhZsXHXJBXLx8Fi5cmbr4osQElnPtaAXFrNnz1ap/2ByRhDbSy+9pMzkMD8Hs6XihDMmSO713STpiEwxVhtFBoq065ImeZ3byZhDO0v1X0tk+O4KSai0NudHZ3SWzMETZMCpt8rIM26U/iMnSEb71lPOEkLMmYLa19fLkckp0q6+XubOnRvS1goNX8ZaAMQ04FghABnxE4h5gPvOpk2bnPo+MhlBTMycOVPFSSBAGaIEcQW+AsHPsCzYip+bb75ZWQ+0CXEQiH+AKxZcnmCt0CYEmMMVyd6zBNYDBJM7wyGHHKK24ypw55o/f76ydMC1DG3BPLRXA2IIrln4PJhAWtzk6j0yuU+MJFXny9KlSwPdJELCki9C8LlmMGnpiIIQBO5BRCD3N1LyaSAAD+Z65A1vC/in4kEJ074rwX6eAPcnWCoyTu4o8mmF9BjTXrKS48VUVyPGWqN0jkmQjvlGSY/KlAEDBklMRhdJ7TZIcnsPk7SMdn5pIyHhRs+sdHk0o530GDpMtq1cIf8uKZLNB5ozE/kajJBv3bpVxRfYpidty1px1NTpYhp/g8NlDD/Mlp8/fdPndS1CiV9//VWuv/76sK68jSxW2E8EdnvznPOUEQN7yctHFErXfsNl5/q/5PLF2bJsrXNClBASOs81d/rSQR28DRMwTN225mi8d+RfC9O3PtOHFuAH/1pM/uD7xd9I7h3dpaGoQQYNzpTkRIPEGI3SGB0lXfYbpGNqrOS3M8i8+Vvl4zvfkZS05pE9f7WRkHACbi3ZjY0yIClZKg0G9dqhqEDNx+i7P8C1i3EabXKWm++apawSLfMJ2VotZsm7c/7jlbaGA7AooNMdxGNjHoFq3cjWBRzto3au+fP5htiKlNp9MrxTvBSKQYZ3ipXk2r1qPqw3hJDwea5puHJ/CWph4Q4oujRr1qwW85FfHaM7/mDQoCHSMSNXDvx0QJIOipMYKZMEiZOMhiwpahcry7eUScrYTKlJqJOqGkzBHS9CSLDz6tOz5aYjjpbK+ASp7WyOQ7qpezf5z+wnHKYL9TYIBsbNF37+mJwB/v/ffD1P0keImPatcbgc8iLNWz5PuSu15fdPIgecZzjnENOCVL/+4OnHH5QHzx4uBWkxUprUQ0xikAfPbpCnHn1AnnqewpeQcHquaWhZAENeWLRv3175/+Lhqwfv4SNrj9tuu00Fe+stFghMhCnZX65Qa9askn1b90vhqkKpGdVTMurjJDkpS5bIVjGKUXZ8ukM6dOsghWvymaqPEA/B6E3h8mUyoHN3MTVlH0resEEGGI1SuHu78v/2x+gOBi5w80XtA0zOgGxMX3/2oVOj7gbDRWp5Z9dNwh+cC8i4hdgWf7hCwSqRv/InOXxwrBjLosQgJulQtlpyYoxyx8p6lX6WVgtCwue5puHK/SWon1DIX47ANmTu0GIsMDqD91dffbXd76BAkb0iRbj5ejvloSOOPWKizHt7nuSc3UnKY+ukMrZB+sREibEBssIo7Sa3k/x3dssJR53gtzYREq5cP+NCeTSzvRiaTLUGk0n9jenGzPZy3bTzZYoffFJxLaMAnDY5e4/TZwEixBW0c81fz7crZ54n/xmHrC9N15qY1N+YZo8TuWzGuYy1ICSMnmsartxfgr5XC+sDUvAhU8bff/+tqrVWVla2WbgokJxx+pkiJpHEPHOFWVvUfGPTcoQQjzJmdKivl0EJ9q81zG8fIpk0CAlmtExQh+RG2/0c85khihDPCfXnWtALCxQgeuKJJ+Tuu+9WRYKQfxwFiYLZz/iq6y+RnHM6tbpMzrmd5Ip/Xey3NhESjlw3/QK5qV3rlX/x+b8uPM9vbWICBhKO59oVF50rTx3bepcBn18+/Ry/tYmQcOS6IHyuuUJQu0JpwO3JketTMBbGKymtlIS/4qXmrzIxImuHREmHrh2kYOdeMcBsDPO1iJSUVqjlx44dG+hmExJy4NopLquQhTGxsrDKXCXaAH/z8hwpOlAoJl2n60CZ7681uDXBXIyCZ4jpwntnXaIIcQXE5CAdO5KS4JzDueZL1qxZIzu2bZOPOyTJxxuariuDSEaeSUq2GkVM2rVmkO3btqrlBw0a5NM2ERKOLAiy51rYCotQAnnHb7jqxhbBmCh8NCJ5hNU8w0EGtTwhxL1r7dIbb2pxrcVnZkriiIOt5l1q8P21hg4e6gns2bPHUk2ZEF+COk8o/ufr+IqePXvKQ0+92PJai4+XjJHN6d3BQ+ca1PKEkNB/roVdgTxvEIgCefbM1QUFBSqjC4O1CQnvaw23VKQBRQ0eQnwFMiYiK1SgrGLBcK0REgkYg+BaC5sCeYQQEmqgo4eaAv6qK0AIIYQECxxmIIQQQgghhHgMhQUhhBBCCCHEYygsCCGEEEIIIR4T9jEWWmw6Ak8CGXhTXl6uSqIzyI0QXmuEhDp8rhESOddaWVMf2pl8T2EvLPBjgK5duwa6KYQQQgghhIRsnxrZoSI63SyUHnLKp6amBiwtH5QehM3OnTsDlvKWkEiA1xohvNYICSfKgqAPCakAUZGbm9um1STsLRY4AF26dJFgACcEhQUhvNYICRf4XCMkMq619DYsFRoM3iaEEEIIIYR4DIUFIYQQQgghxGMoLPxAfHy83HPPPeqVEMJrjZBQh881QnitRWTwNiGEEEIIIcT30GJBCCGEEEII8RgKC0IIIYQQQojHUFgQQgghhBBCPIbCwodMnz5dFeWznS6++GJfbpaQiKKxsVHGjBkjU6dOtZpfWlqqigrdcccdAWsbIYQQ4kk/8pRTTpFQgsLCx0ycOFH27NljNc2ePdvXmyUkYoiOjpY33nhDvvnmG3nnnXcs86+55hrJyspSGdkIIe51Yj766CNJSEiQJ5980jJvxowZcuedd8qoUaPk8ssvt1r+pZdeUgNouCZt133kkUfyZyAkzAn7ytvBkJIvJycn0M0gJKzp27evPPLII0pMjBs3Tv744w95//33ZenSpRIXFxfo5hESkrz66qty1VVXKbEAMaFZCOfOnStfffWV+vvTTz+1+s5PP/2kLIULFixQYkID76dNm+b3fSCE+BdaLAghYQFExdChQ+WCCy6QSy+9VO6++271nhDiOo899pi6piDQNVEBfvnlF4mNjZVDDz1UjjnmGFm/fr3s3bvX8vnChQvl3//+txISGlu3bpXt27er5Qkh4Q2FBSEkLID7xYsvvig//PCDdOzYUXVuCCGuc+utt8r999+vLBOnnnqq1WdffPGFTJkyRV1vhx9+uBIZsFKAdevWSXV1tcycOVOKioqUoAD4HO5Uo0eP5s9BSJhDYUEICRtef/11SUpKUh2aXbt2Bbo5hIQc8+bNU9aKzz//XMaPH9/ic8w/6aST1N/Jycly2GGHWawTeD3iiCOUCzASKujnQ1RgPiEkvKGwIISEBXDReOqpp9QoKzo7GDU1mUyBbhYhIcWQIUOkR48eKulBRUWF1Wd///235OfnWwmOsWPHWgkIvAdHH3201Xy6QRESGVBYEEJCnqqqKhUoesUVV6gOzGuvvaYCuBF0Sghxns6dOyshsHv3bpXVsLy83MoN6rjjjlNuTRq43jZs2KCWx/cgKPTCYvPmzbJz506VVIEQEv5QWBBCQp7bbrtNWSeQGQpgxPWJJ56QW265RbZt2xbo5hESUnTv3l0FYSMoWy8u4AZ18sknWy0LlydkXnvhhRekpqZGDj74YDUfwd2FhYXKPVFzmSKEuA5qMq1YscJqglgPVigsCCEhDTpAzz//vMyZM0fFV2hcdtllqtNDlyhCXEdLGVtQUCATJkyQHTt2yJ9//iknnnii1XKJiYmqnsWzzz6rgrlRVwZAbOjnI8ibEOI6uA6HDx9uNc2aNUuCFdax8CG2BYIIId4HLhcNDQ12P5s/fz4POSFu0qVLF0t8xMiRI2XQoEHSvn37Fsvh80WLFlniK/TXJjJCMb6CEPf7kaHWlzSYGN1ICCGEkFZAJihkfIJ7ISGEOIKuUIQQQghpFYiKc845h0eJENIqtFgQQgghhBBCPIYWC0IIIYQQQojHUFgQQgghhBBCPIbCghBCCCGEEOIxFBaEEEIIIYQQj6GwIIQQQgghhHgMhQUhhJCgZvr06XLKKacEuhmEEELagOlmCSGEBDWlpaWCWq4ZGRlOf8dgMMinn35KQUIIIX4kxp8bI4QQQlwlPT2dB40QQkIAukIRQghxisrKSrnwwgslJSVFOnXqJE8++aSMHTtWrrvuulYtBy+++KJMmjRJEhMTpWfPnvLRRx9ZLbN69WoZN26c+rxdu3Zy6aWXSkVFhUNXKGzz2muvlVtuuUWysrIkJydH7r33XsvnPXr0UK+nnnqq2r72nhBCiG+hsCCEEOIUN998syxcuFA+//xz+fbbb2XBggWyfPnyNr931113yWmnnSYrV66U8847T84++2z5+++/LWJlwoQJkpmZKUuXLpUPP/xQvv/+e7n66qtbXeebb74pycnJ8vvvv8tjjz0m9913n3z33XfqM6wHzJkzR/bs2WN5TwghxLdQWBBCCGkTWBBee+01eeKJJ2T8+PEyePBg1blvaGho87tnnHGGXHzxxdK3b1+5//775ZBDDpFnn31Wffbuu+9KTU2NvPXWWzJo0CBluXjuuefkv//9r+zbt8/hOocMGSL33HOP9OnTR1lRsM4ffvhBfdahQwf1ipgMWDO094QQQnwLhQUhhJA22bx5s9TV1cnIkSMt8+CG1K9fP/X3Qw89pFyktGnHjh2W5UaPHm21LrzXLBZ4HTp0qLI+aBx++OFiNBpl/fr1rQoLPXDNKigo4C9JCCEBhMHbhBBCPObyyy+XM8880/I+NzfXp0c1NjbW6j1iKSBGCCGEBA5aLAghhLRJr169VGceMQ0axcXFsmHDBov1onfv3pYpJqZ53Oq3336zWhfe9+/fX/2NV8ReINZCY8mSJRIVFWWxhrgD2trY2MhflhBC/AiFBSGEkDaBe9PMmTNVAPePP/4oa9asUdmaIADaAgHZr7/+uhIhiIv4448/LMHZCOZOSEiQadOmqXX+9NNPcs0118gFF1wgHTt2dPuXQSYoxFzs3btXCSBCCCG+h8KCEEKIUzz++ONy5JFHypQpU+TYY4+VI444Qg4++OA2vzdr1ix5//33VVwEgrTfe+89GTBggPosKSlJ5s+fLwcOHJBDDz1UTj/9dBUcjgBuT0AqXGSJ6tq1qwwfPpy/MCGE+AFW3iaEEOI2qCkxbNgwefrpp+0/ZFgBmxBCIgZaLAghhBBCCCEeQ2FBCCGEEEII8Ri6QhFCCCGEEEI8hhYLQgghhBBCiMdQWBBCCCGEEEI8hsKCEEIIIYQQ4jEUFoQQQgghhBCPobAghBBCCCGEeAyFBSGEEEIIIcRjKCwIIYQQQgghHkNhQQghhBBCCPEYCgtCCCGEEEKIeMr/A3TMJMmSh5g1AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 800x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "q_index = np.arange(out_ase.q_points.shape[0])\n",
+    "for b in range(out_ase.harmonic_frequencies.shape[1]):\n",
+    "    ax.plot(q_index, out_ase.harmonic_frequencies[:, b],\n",
+    "            color=f\"C{b}\", lw=2, alpha=0.5,\n",
+    "            label=\"harmonic\" if b == 0 else None)\n",
+    "    ax.scatter(q_index, out_ase.renormalised_frequencies[:, b],\n",
+    "               color=f\"C{b}\", marker=\"o\", s=50, edgecolor=\"black\", linewidth=0.5,\n",
+    "               label=\"renorm (ASE)\" if b == 0 else None)\n",
+    "    ax.scatter(q_index, out_lammps.renormalised_frequencies[:, b],\n",
+    "               color=f\"C{b}\", marker=\"^\", s=60, edgecolor=\"black\", linewidth=0.5,\n",
+    "               label=\"renorm (LAMMPS)\" if b == 0 else None)\n",
+    "ax.set_xticks(q_index)\n",
+    "ax.set_xticklabels(q_labels)\n",
+    "ax.set_xlabel(\"q-point\")\n",
+    "ax.set_ylabel(\"frequency (THz)\")\n",
+    "ax.set_title(\"Renormalised phonon bands — Si 2×2×2 (GRACE-1L-OAM, T=300 K)\\n\"\n",
+    "             \"lines = harmonic, circles = ASE MD, triangles = LAMMPS MD\")\n",
+    "ax.legend(fontsize=9)\n",
+    "ax.grid(alpha=0.3)\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb9b0dc2",
+   "metadata": {},
+   "source": [
+    "## 5. Maxwell-Boltzmann velocity-distribution analysis\n",
+    "\n",
+    "Sanity-check the MD thermostat by histogramming the per-atom velocity\n",
+    "magnitudes from the LAMMPS production trajectory and comparing against\n",
+    "the Maxwell-Boltzmann curve at the target temperature. The Si atomic\n",
+    "mass and `k_B T` set the curve; the agreement (or lack thereof)\n",
+    "corroborates the `⟨T⟩` and `σ_T` summary statistics already reported.\n",
+    "Mirrors the velocity-distribution panel in dynaphopy's upstream\n",
+    "Si example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "6b9f5917",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T17:23:31.568180Z",
+     "iopub.status.busy": "2026-05-15T17:23:31.567567Z",
+     "iopub.status.idle": "2026-05-15T17:23:32.169516Z",
+     "shell.execute_reply": "2026-05-15T17:23:32.166702Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "⟨|v|⟩            = 4.747 Å/ps\n",
+      "σ_|v|            = 2.011 Å/ps\n",
+      "T from ⟨|v|²⟩    = 299.3 K   (target 300 K)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAArUAAAGGCAYAAABlpnnfAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAmvpJREFUeJztnQd8FMUXx196CAkECL333ntRqlQpAgqIgEhR/oAiFsQCYkNEEUUFRUFQkKJIVRCQ3nvv0lsIIb0n9//8JuxxOS4hd7nL5e5+389nk9m92d3Zt7Ozb9+8eeOm0+l0QgghhBBCiAPjbu8CEEIIIYQQklWo1BJCCCGEEIeHSi0hhBBCCHF4qNQSQgghhBCHh0otIYQQQghxeKjUEkIIIYQQh4dKLSGEEEIIcXio1BJCCCGEEIeHSi0hhBBCCHF4qNQSh+b9998XNzc3mx3/+eeflzJlytjs+M4C7gHuhTPc84zOg7qAOmFrLl26pM79888/67fhvP7+/uKM99QU//vf/+SJJ56w2/mJ4zyrpmjVqpVanA1nvS5DZs2aJaVKlZL4+HgxFyq1ZoKXDB5SbfH19ZVKlSrJqFGj5Pbt25JT+O6779K8EIl1iImJUQ315s2bKdIM2Llzp5JTWFiYy8vpr7/+sqty6Ihlu3jxovz444/y9ttvP6Tof/7555k+zptvvqn26dOnj8nftWNi+eijj0zm6d+/v/rd+IMCigW2V6xY0eR+69ev1x/7999/t+gdgvINHjxYypcvr/IVKVJEHn/8cZk4cWKmZeDMnDx5UtVfyCmnkBPL5Gi6Az7gExIS5Pvvvzd/Zx0xi7lz5+ogtg8++ED3yy+/6GbPnq0bNGiQzt3dXVe2bFlddHR0jpBo9erVdS1bttQ5OxMnTlT3w1YkJCTo4uLi9Ot37txR58N5yQNiY2N1iYmJ+vWpU6cqOV28eNHh7nlG50FdQJ0wh5EjR5pd3pSUFCXTpKQk/Ta0M7lz5zbrOFkpm/E9zU5eeeUVXaVKldJsQ11CWVG3MivDEiVK6MqUKaPLlSuXLiIi4qE82jF9fX111apVe+j3qKgoJXP8bix7tK/Yjv337Nnz0L64X9rvS5cuNfsdcu7cOV1gYKCuaNGiunfeeUflwz49evTQ+fj46BwBWz+rkCuOv2nTpod+i4+PV0t2k1GZrIGtr6t6DtEd3nzzTV3p0qXVc2wOtNRaSKdOneS5556ToUOHqq+aMWPGKOvCihUrxBrWQJIz8PLyEh8fH3sXI8cDK5Knp6c4O6gLqBO2IikpSVkoNAueh4eHuNo9TUxMlAULFsgzzzyTpeOgN+XatWsyZ84cJddly5alm7dz587KwnbkyJE029Ge436k5wYBC2rlypXlt99+S7M9Li5O/vzzT+nSpYvF75Avv/xSoqKiZNeuXcqKjHzvvfeeOu6VK1fElmj10JHx9vZWS05Gp9NJbGys012XMXgeUlJSxBzw/F++fFk2bdpk1n5Uaq1EmzZt1H80Shq//vqr1K9fX3LlyiX58+eXvn37ytWrVx/qwqpRo4YcOHBAdSv5+fml6XIzZu7cuepchQoVUi/YatWqycyZMx/y+ztx4oRs2bJF38Vl6IPz33//ydNPP63KhPM1adJE1qxZ89ALAfstWbJEJk2aJMWLF5eAgADp3bu3hIeHK18XNMIoB7rl0EX2KP8XdK8hrymlvV+/fqprLTk5Wb/t77//lscee0xy586tzo0XBK4rMw3yhx9+qF44kBHkAZmaKh/O0bJlS3X8PHnySMOGDWXhwoUmfWrRnVSwYEGVhkw02aKrCfcF6UOHDj10jk8++UQpJ9evX3+k79nZs2fViy5v3rzqXHiJoeFDvenevbsqI+T0xRdfpNkfL6AJEyao+oZ9ITPIzlSDcPfuXRkwYIA6VmBgoAwaNEi9zNPz4US5e/ToodIo0+uvv57mPhn7X+L/G2+8odJly5bVywnyM+UrauoYGtu3b1f3BAoW7mdG3VGZed7SI7PnMfaphQKGuoAuaOxboEABadGihep61mT47bff6q9PW4y706dPn66vr1CuMpITnt8OHTqoe1ysWDH54IMPVB0xfnaNXWSMj5lR2dK7H6jfUMZQd1Af2rZtK7t3706TR+te37Fjh4wdO1bVGZT1qaeekjt37mTqXoSEhEi7du0kK0AxRvvYunVrdSysp0fTpk1VXTV89rVjdOzYUdWn9EDbtXjx4jQv7VWrVql2zhzF3PgdcuHCBSlRooSULl36obxodx+F9vw+qr5kVA/Bv//+q2+H0V6gHTp16pRFz5C5zz/aniFDhqhyo0y4RyNGjFDtHY6B9xjAPdbqr1bvTfmeBgcHq+MVLlxYlbN27doyb948k2WEPH744Qe9PHBt+/bty1DmjyoT2o8nn3xS1q1bJw0aNFBtlSanzLzb07suvNvgklKhQgW1b8mSJZXrjal3HtrJRo0aqXd/vnz5lN7xzz//WF13WLRokbz77rtKd0Dew4cPq+34WDPlrobfDD8O0ZbjPOYaCp3ftJJNoAECeKmBjz/+WCkkaNTwhY3GfMaMGaoC4cWAxsFQycCLAi9hKDR44NIDlbx69erSrVs3ZUVB44kBFWhQR44cqfKgYRo9erRq0N555x21TTsmfLaaNWumGtyXX35ZlRcPNY4Hvy+8eAyZPHmyevDeeustOX/+vLoGWKrc3d3l3r17qhHCSw0PMxocKFbpAb82vETxEGgPPkBZcB1ohDXL1C+//KKULTTGU6ZMUXlw7VAYIL+MBm9B3rgmKOCvvfaa7NmzR10HGmJYOTRQ5hdeeEHJc/z48eqe4Nhr166VZ5999qHj4uWMMqBRhZx69uyptteqVUtdO+SPl2DdunXT7IdtaBjwcD8KyKhq1ary6aefKjnBQoMHGw0fGjzIAseDYolGFvUJREREKB9EvGCHDRsmkZGR8tNPPyn57d27V+rUqaPyoZ507dpVbcN1VKlSRTUakLUpoLziGI0bN1aN/IYNG5RCjYYe+5sCcoFyjgYKDVhQUJBefplRajSOHTsm7du3V/uhnuFjBQ23qefDnOctK+cxBvlRt3BOvChwH/bv3y8HDx5U1r0XX3xRbty4oZRc1GlT4GUGS8bw4cPVCwn3Oz2rBu4HlCy8TD777DNVV1FWlBnKijlkpmyG4GUH5QYKLV6YaAdQL1G38RJEHTEEbRBemigfFAW0S/iwhQKYEdoLzvg5Mge8zP/44w/1/AM8F/jwvnXrlvooNAXy4IWPZw/nh2KNlz1kAzmnB9oKzc9eU0yhHEPhz4zymd47BMosnjcoldpxzcWc+mKqHuL8eDeVK1dOXSOsiniumjdvruq41g5n5RlKD9RNPFPwy0eZ0FZBycV7Cu8DPNt4h3399dfKaIF2E2j/jUHZUVfxHkM9RJu9dOlS9d7BOV555ZU0+XEP0Y7iOUF9gPzQtkGxS6+3JjNlOnPmjKprOC7aalj6M/tuNwV+xz74qBg+fLg6F+4H2l60w8uXL9fnxQc47g90ANx/WHzxfkQdw/2zpu4AwxKOj3cVnkfcP9QbvL9effXVNHmxDYYlfDAZUq9ePfVxbBY2c4hwUjR/qA0bNij/yqtXr+oWLVqkK1CggPLbunbtmu7SpUs6Dw8P3ccff5xm32PHjuk8PT3TbIfvCo43a9asTJ0/JibmoW0dOnTQlStXLlN+MWPGjFHn27Ztm35bZGSk8uWC71lycrLaBn8g5KtRo0YaH8J+/frp3NzcdJ06dUpz3KZNmyr/l4yAb0zx4sV1vXr1SrN9yZIl6lxbt27Vlwe+ZMOGDUuT79atW7q8efOm2W7ss3X48GG1PnTo0DT7vv7662r7v//+q9bDwsJ0AQEBusaNGyvfQeNyasDXzfC6MvKphWyKFSumlyE4ePCgyo96kxHadQwfPly/Df6U8AmEvD/99FP99nv37qm6hrIZ5jX2s0K+woUL61544QX9tj/++EOdZ/r06fptKG+bNm0eKieOr/n+GVK3bl1d/fr102wzlkl6PrWaD6MpeRgfA76D8Em8fPmyftvJkyfVs2V4z8153kyR2fMA1AVDudeuXVvXpUsXi/xWNVnkyZNHFxwcbPI3U/dj9OjRaeoqzu/t7a3qpuGza+zTZ+qYGfnUmrofOM+FCxf0227cuKGeo8cff/yhNrJdu3ZpnqVXX31VyRTPXkY899xzqj1NT16Z8an9/fffVV74pQL40+Ief/nll+ke8/jx42naxm+//Vbn7++vfFxN+TOjfUU7Cxo0aKAbMmSI/rmDnObNm6e/F6Z8ajN6hwCUB+vIW6dOHeVnvHz58kyP28hsfcmoHuK8hQoV0t29e1e/7ciRI8r/d+DAgWY/Q+Y8/zg+zrNv376H8mr1KiP/Vdwfw3cg2jzk/fXXX/Xb8G7Duwv3WfO51sqI+xEaGqrPu2LFCrV91apVuozIqExoP/Db2rVrLX63G18X/LIhJ8N3OoBOgXPt2LFDreNZQL6nnnoqzTsKGD6n1tIdUG7ja/r+++/Vb6dOnUpzD4KCgtK0qxp4H+IZMAe6H1gIurPwVQozPyys+LKBFRDWOPhu4esJViN87WsLLATopjTuEsZXMawImQFWUw24AeC46D7H1yPWMzPaGV+/sHhqoOz4woM1Rety0hg4cGCar1JYY9D+wMJpCLajqxdf6OmBr11YaFEG+IppwHIDuWllguUIX874mjWUH6y4OE9GPjY4NkC3pyGaxUbrKsE58BUOCzS6oYzLaQmQFawLhuXDFyjuWa9evTJ1DFj8NHC96KKCvNFlpgGrI77ucc8N82p+Vqh7oaGh6l5gf1hUNGCpwf2EhUADVveMLAEvvfRSmnVY6wzPbQtgYUIXHdweENpFA1YIWI4NMfd5s/Q8psC9gAXz3LlzFl8r6obm1pIZYGUyrKtYR3csrGq2AnKC1RJygtVOo2jRospSCSsRrNSGoE0xfJZQb3Ac+MllBHquYOHNCnjuUPfRHQs096WMXBBgJUOvi9YFCksdLEfoOn0UkAHqIe4DrFZ4Ho0tV+a8Q7TyoMsWvXdom7/66islf1jOZs+ebfX6YlwPb968qc4PS6ah+wVkhF4Ira3N6jNkCjzPsDCiVwn30RhL2miUF20C3isaaAthdcT7CL0Nxr1mhvUQ9Rdkte2DhdiUXCx9t8PaDFnDEhpi0P5p1n2t/YM8IVf0pqLNN1ee5uoO6P0zvCaANhrvW8PnEHUH5UU9Nwbyh4XdnHFGVGotBN3oUIxQYXAzNb8lgBccFBG8UNFIGC7oAodfjyFoxAwdv1GB0U2mLVBQNGCKR2Oo+TfhmJoPbmaUWrxQtO4OQ7TuEeMXjmEjBeCvCdAQG2/HA/OoMqChQCVduXKlWkdjgocFyq72YGkKAh5KY/nhxWosP+PrwwOrvcw00JhBXtr1aV198Ge2Fmjo8ZLXHljIAy9IvBjxUs0MpuSNRkDrwjfcDvcPQ9AVhBeO5tsJeUGJN7wnuH6U0fhFbSwvDRzLWOFCQ2N8bmsD9wHUE1Phkozrr7nPm6XnMQW68PABhpBMNWvWVL7ER48eFXNfcpkFddtQqQQ4N7BlCCHICS+W9NoO1HVj/2XjuqwpCJmpO4Y+n+aC+4E2BQoBupq1BV2fcA1Bl2xGyimUBOSHG4QpNyRTQCnFcwYffTz/8Jt81DOf0TvE8N7C/QEvfdQr+OejaxqKRGY+YsypL8b1UGsr07vnKFN0dHSWnyFT4Jj4SLJm+4zrQRmNFbrMvvvMqb+WPO+WvtvR/uHD2rjtq3T/PmvtH955uHb46lqCubqDqevEdeFDxdB3Hc8LdCBTLjZaO2DORwx9ai0EXyymviABGnjcBDRwpkYvG8c7NP6agW+PofM6Gmf4a6FSwk8LX2TTpk1TiiWUYTTg8J8xd3RhZkhv9HV62x/1MoJvF/ywMAANLwz4DaFBNIwjqV0HGnNT/m+ZGZFtj4DfkAmuCVYUxPpDIwXLrakv0IyOkZltxrKGLyAsKrCWQLGCLx/2g7+npsBbgrVH36d3X4wHnpmDuc+bNYEPHeQLv2R8cMGvGc8igocbWt0zwvj5z4kytgRL2wh8kGVFcYBSCh8++H4bD6jUXqLwLTQFrHjwr0dPBsoBP8PMgA9F+GvifHju4c+blXeIKVniowkLBrVhEBKuI6uD6WxZD3Ny3bRl/bVEzll5t+M31AvsZwpjA1R2kV59Qo8mnlF8NKLcMHDBd9j4YwOgHYABxpy6SaXWBmAQDSo+vlS0ryVzwCAMQ0VI+0KEAojGGpXA8CvSVPdqeo0HBh/AUd2Y06dP63+3NeiCQFcavsThegAlF8quofwAFDNzG22UHw85vl4NnfPh5A4LjnZ92jmOHz+erpXSEmUZDyxebLhXULLwxWxpF5w5oMsTFhl0gRqW0ThIO64f9QVWN0NrLSxT1iQ9OWl12XhSBuOvfMgNDZmpbn3j+puV582c86QHumbhPoQFPQ9QdDEYQ1NqrfmBhboNi57hdWqWR23QTmZlbE7ZICfUl/TaDryQrPXyxIsdChusU1rPkDlgX1j4TE1QgIFtsBKlp9SiXYVFF0YEDIQ0J6QZPmhxz2GNQogwW6EpwnAPsEZ9SQ+trUzvnqP3CFZF9OZk9hky5/nHgES0zxlhzrOF64G1GzIxVKCs/e6z5Hk3591uDNo/RK+BUuyWwbmRD9eOXgFt4LA55beW7oCBi7i/eE7hToh3EaLxmAKRQNIb+JcedD+wARghia88NJzGX3VYh89YRqB7AMqctiC0heGXo+Ex0fBj1KoxaGxMzeaExhYj3xH7UANdSAhdgkbO0q4Jc4BVFg8wrNHw8TQOewMlEA0autoQMsmYjEbQay8TjOI0RPuK1eJGwgKD7kFYMjHiN7Nf4poimN5MWej+xwKLHaw16JbMjlifpuoGRrUa3mdNtpCpoU8eGjottJO1QP0zJSfcV7wMt27dmmY7LNvG14Oywg/MMCYn3Angg2Wt582c85jC+NiwCuMjyTCUTnqysJRvvvkmzfVhHb6BeKlpLxdc16NkbE7ZcDw8M7BIG3Zb42MRSiL87HBvrQEskbguhDk0F7hA4LrRpiD6ifGCDw98wOHZSA9EHIFCjFHg5oDjYz/I2RpxRLdt22ay/dN8WTPbtf+o+pKR9RnKD9ppw/oBRRO9Elpba84zlNnnH0onep2g7MFlxBjtOTfn2UJ54c5nGH0D4w4QzQHPLXpErYElz7s573ZjUNcRFcKUn3VsbKx6vwPIE3KFy5Sx5dfwvLbWHfA+RI8IemsRgQjWWrwzTYHxIIi4YA601NoAfBGhYUQ3Fl4AqExQoPDVgYEA8IdCmAtzwUsFjSV8UhAOBFYhVGRYNI2/2qEII0QIyoGXLPLAZwUDo+DniTAtcJCHlQmNFsoGJcxUF4C1QZgOlAkhQ/DyN57CEg0fyo6vN+SFYogvOzSY8BGFJcWwoTYEcQfhoI4HDQ8mGio8iLhG3Ad022nnQLcOLCsIjQUrC6wI+OLFl6Nx7EINWCTw8KJhhPUD8oNVyND3C9Za7f6a43qQFeDDBystBqdAccf9RBc4ymo4KA8yQLcnBs7h5Q6rGKwDmt+2tayK2ocY7jHuH16iqLdoMCFzhE3Cf1id8IIz5ecIJRUfPRigge4p7QWEATSGfqtZfd4yex5TQL7odtZiKuIFDKu54eAcTRZ43vDyxwsMMrEEWMVQVtRxWDnQG4BnAr53mu8zrJvwUcc14H5CPqtXrzbpW2xO2SBj+IBCgYWc8HKC5RPPMMIdWQscH13/8Bk15We3cePGhz5EAe47ZIEXNMIMmQIvZpRbsxKZAm2GJQoO5G7NKYcRvg+KPT7atJc+XvLz589XdQ1xwq1RXzJi6tSp6l2BDw0MVtVCehlfqznPUGaffxg1oDzjXmihqvCeQ9c1BibCIg6lG3UWsoISiEHXWqxXY3AM1Fe4aUGuUMTwrMJdBEaQzI57eBTmlMmSd7sxeE9CQcSA3k2bNqn3I9w5YEHFdi0mrvbORagt3CfUK5QNsXcRBxgGnuzSHfCORNgzlBdyMgXuEd5LxmG+HolZsRKIPhyLqTAjxiB8UosWLVQoGCxVqlRRIXTOnDljMixMZli5cqWuVq1aKnwKwmhMmTJFN2fOnIfCJyH8FUK3INwOfjMM0YGQPL1791Zhs3CcRo0a6VavXp3mPKZC0WR0/VpIKi1MzKPAtI/IX6FChXTzoAwIaYIwXihn+fLldc8//7xu//79D53XEEztOWnSJBVqxMvLS1eyZEnd+PHj00x3ayjPZs2aqbAhCGkDWfz222/phvQCO3fuVCGtEBbHVHivmzdvqlA2xtN8ZkR68ktvalTjeoOQLJ988okqK6bQRNgt3FNT5cc5nn32WVU3IFvIFGFfcH6EFnrUuU3J3JQcPvzwQxXCDWFkDOsnwrwg/BHOjTI888wzKpSQqWNs2bJFL2uEiEGYmvSm3szM85YemT2PcUivjz76SNUZPEuoQzgnQogZhsFDuDWEVSpYsKAKz6YdM6MQVemF9MJ14flt3769zs/PT4VsQzmNQ/TgHiN0HvLky5dP9+KLL+pDVhkeM72yAVP3AyHq8EwiBBKO3bp1a/U8ZKaNSC/UmClefvnlh9oGTSbpLQhtVLNmTV2pUqUyPHarVq1UmCq0E5kNE/aokF7pkVFIr0e9Q/BMov4irCKeFbRluDY8r4Zh1R5V5kfVl0fJAKHHmjdvrm8ju3btqsJ1WfoMmfP8I0QYQnuhfqJdw3EhE8PwhZg+GNu18GFa/TIOfQVu376tGzx4sAohhXKivhiHF8tIHpmdIj29MqH9SC8EYGbf7aauC+0N8levXl3JCc887gXeg+Hh4Wny4ph4P2j5cKz169fbXHcwBmXFu0ELYWfMuHHjVH03d5pcN/wxTw0mhGQERgWj6w6hUzAhgCOArkNYeWEBwZc+IfYEfqDoRYBl8VHd5MQ0sEjCEmnYU0McH1hZYWG1ZQi/7ACTq8Dai54XY9D7A0s6rMPGk2I8CvrUEmJl4CeE7p/0nN/tjfFc4ygrugrhkgF3D0LsDQY9orsb3dSEkAfAHcE4xKOjsX//fhUDGW4IpoAvMVzWjGOkZwb61BJiJTDVIEaWYspW+Pc9anSxvcAAGCi28JPDFzF8cRFeBT5s2RHWh5DMYGree0JcFbTRaKsR/mvcuHHiiBw/flz5yiJCEHozjcfTaECZtUShBVRqCbESGFWKhgfd97B85lTg9I9GBYOHMOAGgwFQXsPBTYQQQnIOGDgGdxwMEMzsDKQ5DbjD4D2JyB0YdGY8m6c1oE8tIYQQQghxeOhTSwghhBBCHB4qtYQQQgghxOGhT62FYEaOGzduqIDN1pwGkxBCCCHEldHpdBIZGakmhjBnYgcqtRYChdZac50TQgghhJCHp74uUaKEZBYqtRaiTakHgVtrzvOMrMJ37txR0xpmxzS2zgRlR9mxzjkOfF4pO9Y7xyHFhrpJRESEMhyaO30xlVoL0VwOoNBmh1KL0Es4D5Vayi67YL2j3LIb1jnKzh6w3uVcuZnr3kmzHyGEEEIIcXio1BJCCCGEEIeHSi0hhBBCCHF4coRP7bfffitTp06VW7duSe3atdWUnY0aNUp3qrj58+erOYRB/fr11Zz1hvkRCmLixIkqb1hYmJq2FPOIV6xYUZ8nNDRURo8eLatWrVK+IL169ZKvvvpK/P39s+GKCSHEuUlOTpbExESzffSwD/z0OH7APCg7y6Hssl9uXl5e4uHhIU6n1C5evFjGjh0rs2bNksaNG8v06dOlQ4cOcubMGSlUqNBD+Tdv3iz9+vWTZs2aqXmDp0yZIu3bt5cTJ05I8eLFVZ7PPvtMvv76a5k3b56ULVtW3nvvPXXMkydP6uca7t+/v9y8eVPWr1+vbgrmUh4+fLgsXLgw22VACCHOAowKMFDAoGDJvnhRIj4l439TdtkF65195BYYGChFihSx6rPupkOp7AgU2YYNG8o333yj1iEghHGAFfWtt97KlDUgX758av+BAwcqISNY72uvvSavv/66yhMeHi6FCxeWn3/+Wfr27SunTp2SatWqyb59+6RBgwYqz9q1a6Vz585y7do1tX9mwk3kzZtXHTs7oh8EBwcrJZ/WC8ouu2C9o9wsAcYCKLRor/z8/Mx6YaH9TkpKEk9PTyq1ZkLZWQ5ll71yw34xMTFKr4FiW7RoUavpWHa11CYkJMiBAwdk/Pjx+m1Q2tq1aye7du3K1DEgGFha8+fPr9YvXryorAQ4hgYEA+UZx4RSi/8QpKbQAuTHuffs2SNPPfWUVa+TEEJcARgZNIW2QIECZu9P5cJyKDvKzpHqXK5cudR/zWBnLVcEuyq1ISEhqhGEFdUQrJ8+fTpTxxg3bpyyrGpKLBRa7RjGx9R+w39j1wbcFCjGWh5j4uPj1WL4FaFZs7DYEhxfM/MTyi67YL2j3MwFbSTaKrywLO0E1PazcyeiQ0LZUXaOVOe0dgLthuYaqmGpvmN3n9qs8Omnn8qiRYuUn62xQKzN5MmTZdKkSQ9tx2wacJK2Jbi5MMHj5tP9gLLLLljvKDdzQa8Z6g2MFbDgmAvaOOwL6FNL2WUXrHf2kRv2RXtx9+5dNXDMEPjpOpxSGxQUpEzOt2/fTrMd63AezojPP/9cKbUbNmyQWrVq6bdr++EYhn4aWK9Tp44+D0zehqABRkSE9M4LFwkMaDOewg3Tw2WHTy0qDKfJpeyyE9Y7ys1c8IGPlxF6vrBYivELjlB22QHrXfbKDW0EDHVwVTI2TFpqqLSrUuvt7a1Ccm3cuFF69Oihf5FifdSoUenuh+gGH3/8saxbty6NXyxAtAMopjiGpsRCAYWv7IgRI9R606ZNld8X/HlxfvDvv/+qc8P31hQ+Pj5qMQY3JDusp1Bqs+tczoazyC45LEzi//tPkm7flpSYWHHz9BD3vHnFu2RJ8S5dWtyyoEQ4u+yyG1eVG64X164tllh+tP1oqaXssgvWO/vITWsnTLWVlraddnc/gPVz0KBBSjlFrFmE9IqOjlYhtgAiGiBUF7r/AUJ4TZgwQYXeKlOmjN4HFvFlsUBAY8aMkY8++kjFpdVCesHvVlOcq1atKh07dpRhw4apUGLoMoMSjUFkmYl8QEh2NRhxx49LxOo1ErVliyRcupRuXjc/P/GrV0/ydOkiAU88IR7+uXmTSI5i/LJjmciFsQNws8IL0vIwP5N71jQr//PPP68MHcuXL88wH6LjlCtXTipVqqSPlW6I9mLHYOQmTZrot8NnEO8W9AZu2rRJWrVqlaX8AD2ENWrUkA8//FDatGmjd4f74IMP5K+//lK9k4gMhNjveGciXrsp3n//feVah7CXiAJkCOLHv/nmm9KyZUvl5meYH6CnFYOuEU2oZ8+eynBkyvhDSHZhdzNCnz59lCsBHjpYVg8fPqweLG2g15UrV1SIGA1MooCoCb1791buBdqCY2jgIURIMMSdRbiwqKgodUxDc/aCBQukSpUq0rZtWxXKq0WLFvLDDz9k89UTYlqZjdq6VS71flouPf2MhM6bl6FCq/aJiZHo7dvl5vjxcq5FC7kx/m1JuHqV4iXEiiAs5DPPPKPv/TMF3NLmzp2bZtuff/6Z7sQ+5uZHXrwTd+zYoVz4nnzySfnvv//071O8QxGj/ezZs7Jy5UqlEMNnMSPwDoXyDKXdkDlz5kipUqUeyl+9enVVBryfsd/TTz+tDE+IH2+pLyQh1sDulloAK2l67gba16HGpUe83LWvWXytYkkPRDrgRAskpxF77JjcnjJFYvcfSLM9xd1d7hYvL3eLlZXofIUkwSeXuKckS66oMMlz54YUunJG/CLuqby6uDgJ//NPCV+1SgKf7i0F//c/8SxY0E5XRIjzfGxCofzuu++kRIkS8tNPP5l0V0PPIyb/Qa+jFrYIyiG2w6qa1fxawHosMPKgJxOTCEHZ3r59exrLbunSpdOdndMQRAOCKx6U4XfeeUdt27lzp4pQBIUVExcZ+0Jq409gUa5Zs6Y88cQTyiqM3lT0lBLikpZaQoiILjlZ7nz3nVzq2y+NQhtatIzsfOpFWfLOj/L3iI9lb/ehcuLxbnKu8RNypmlHOfxEX9n67Fj5fdws+eulj+R04/birg1cTEqSsN8WyYUnu0r4mjUUMyFZAMoi4qIjfORzzz2nIu/AVc4YKIdwjfvjjz/UOqyZW7dulQEDBpg8rrn5DdGUYPReai54cKEwDD+ZWV544QVlidaAYo2ZNzH2JTOg57NTp06ybNkys89NiLWgUkuInUm8eVMuDxwkIV/PQIwTtc27bFkpPv1LWT3yUznfsK0k5DLdFanHzU1CSlVSSm+FjRsk6H//E3c/P/VTSni43Hjtdbn26quSHB6eHZdEiNMByyzGXcCPFL6s8K1dunRpugoilEIARREubohekx7m5gdQsN99911VHvi8wnr6448/yvz585U1Fz60b7/9thw9ejRT1wc3BrhVQKGGsr5kyRJVLnOAYpuZ3lRCbAWVWkLsSNyZs3KpT1+JPXDfOuvuLkEjR0q5VSslT8eOat1c3l1/SaaVaCWLxnwlF2s202+P/HutXHqmj8RfvGjNSyDE6cEgMlggYaHVQBqKrinwGwZ/wdcVSuqjlENz8vfr109ZZAMCApR1F2XQwlpisNb169eVLy0GQ8N9r169emkssBmFZUI54GIBZR2D4QzDZZo7Gp4Ql/WpJcQVid67V66NHCUp9wdWeBUrJsU+n6qiGFiDOP+8sq3fGLlaraE0Xvmj+MRGS8Lly0qJLvHVdMndtKlVzkOIs4PxF4jBa+hDq83yiAFZUAANQdxNWD6HDBmi9kO3fEYDqMzJ/+WXXyoXCEz/bsqaiwHR8G/Fgsg/Q4cOlYkTJ6oID48CyjSuEZEdzLXSglOnTqmIQ4TYC1pqCbEDUdu2y9Whw/QKrW/NmlLm96VWU2gNuVS7uawe9Zn4VKyo1lMiIuTK0GH0syUkk8Aa+tprr6nIAtpy5MgReeyxx/RuA8ZAKYSlFGEpMzOvfWbzY4BWhQoVHumeoIFwW6Z8f02BqAZYoNQ+++yzYg6Y2h5Rhnr16mXWfoRYE1pqCclmYg4dkmsvvyy6hAS1fq1SXdna61VJ2nxdRLBYn+h8BaX0b7/JjddflyhEFElOlhtvvInZTiRv1642OSchjgSmIoeyamxBRTisgwcP6sNAGrsCIMoORvsbz6CG7n/Ejc3sjJPm5jcG5USkAijHiEIA94T9+/eryYq6d++e6eNgIiLEbodfbnpgBk7EiNemOIUyDhkgLOcbb7xhUfkJsQZUagnJRuLOnpWrL40QXWysWg9o3142Pfa86Dxs/yi++89/4tbuJWkc7SGV9m1UCu31N8fJkj2XZNhHo21+fkJyMlDM6tatm2Yb3AEQYQDWTmOFFjz11FMqHCUmO+jWrVua3+BbijiymcXc/MbAzxZx2REa7MKFC0oxRQxcTDKEAWOZJXfuR0/ccuLECRXbFhZluEFAPphKnpMvEHvjpoNjEDEbjBLFw4yve0u/rDMLvoaDg4NVLEFXm3bTmWSXeDtYLj39tCQFB6t1v6ZNpOT338s7q89kb0EwHfSqOVJ5zz9qVefmJiVnfC0B7drlWNk5Eq4sN/iDXrx4UflVWjJ3O15HsALC6skBR5RddsF6Zx+5ZdReWKpjuVaLS4idgKvBzgHD9QptSIny8mP7Edmv0AJ3d9nTbYicatpRrbrpdHL9tdcl5uCh7C8LIYQQYiWo1BKSDdz+dIqa9QtEBQbJxoHjJcknNXC6XXBzk31dnpcLdR5Tq7r4eLk2YoTE/8dwX4QQQhwTKrWE2JiwP5fLvYULVTrZ00u2PPuaxPvb1mUlU7i7y66eI+RGhZpqFRMzXH3xRU7QQAghxCGhUkuIDUm4dEluffCBfn1396Fyt0T5HCPzFE9PpWSHFi2t1hOvXpV/B4yQt38/Iu8sP27v4hFCCCGZhkotITZCl5QkN8a9pY90cK5BG7lQv3WOk3eir59sGjBO4vwC1HqJs4ek9oYl9i4WIYQQYhZUagmxEXd//FFijxxRaa9SpWTfk4+e0cdeRAcGyZZ+r0rK/dH6tTYvk5In99m7WIQQQkimYZxaQqzI+GXH1P/8Ny5K5+++UV+NKW5usqLzcEnyNj/EUXZyu3wNOdDxOWn413y13uyPmZLSraFIoUL2LhohhBDySGipJcTKuCUnS9Nls8Q9JVmtH2/ZQ0JKpZ0bPqdyqnkXuVSjiUr7xEZL9MefiC459ToIIYSQnAyVWkKsTOU966TAjdTQWPeKlJKjbZ52HBm7ucnup4arsGMg6cgRCZ09296lIoQQQh4JlVpCrEiuiFCps36xfn1392EqwoAjkZDLX7Y/87JymwAh336n9w0mhORMMHvdihUrVPrSpUtqhqfDhw/b/LytWrWSMWPG2Pw8hGQGKrWEWJEGa+aLd/yDaAd3Sld2SPkGl6kiR9v0Sl1JTpYb49+WlPh4exeLEJvw/PPPKyXwpZdeeui3kSNHqt+Qx5mAMorr0pbChQvL008/LZcvX87SccuUKSPTp08XV+Du3bvy/vvvS8OGDaVgwYJSqlQp6dKliyxatEhNIZsRhrI3teC45jJ79mx57LHHJF++fGpp166d7N27N02e27dvq7pcrFgx8fPzk44dO8q5c+fS5Llw4YI89dRT6powRe0zzzyj9ssIHLNHjx5ptv3+++9q+tsvvvhCsgsqtYRYiehdu6TssZ0qjfBYBzv2d2jZHmvVUzyqVFHphP/+k5AZM+xdJEJsRsmSJZUyEns/BJ82N/3ChQuVsuKMDBs2TG7evCk3btxQVt6rV6/Kc889Z+9iOQT//POPVKpUSfbt2yevv/66Wl+2bJk8+eST8uGHH0qHDh0kOjo63f0hd23BRwCUR8NtOKa5bN68Wfr16yebNm2SXbt2qTrdvn17uX79uvodijYUz//++0/d70OHDknp0qWV8quVFf+xDxTrf//9V3bs2CEJCQnStWtXSUlJyXRZfvzxR+nfv7/MnDlTXnvtNckuqNQSYgUwmApT4Woc6PScxN+P++qo6Dw8JPe4N8XNy0ut350zl24IxGmpV6+eUgKgmGggDYW2bt26afKuXbtWWrRoIYGBgVKgQAGlyMC6pTF//nzx9/dPYwH73//+J1WqVJGYmBj55ptvpEaNGvrfli9frpSIWbNm6bdB0Xj33Xf161BCUEZYvsqVKyeTJk2SpKSkLF0zLHVFihSRokWLSpMmTWTUqFFy8ODBNHm2bNkijRo1Eh8fH5XvrbfeSve8sP7C0vvqq6/qLY7adlPWSLhJAKS///57JUeUqWrVqkopO3/+vNo3d+7c0qxZszQyRrp79+7KwgxZw1q6YcOGh6zGn3zyibzwwgsSEBCg7uUPP/yg/11z08B9fuKJJ9R5ateurc6dEfv371fK488//yxr1qyRPn36qDrSoEEDGTFihBw5ckRKlCih8qQH5K4tefPmVeUw3IZrMpcFCxaoelanTh1V16BYQhHduHGj+h31cffu3UrRhLwqV66s0viQ++2331QeKLGQC66tZs2aapk3b566Zii5meGzzz6T0aNHq4/EwYMHS3ZCpZYQKxC+YqXEnzmj0iHFy8mFui2dQq4eZctKgZEjU1dSUlLdEBIS7F0sQmwClJ+5c+fq1+fMmWPypQxr1tixY9WLHgoD/FnRXatZsgYOHCidO3dWlioogFB8oGBA6YDS1rJlSzl58qTcuXNHrzgGBQUpSxtITExUihUUOrBt2zZ1zFdeeUXtBwUQSsfHH39stWsPDQ2VJUuWSOPGjfXbYOHDdUABgqIGBeinn36Sjz76yOQxoBxCmfvggw/0Fkdtu6EVsmfPnkqhgkKqAesmrhF+wFDInn32WXnxxRdl/PjxSs6wMkLp1oiKilJlg/xhcUQ3OqyJV65cSVMmdH1D2UQeKHxQOs/cb6s18PEARRx5YH2FMprRBwMUNsge58P9wP1EVz266VEvoNThAwW/wWqaFaDcZrSYcpnRwAcU6lL+/PnVevx9FzJ8GGmg7uKDZfv27fo8ULCxTQP5kU/LkxHjxo1T93L16tXqmchuHGsECyE5kJTYWLnz1Vf69QOdBqClEGch/wuDJWrDBok7fly5IdydPVsKaoouIZngYq/ekhQSkilZQXnRLHxZwTMoSMr+8btZ+6DrHUqU5lcKqxWsTZqyqdGr131/cwPlF0oNlBjNAgvFs1atWvLyyy8rpQ4+kvXr11e/IQ8UDSizvXv3VsdHF+1X99sR+EFCGYF1EsAqCwvpoEGD1DostVAc3nzzTZk4caLFMvruu++Usg2ZQwGCQrdu3bo0v8N6Dcsy7gmUTbgqQHGZMGGCUnQMwTV5eHgoqyisjYbbNb788ktl8duzZ4/kypVLvx0fD1AKAY7ftGlTee+991Q3PoBCb/iBAYsqFg3I488//5SVK1emUX6h+EKZ1Y6L80PRhFKtAdkjn6enp5J19erVlZUY12sMrJ2wZA4dOlSSk5OV4oaPD9w7fHxAqX3nnXfE29tbKceQZ+vWls8k+ajBfnBbSI9x48Yp31lY/QGuB9Zq1HHUT1imIY9r167pP0Bgscd27AsrN+oG6h6uVcuTHn///bfqUcCHRps2bcQeUKklJIuEzpsnSfed6K9WqS+3y1V3GpnO23lJwiRYAlsPkidPjhP3lBS5PfN7me1VUd4e3t7exSMOAhRa7RnJyUAxxUAfWEHxMkcaFlRTig2UOihmISEhegstrISaUouBOrBqQimDcgrFQAMK4uOPP66UWSgcUIaheMHCd/r0aaXswjoKqy6AlRQKtqFlFkoGfH6hjGr50gNKmqaoYyARlA8ASzIUMICBQFBi4E954MABpZieOnVKKZeGHxnNmzdXVlIoQub6GuO8kMOqVauUAm0IPgA0NAsuur4Nt+F6IyIilCKHMuBDAVZwKFuwrKIb3dhSa3hcrYs/ODg43TxwsQDIY0qpPXbsmLo3UIBx32DNhtLv5eWluv2hVBseC/cuK1SoUMGi/T799FP9B5lmmUUZ8YE1ZMgQ/QcI6l+nTp30A9vwDCxdulRZtL/++mv14QLlHK4vxh8xxkCOeB7woQWXFUtcKLIKlVpCskBSaKjc/eF+HFcPD4cfHJYeYUVLy8nmT0qNbSvFIylRmqz4UXTDnrCKRY04P7CaZhZrWmotdUHQLH3ffvutyTzodsYAG4w2hyUMSi2UWQyoMWTr1q1KcYDSBZcFKIoasO7BvxPWPfhjQlHTFF0otejS1oACBwsiuu2NMexKTo+//vpLWX6BoXUUvpya0oT/UMKhiC1evFhZIq0JFMC+ffsqZQuKszFQuDS0+29qm/YBgYFU69evl88//1yVHdcFq7fxPTA8hnYc4wFPGZ3HGCjPmgxxLuxruL+hIgf/ZEOLsCU8SjFE74KhLzaATCBn+BgbKuwAvQWw/oaHh6vyQ4mFywlcNDRwf+CzDAUVyjt8x/ExgB6CjChevLiKeADLNNxB8BFjWOddQqlFozF16lS5deuW6kqYMWOG0vBNceLECfV1jK9IfHXCbG4cHw+O4aZCkuArWGug0Jig0TAEvjvGFYOQR3H3p58kJSZGpQOf7i3hhUo4rdCOtu0tZY7tEv+wO1L0wjGJWL1a8nbtau9iEQcgs24AUGihNOBFaq8PJryM8bLH+bWub+MwTvDJ1MInAVO+hjt37pQpU6YoqyS6cqEoY8CNBpRWvL9gFdN8Z/EfigissoYjxmElwzkttdpBAc8MUMCBFgECA7b++OOPNB8aKBsUFfjOmgLd7rAiGwLlCB8CcNuA76o1QDkQRkrz24Tirw08syW4B7DWAiisUGhhqYVlE5EQ4G5QrVo1da+h1E2ePDlL5zPX/eCzzz5TFn2Uw1BRNQYfNFqvA3yW4b5hjNZLAXcRWK67deuWqboG/UpTbDGoMjsVW7sqtfgahP8JlEl8KSCsBRoRPLyFTMw3j24WfCkgll56DwYqleEDdfz4cTWqEfsYhzKBM7vGo7pvCDHVpXpvwUKVdvP2lqAR/xPZkfO7WC0lydtX9nR7QdrOT43ycHvKZ+LfurV42KGLiRBbAcUO3e5a2hi4FSDiAayssGqiu9vQtQBERkbKgAEDlD8tunahAKLLGoodrIkAFjQcCyHDMKhGU2phgYQCiW5+DRhzEBkA3f3YH93A6NbG+y29QVuZAe9UGJQ09wMoNrD8apZUGIPwXsbAKCjleDejaxnv7fS6omFYgoUaVlkMNoJiBGUW71i4C2jnA7ASmpJxZqhYsaLqSodMIS/435oTcspSYFWH0g+/XChucFWBtRQfKCgTQmbhYwbRMRDmC9eYFcz5kJkyZYqqK6hTuA+arLVBZQAfUVpMXSjn8FVGmQ2t5xgsiQ8a5MOAReSBzpVZqzP8sNHjAPlAp4Nim5HvrzWx62iWadOmKeUSzt/4soFyi4oPp3tToFGAVVd7WEyBm2AYFgONRfny5dN05RiGMtGW7BI4cR7u/viT6OLiVDqwbx/xKvzwh5izcb1KfblSraFKJ4eEyN3vv7d3kQixOngfpPdOgDIHX0X0GMLlAC97vJcMgRKAwTbwUdV8Q5FGj6AWMxSKGCy9+A8FSFN0cV5Y2LC/BhQDvMugJOE9iME86KnMrAU2PWBthmKOBQoILKpwVdCUF3QnYx0D19CTipH28Mc0DDVmDIxFsJjivaspdFByoYCjvNr5sCAublb0B3wUwF8Zii1kBIu2rcH9gvKIQXu4TgwwQxQL9BDDxQKD68LCwpRSB1/m7GTmzJmqlwEfPoZyhjuCBlxh8MEFf2F8dCGthfPSwMcLFF0otrif8Ls2PEZmwIccZIA6hXsDX+jswE33qGkvbAQED8US/heGs1CgoqBCaNP9pQe+QvBllNH0fDgH/J3wVfn222/rt+NrGK4MuHQotHgg8JVnjrUWNwjme/il2FohxtcnTP+wXj/KUZtkj+wSg4PlwhPtRYfwJz4+Un79P+JVqJCMX5baLeUc6CRQYiRM8Fw86Ar2D70t3b98VTySk1QM23JrVou3kwantwRXfl4xkOfixYtStmzZTPl65kT3A0eFsste2eEjBYo1IgkgTi2UOITDQtc7LN7QO+wR0sqR6lxG7YWlOpbd3A+gvcNNwDBOHcA6Rn9aAwS0hoJsPL0h4t/hixEK79GjR5W/E75MDINuG4PKqsV4A9pXB15gtu7ywPFRebKja8XZsJXsVr71qVS7Xx+ON2wn87ajm+dBt5pzoDNYHhCVv5CcbPGk1NyyXHSJicoNofiMr+1WypyGKz+v2rVriyVo+9nJ3uLQUHbZJzsos7Cww38VRjNNwUOvM9w14H/qCnVYl4XnVWsnTOlRlrafdh8oZkswkhP+TFBeDRk+fLg+jW4hmOfbtm2rRvuhy8QUcPbG6FNj0O2Arw1bgpuLrxXcfFez/ORE2aXcuyeV96bOXJPk5S3XHntCWTSdEX/BSOKHv8CvtGovtY5tFV1oqERt3CjX//5bvO7H4HR1XPl5xQh7XD9e7pbMdgWZaWMiaKml7LILS+sdwp3BLQQGL/TOYEAUIgVkl8HL3uiy+LyijYCMMPjSOEoF/NIdSqmF8zgcxOGcbgjWDYM2Wwr8WzCKNCPrq4Y2gwqCLaen1OKrDN0JhpZaOEPDZyg73A9QYXAuV3tJ5kTZhSxapMJagbON2sntgNS4hs5HqpU2TBC+xqjB8vGTwq+/JrfeTo1xmTDreyn2x+/i5unU38mZwpWfV3zg42WE7kgslmL8giOUXXZgab1DXUcXuqvilQW5oY3EwEtj9wNL3JfUMcVOIOwH4qVh5gnNp1abo9hwNhBLweg9+LQheHZmQ2ZoQZdNgYFppgan4YZkx4sLL8nsOpezYU3ZJUdFy73fFqWmPTzkZAuEtHJm3z83gyUtgT16SNhviyTu2DFJOHdOwn//XfI/+6xdSpnTcNXnFdeLa9cWczEMHUVLLWWXXbDe2UduWjthqq20tO20a4sLyydGXyKeG0KoIM4bAlRrU+FhHmhYSA0HfkEBxYI0RpEiDQurIVCOodRi0JmxtQAuBnDixshVjFzE7B84D4JeGwcpJsSYsKVLJSU8XKUv1n5MYvIWcFkhvb38hCxr3ke/fvnz6TJh4R67lokQQojrYte+QowYhE8q4qohnhqmmEM8M23wGOL/GWrrmHMaMeI0EGICC8J1Gc7NDbcD7IuZYUxZiPE7Yu9BgYYLAWLoZRSihBCgS0iQ0J9/1gvjxOOPDkTt7ISUqiQXazWXskd3iG9MpFTftlLk2VR3HuK6OLsvISEkZ7YTdgvp5egwpJfrhVcK+2OZ3Lw/T/qVqg1k84A3xbkxHdLLmNQQX2PEIzlZEr18pNq/68UziwHHHRlXDumFa8cMRRgvAZ9iGBHM6ZZkWCrLoewoO0epc9gPve0wamKgGSatMG4rHS6kFyGOBB5CQyvt8ZYPYiu7OlH5C8u5hk9Ild1rxSsxXkJmzpQiEybYu1jEDuDFhAEzCPCOnjVz0cL7aL65hLLLDljv7CM3zA2Amc2s+fFPpZaQTBCzZ4/Enzun0rnq1FHd7uQBR1v3lPIHN4lXQrzcW7JU8g8aJN5ZnO2IOCawzuJFBQuO4ZTlmUEL74PR0K5m5c4qlB1l50h1Dr05tphkhUotIZkgdP4v+nT+gQNEbBua2OGICwhUkSBq//s7gg/Kna++luLTvrB3sYidwIsKYX7MDfWDlyT2QTgfKrXmQdlZDmXnPHLLGaUgJAeTcOWKRG3apNKehQtLwBNP2LtIORLMMhbnF6DSEX/9JXEnT9q7SIQQQlwIKrWEPIJ7CxbAeUil8/XvL24MDG+SRF8/Odq6l349eNqXrFuEEEKyDbofEJIO45cdE6+4GOm1aKl4358S9xu/6hK/7Bhllg5nGz8hzQ+vl8Tr1yV6+3aJ2b9f/Bo0oLwIIYTYHFpqCcmAcoe2ind8rEr/V+cxib/fvU5Mk+LpJUEjR+rX78z4hqIihBCSLVCpJSQ9dDqptG+DfvV0k46UVSbI262reJUupY8aEb13L+VGCCHE5lCpJSQdgq6ek3y3rqh0cKlKElaUIaoyg5unpxT83//06yG01hJCCMkGqNQSkg6V9j6w0p5r2I5yMsMXeUpCaQkPKqrWY/btk+lTf1PbCSGEEFtBpZYQEyRHREiZYztVOsHXTy7VbEo5mYHOw0OOtumtX6+zcak+ggQhhBBiC6jUEmKC8BUrxTMxQaUv1H1ckr19KCczuVSruYQVLK7ShS+dkiIXjlOGhBBCbAaVWkJMzGcdtmSxfv1sI062YAk6d3c52uZB3No6G5co2RJCCCG2gEotIUbEHjok8efOq3Rw6coSXrgkZWQhl2s201trC10+IzG7d1OWhBBCbAKVWkKMCFu8RJ+mldYa1toHvrUh3//A+kYIIcQmUKklxIDk8HCJWLtWpeNz5ZbLNZpQPlnkcs2mElGgiErDUht7+DBlSgghxOpQqSXEaICYLj5epS/UbSnJXpggl2TVWnu8ZQ/9esgPsylQQgghVodKLSEGhC3/U59mbFrr8V+dxyU6bwGVjvr3X4k7c5b1jhBCiFWhUkvIfaBoxZ88pdK+NWtKeOESlI2VSPH0lBMtuurX7/5A31pCCCHWhUotIfcJX7FCL4u8PbpTLlbmfMM24pEvn0pH/P23JFy+TBkTQgixGlRqCYHfZ1KShK9amSoLLy/J07kz5WJlkrx9Jf+gQakrKSly98efKGNCCCFWg0otcXnGLzsm30xdKMl3QpQsLlesK+9tuubycrEF+Z7tJ+7+/iodtny5JN66RTkTQgixClRqCRGR8ge36OXwX72WlImNeHfDZTlSv13qSmKirHxnqvqoIIQQQrIKlVri8njFRkupU/uUHOL8AuR6pbouLxNbcqp5F0m6Hyqt4t6N4hMVQXkTQgjJMlRqictT5vgu8UhKVHK4WLuFGqlPbEecf14516CtSnslxkvVnX9R3IQQQhxfqf3222+lTJky4uvrK40bN5a9e/emm/fEiRPSq1cvld/NzU2mT5/+UJ73339f/Wa4VKlSJU2euLg4GTlypBQoUED8/f3VMW/fvm2T6yOO5Xpwga4H2cKJx7pKiruHSlfes05SoqOz58SEEEKcFrsqtYsXL5axY8fKxIkT5eDBg1K7dm3p0KGDBAcHm8wfExMj5cqVk08//VSKFEmddtMU1atXl5s3b+qX7du3p/n91VdflVWrVsnSpUtly5YtcuPGDenZs6fVr4/kfBBWqtDlMyp9r1BJCS1W1t5FcgliAoPkYu3mKu0TGy1hfyyzd5EIIYQ4OHZVaqdNmybDhg2TwYMHS7Vq1WTWrFni5+cnc+bMMZm/YcOGMnXqVOnbt6/4+Pike1xPT0+l9GpLUFCQ/rfw8HD56aef1LnbtGkj9evXl7lz58rOnTtl9+7dNrlOkrOnxU0zQMzNza7lcSVOPNZNnw6dN0+FVSOEEEIcTqlNSEiQAwcOSLt27R4Uxt1dre/atStLxz537pwUK1ZMWXX79+8vV65c0f+GcyYmJqY5L9wTSpUqleXzEsdCp9NJ+JrVqWk3N/mvTgt7F8mlCCtSSq5XqqPSidevS8S6dfYuEiGEEAfGbiNiQkJCJDk5WQoXLpxmO9ZPnz5t8XHhl/vzzz9L5cqVlevBpEmT5LHHHpPjx49LQECA3Lp1S7y9vSUwMPCh8+K39IiPj1eLRkRE6ojtlJQUtdgSHB8KmK3P44xkJLu448cl8XLqB8+tstUlNg9mu9LZoZQ5FZ3BYjvf2uJnD6v03Z/miH/HjsoP3pHh80rZsd45Fnxmc57cLD2m0w3z7tSpkz5dq1YtpeSWLl1alixZIkOGDLH4uJMnT1YKsjF37txRA89sCW4u3CZQeWDNJtaRXczvf+jTt2s3kECJoWiN8JcEEbGdkhlXrqyEFSstgTcuS/zJk3Ljn3/Eq65jh1Tj80rZsd45Fnxmc57cIiMjHUuphZ+rh4fHQ1EHsJ7RIDBzgUW2UqVKcv78ebWOY8P1ISwsLI219lHnHT9+vBrUZmipLVmypBQsWFDy5Mkjtq44sF7hXFRqrSM7XUqK/Ld1q0one3jI6eqPSYL4WfnOOTqpVtowyWU7xdZN5Ohj3eXxxV+nnnHZn1KoQwdxZPi8Unasd44Fn9mcJzdExMoWpXbTpk3SunVrySpwAcAgrY0bN0qPHj30AsL6qFGjxFpERUXJhQsXZMCAAWod5/Ty8lLnQSgvcObMGeV327Rp03SPg4Fppgan4UZmh6KJipNd53I2TMku5sABSbrvbnKjYm1J8AuwYwlzMm4Gi224XKOpeG37XRJv3JDobdsk4fx58a1USRwZPq+UHeudY8FnNmfJzdLjmb1Xx44dpXz58vLRRx/J1atXJSvA8jl79myZN2+enDp1SkaMGCHR0dEqGgIYOHCgspBqwMJ6+PBhtSB9/fp1ldassOD1119XYbouXbqkIho89dRTyiLcr18/9XvevHmVGwLODQUdA8dwPii0TZo0ydL1EMch/K8HAf8v1eIAMXui8/CQ/M8P0q+Hzplr1/IQQghxTMxWaqFIwpL6+++/q+gCiCsLf1UomebSp08f+fzzz2XChAlSp04dpaCuXbtWP3gM1lMM9tJAPNm6deuqBduxL9JDhw7V57l27ZpSYDFQ7JlnnlETLCBUF8zjGl9++aU8+eSTylL7+OOPK7eDZcsYJ9NV0CUmSuTa1JH2br6+crVqA3sXyeUJ7NVL3PPmVXIIX7NGEjkZCiGEEDNx08HD10IwYQJivP72229q/dlnn1VWUEyi4OzApxZWXzhJZ4dPLSakKFSoEN0PrCC7qG3b5Oqw4Sod0KmjfPvYC9a/aU6BTg2eC1O+xraNSDC5Z00J/nK63P3+e7Wef8gLUviNN8QR4fNK2bHeORZ8ZnOe3CzVsbJUinr16in3AFhu4buKSRPgs4oQWpjSlpCcSMTqNfp03i5d7FoWksr4ZcdkZv76kuyR6uZ/69ffZMLCPRQPIYQQ2yq1mLwA7gedO3dW4bLWrVsn33zzjYogAP9WbHv66actOTQhNiUlPl4iN2xQafeAAMn9+OOUeA4hLiBQ/qubej+842OlwoFN9i4SIYQQZ1ZqR48eLUWLFpUXX3xRhco6dOiQmokLfq25c+eWMmXKKF/XrEygQIitiNqyRVKio1U64IknxN3bm8LOQZxs/qQ+XWXn36JLTrZreQghhDgOZof0OnnypMyYMUN69uxpMsSVFoMWkQUIyWlE/PW3Pp2nc2e7loU8THjhEnK9Ym0pfu6IBNwLlsiNGyVP+/YUFSGEEOtbaidOnKhcC4wV2qSkJNl6P5i9p6entGzZ0txDE2Iz3ll+XN5dtF9CN6Z+bMX5BcgnN3MrX06SszjV/IGfc+i8+XYtCyGEECdWajHxQmho6EPbMULNGpMyEGIrip89LF6J8Sp9pXpjFR+V5DwwGUZYoRIqHXvggMQe44cHIYQQGyi1iACGGSSMuXv3rvKpJSSnUvr4bn36co3Gdi0LyQA3NznV/IFrSOjP8yguQggh1vOphQ8tgEL7/PPPp3E/SE5OlqNHj0qzZs0yezhCshX3xAQpcfqASsfnyi23ylXnHcjB/Ffncam77jfxjYmUiHXrpNAbr4tXkSL2LhYhhBBnsNQiCC4WWGoDAgL061gwI9fw4cPl119/tW1pCbGQYuePildCnEpfrdZQdPfjoZKcSbKXt5xpfH+AWFKS3FuwwN5FIoQQksPJ9JsdM4cBhOx6/fXX6WpAHNj1oIldy0Iyx5kmHaTO9pVqWuN7S5ZK0IgR4u6H2c0IIYQQK0U/oO8scSR0CQlS8lSq60GCr5/cLF/T3kUimZyMIc/9Gd9SwsMlbPlyyo0QQkjWLLWYDnfjxo2SL18+qVu3rsmBYhoHDx7MzCEJyTaSDh4U77gYlb5atYGkeHpR+g5C/ucHSfh9ZfbevPmSr29fcbPyHOOEEEJcSKnt3r27fmBYjx49bF0mQqxKwpYt+jRdDxwL3ypVxK9xY4nZs0cSLl9WM8IFMHQgIYQQS5VauByYShOS04E/ZuL2HSqd6O0rNyrUsneRiBlgcowSlVpKmz171Pq+qd/J+ntBKj25J91ICCGEPMDsfryrV6/KtWvX9Ot79+6VMWPGyA8//GDuoQixOTF794ouMlKlr1WpLyle3pS6g3Gtcj2JKFBUpYv+d1zy3bhk7yIRQghxBqX22WeflU2bUqcavXXrlrRr104ptu+884588MEHtigjIRYT+c8/+jRdDxwUd3c51ayTfrXqzjV2LQ4hhBAnUWqPHz8ujRo1UuklS5ZIzZo1ZefOnbJgwQL5+eefbVFGQixCl5wsURv/VelELx+5XqkOJemgXKjXSuJ9U2csLHtkh/hGhtm7SIQQQhxdqU1MTNQPGtuwYYN069ZNpatUqSI3b960fgkJsZDYw4clOTRUpW9Uqi3J3g9mwSOORZKPr5xr1FalPZKTpPLudfYuEiGEEEdXaqtXry6zZs2Sbdu2yfr166Vjx45q+40bN6RAgQK2KCMhFhG5YaM+jVnEiGNzuklHSbkfzqvynn8kJS51hjhCCCHEIqV2ypQp8v3330urVq2kX79+Urt2bbV95cqVercEQuwNpnOO3HhfqXV3V4ONiGMTExgkl2s0VWnfmEgJX7XK3kUihBDiiNPkakCZDQkJkYiICDUZg8bw4cPFj1NYkhxC/Llzknjlikp71qktCX7+9i4SsQInW3SRskdTQ7Tdmz9fAnv3znAyGEIIIa6DRVPzeHh4pFFoQZkyZaRQoULWKhchWSJKs9KKiFeLFpSmk3C3RAUJLlVZpePPnZeYXbvsXSRCCCGOqtTevn1bBgwYIMWKFRNPT0+l4BouhOQ0f1rv5s3tWhZiXU4176xPh86bT/ESQgixzP3g+eeflytXrsh7770nRYsWZdcfyXEzUPmFhUjvEyfU+t1iZWXlhVgR8bN30YiVuFKtkUQFBol/WIiaNjf+v4viU64s5UsIIS6O2Urt9u3bVeSDOnUY85PkTEqe2q9PX2HUA6dD5+Ehp5t2lAZ//6rW7/36ixSZMMHexSKEEOJo7gclS5ZUI8utxbfffqv8cX19faVx48ZqdrL0OHHihPTq1Uvlx+CQ6dOnP5Rn8uTJ0rBhQwkICFA+vj169JAzZ848NNgN+xsuL730ktWuidiXUif36dMM5eWcnG/QRtzuD0wN+3O5JIeH27tIhBBCHE2phSL51ltvyaVLWZ9/ffHixTJ27FiZOHGiHDx4UIUH69ChgwQHB5vMHxMTI+XKlZNPP/1UihQpYjLPli1bZOTIkbJ7924VRxeTRbRv316io6PT5Bs2bJiaLEJbPvvssyxfD7E/3rFRUvhiqutBZP7CEla4pL2LRGxAQi5/CezRQ6V1sbES9vvvlDMhhLg4Zrsf9OnTRymX5cuXVyG8vLy80vween8Gp8wwbdo0pVwOHjxYrWNShzVr1sicOXOU4mwMLLBYgKnfwdq1a9OsY+peWGwPHDggjz/+uH47yp6eYkwcl+KnD4p7SsoD1wOGe3Ja8g14Tu4tXKjSob8ukPyDBombp9lNGiGEECfB7DeAqS5/S0hISFCK5vjx4/Xb3N3dpV27drLLimF6wu93S+bPnz/N9gULFsivv/6qFNuuXbuqgW+Ms+tkrgdVOYuYM+NTtqz4t2olUZs3S9LNmxK5fr3k6dTJ3sUihBDiKErtoEGDrHJiTOCQnJwshQsXTrMd66dPn7bKOVJSUmTMmDHSvHlzqVGjhn77s88+K6VLl1ZhyY4ePSrjxo1TfrfLli1L91jx8fFq0cDkE9o5sNgSHB9+zLY+j6ODaVOLnTus0nF+AXKndCV0ThssxDxytuzGLzsqRcq1kPabN6v1Q1/OkrWxxeXjHg+edXvA55WyY71zLPjM5jy5WXpMi/rqLly4IHPnzlX/v/rqK9W9//fff0upUqWkevXqklOAb+3x48dVxAZDMPuZRs2aNVVosrZt26rrgVuFKTAAbdKkSQ9tv3PnjsTZeA563FxYnFF5YM0mpknYuUu8ElI/PG5XrSN53VPvi78kiAhnnbKEnC67uPLlJKJwcclz+7oUunJWylw9JsHB9p0Ehs8rZcd651jwmc15couMjMwepRYDsTp16qSsn1u3bpWPP/5YKbVHjhyRn376SX7P5ICNoKAgNVkDJnMwBOvW8HUdNWqUrF69WpWxRIkSGeZF1AVw/vz5dJVauElgUJuhpRaRIAoWLCh58uQRW1ccRGjAuajUps+tAwf06QvVmkqYik2bamkMk1w5WjnLmTiA7NxEjjd/Upot+16tltzxrxQa3c+uReLzStmx3jkWfGZzntwQEStblFoM0Proo4+UgoewWRpt2rSRb775JtPH8fb2lvr168vGjRtV2C1NQFiHQmop+GIYPXq0/Pnnn7J582YpW/bRQdkPH07tsobFNj18fHzUYgxuZHYomqg42XUuR0SXnCxRmzapdKKXj9ysUMtAEXMzWIh55HzZ/Vf7Mam3dqH4xkRK6eO7JTk4WLzsPAiUzytlx3rnWPCZzVlys/R4Zu917Ngxeeqppx7aDmst/GTNAYrx7NmzZd68eXLq1CkZMWKECr2lRUMYOHBgmoFkGFwGBRQL0tevX1dpWFgNXQ4wAGzhwoVK6b5165ZaYmNj9a4TH374oRqkhrBkK1euVOdBZIRataAIEUck9vBhSb4feeNGpdqS7OVt7yKRbCLFy1vONG6v0oh8cW9BakQEQgghroXZSm1gYKCK62rMoUOHpHjx4maHB/v8889lwoQJaoYyKKgIyaUNHsN0vIbnunHjhtStW1ct2I59kR46dKg+z8yZM5WPByZYgOVVWxATV7MQb9iwQcWurVKlirz22mtqQodVq1aZKwqSg8AIeI2rVRvYtSwk+znbuL0ke3io9L0lSyTl/kcsIYQQ18Fs94O+ffuqaAFLly5VZme4DOzYsUNef/11ZfE0F7gapOduAPcBQzCT2KNmM3vU7/CDhV8wcS6iNqfeU52bm1yvVM/exSHZTGyefHKpVnMpf2irpISHS/iKlZKvbx/eB0IIcSHMttR+8sknysIJ5TAqKkqqVaumuu6bNWsm7777rm1KSUgGJFy7LvHnzqn0nZIVJd7ftgP3SM7kVLPO+nTo/PmiYwg8QghxKcxWatF9Dz9Y+KYiugD8VxFX9pdfflHRDAjJbqK2PLDoX6tCK62rElq8nNwqU1WlE/77T6J37LB3kQghhGQjFs8piZi0WAjJKa4H4HplKrWuzKnmXaTIpVMqHTpvvvg/9pi9i0QIISQnKbWG8VkfxbRp07JSHkLMIiUmRmL27FFpzyJF5F6R0pSgC3OtagPxKl5cEq9fl+jt2yX+/HnxqVDB3sUihBCSU5RaRDYw5ODBg5KUlCSVK1dW62fPnlWuB4g7S0h2Er17t+gSMOuViH+rlgiaxxvgwujc3SXfgOck+NMpaj10/i9S9IOHZwIkhBDioj61mzZt0i9du3aVli1byrVr15Ryi+Xq1avSunVr6dKli+1LTIgBUZse+NP6t2pF2RAJ7N1b3HPnVpIIX7FCku7do1QIIcQFMHug2BdffCGTJ0+WfPny6bchjVnG8Bsh2QXCt2nxad18fCT3/emOiWvj4e8veXv1VGldfLyELVlq7yIRQgjJiQPFIiIi5M6dOw9tx7bIyEhrlYuQdBm/7Jj6n//6f/Lk/bp4tUx1mff3g5nliGvXD/+CDeUpt1/FTaeTyz/9LNPyNxSdh6dM7lnT3sUjhBCSUyy1mCIX09guW7ZMuSBg+eOPP2TIkCHSs2eqdYSQ7KD4mYP6NEN5EUOiChSRq1VSffz9Iu5JmWO7KSBCCHFyzFZqZ82aJZ06dZJnn31WSpcurRakO3bsKN99951tSkmICUqcNlBqGcqLGHGq+ZP6dNUda+CvQhkRQogTY7b7gZ+fn1Jep06dqiZgAOXLl5fc9wdmEJId+EaGScFrqe4GoUVLS0xgEAVP0nC7bFUJLVpG8t+8JEHXL0jBK2dFpBalRAghTorZlloNKLG1atVSCxVakt0UP/sgzByttMQkbm5ysnnntNZaQgghTovFSi0h9qTE6QP69LX7vpOEGHOpVnOJ9c+r0qVO7FGTMhBCCHFOqNQSh8M9KUmKnTuq0nF+AXK3BGeMIqZJ8fSSM407pNYbnU5CFyykqAghxEmhUkscjsKXTopXQpxKX69cV80iRUh6nG38hCR7pA4fCFu6VFKioyksQghxQszWBqL5QiB2pjijHhAziPPPKxfrtFDplMhICVu+nPIjhBAnxGyltnDhwvLCCy/I9u3bbVMiQh4xi5jmT5vi7iE3KtamvMgjOdXswYCxe/N/EV1KCqVGCCGurtT++uuvEhoaKm3atJFKlSrJp59+Kjdu3LBN6QgxIuHiJckTelulb5epIom5GEqOPJp7RcvIzXLVU+vQ5csStWULxUYIIa6u1Pbo0UOWL18u169fl5deekkWLlyoJmB48skn1SxjSUlJtikpIZgpavNmvRwY9YCYw6nmXfTp0PnzKTxCCHEyLB5hU7BgQRk7dqwcPXpUpk2bJhs2bJDevXtLsWLFZMKECRITE2PdkhLykFJbjzIhmQbxjL1KlVLpmF27Je4MJmMghBAirq7U3r59Wz777DOpVq2avPXWW0qh3bhxo3zxxRfKYguLLiHWJDkiQmIOpPrTRhQoIpFBxShgknnc3SX/gAH61dD58yg9Qghx5WlyobDOnTtX1q1bpxTa//3vf/Lcc89JYGCgPk+zZs2katWq1i4rcXGiMTgxOVmlaaUllpD3qafkzldfSUpUlESsWi2Fxo4VzwIFKExCCHFFS+3gwYOVi8GOHTvk8OHDMmrUqDQKLcDv77zzjjXLSUiawT3XKnMWMWI+Hv65JfDpp1Val5Ag9xYvphgJIcRVLbU3b94UPz+/DPPkypVLJk6cmJVyEZIGXXKyRG3ZqtIJPrkkuAx7Aohl5OvfX0LnzRNJSZF7C3+TAkOHiru3N8VJCCGuZqkNCAiQ4ODgh7bfvXtXPDw8rFUuQtIQe+SoJIeFqTRi06Z4mv09RojCu0RxCWjXTqWTQ0KUGwIhhBAXVGoR/N4U8fHx4m2BtePbb7+VMmXKiK+vrzRu3Fj27t2bbt4TJ05Ir169VH43NzeZPn26RceMi4uTkSNHSoECBcTf318dEwPfiGNEPbhemVEPiGWMX3ZMLYvLPa7fduqrmZyMgRBCnIBMm7u+/vpr9R/K5I8//qiUQY3k5GTZunWrVKlSxayTL168WIUFmzVrllI+oaR26NBBzpw5I4UKFXooP8KElStXTp5++ml59dVXLT4m9l2zZo0sXbpU8ubNq/yCe/bsqfyESQ73p3Vzk+uV6ti7OMTBCSlVSYJLVZZCV85IYPA1id62TfxbtrR3sQghhGQBN116plcjypYtq/5fvnxZSpQokcbVABZaWEY/+OADpUhmFuRt2LChfPPNN2o9JSVFSpYsKaNHj1ZhwjIC5xszZoxazDlmeHi4irGLSSMQhgycPn1aRWvYtWuXNGnSJFNlj4iIUAoxjpcnTx6xJbgGuHxAKXd3tzgKm8OSeOOGnG/TVqV9a9eSH/q8a8beOgmUGAkT+IG72ayMzolzy67kyb3S+tfPVdqvUSMpbaUQX67+vGYFyo6yY71zHFJs2NZZqmNl2lJ78eJF9b9169YqrFe+fPkkKyQkJMiBAwdk/Pjx+m0QSrt27ZRyaatj4vfExES1TQMW5lKlSpml1BL7RD0IaNWKoidW4WqVBhIeVFTyhtyUmL17JfbYcclVswalSwghDorZo202bdpklROHhIQot4XChQun2Y51WE5tdcxbt24py7JxGDLkwW/pAZ9hLIZfEdqXChZbguPDoG7r8+Q03ll+XP1vs2iVlLi/bW4yJlzIVOfCfXQGCzEPJ5edu5ucbPGkNF0+W63e/eknKTbtiywf1lWfV2tA2VF2rHeOQ4oN2zpLj5kppRY+qh9++KHkzp1bpTMCU+Y6I5MnT5ZJkyY9tP3OnTtq4Jktwc2FCR6Vx5W6M9H17ZEQL0UvpCq3sXkCJaVoIbXdHPwlwSm7z7MDZ5fd3boNJX79YvGJjpDIf/6Rm4cPi0exrM1U56rPqzWg7Cg71jvHIcWGbV1kZKTtlNpDhw6pLnstnR4YRJZZgoKClF+ucdQBrBcpUiTTxzH3mPgPN4WwsLA01tpHnRcuDYYKPSy18NWFf252+NRCtjiXK70kwyRYiv93SjySUuve1cr1Jcwtt5lHSbU0hkkup1bObIMLyM5L5GTTjlJ3wxIVt9Z9zV9S6J23s3RIV31erQFlR9mx3jkOKTZs6xC9ymZKraHLgbXcD+ACUL9+fdm4caP06NFDLyCsIxqBrY6J3728vNQ2hPICiIxw5coVadq0abrH9vHxUYsxuJHZ8eJCxcmuc+Uc3KTE6YP6tWtV6luoXLkZLISyS8vZJh2k3o5VoouNlfBly6TgqJHimcUxA675vFoHyo6yY71zHNxs1NZZejy7RrCH5XPQoEHSoEEDadSokQq/FR0drabiBQMHDpTixYurrn8AC+vJkyf16evXr6upehFerEKFCpk6JkbTDRkyROXLnz+/srIiMgIUWg4Sy2HodHqlNsnTS26Wr2nvEhEnJN4vQAJ79pR7CxYoxTZs0SIJGjHC3sUihBBiC6UWMVwzCyIjZJY+ffoon9QJEyaoQVp16tSRtWvX6gd6wXpqqK3fuHFD6tatq1///PPP1dKyZUvZfD84/6OOCb788kt1XFhqMfgLcWy/++67TJebZA/5bl6W3BGhKn2rXA1J9n7YUk6INcg/+Hm599tvygUh9NcFkv+FF8TdRM8MIYQQB1dqYd20FXALSM/dQFNUDWPTZiasbkbH1Hw1MOsYFpJzKXHmgevB9SqcRYzYDu8SJSSgQ3uJ/HutJN+9K+HLV0i+Ps9Q5IQQ4mxK7dy5c21fEkKMKHH6gD59jVPjEhtT4IUhSqkFoXPnSuDTvcWNPrGEEOIwcBQDyZEk3b0rQdfOq/S9IqUkOl9BexeJODmYeMGvYUOVTrh0SaKsNCiWEEJIDrLU1qtXT0ULwCxi8GnNKHTXwYMPuowJsZSordswh7NK00pLsov8Q16QmH37VPruT3MkoG3q9MyEEEKcRKnt3r27PpyVFiqLEFsSZeBPfY3+tMTGjF92LDWRkk+6FSohgcHXJPbgQfly2lJ5dezTlD8hhDiLUjtx4kSTaUJsgS4hQaJ37FDp+Fz+ElKyEgVNsgd3dzn+eDdp8XtqNJQaW/4UoVJLCCEOgcVxavfv3y+nTp1S6WrVqqlJDQixBjEHD0pKVJRKX6tcV3QcrEOykYu1W0idDUvEPyxESpw5JHGnTolv1aq8B4QQ4mwDxa5duyaPPfaYmtjglVdeUUvDhg2lRYsW6jdCskrUpgeuB9fVLGKEZB86D0858Vg3/frd2bMpfkIIcUaldujQoZKYmKistKGhoWpBGtPR4jdCrOVPm+LuLtcr1qZASbZzvn5ric2dR6Uj1q6ThMuXeRcIIcTZlNotW7bIzJkzpXLlyvptSM+YMUO2bt1q7fIRFyP+4kW9AhFcuook5spt7yIRFwSz151q3jl1JSVF7v74k72LRAghxNpKbcmSJZWl1pjk5GQpVqyYuYcjJA1RW7bo04x6QOzJmcYdJMEnl0qHL18uibdv84YQQogzKbVTp06V0aNHq4FiGkjDt/bzzz+3dvmIixG12UCprUx/WmI/0EtwpkkHldYlJkro3J95OwghxNGjH2DSBcMJF6Kjo6Vx48bi6Zm6e1JSkkq/8MILjGNLLCY5MlJi7n8seZUqJREFafkn9uVUs85Sa/ffoouPl3tLlkiBF4eLZ758vC2EEOKoSu306dNtXxLi8qjYtElJSg7+LVuKZDBzHSHZQVxAoAT26iX3Fi4UXUyM3FuwUAqOGknhE0KIoyq1gwYNsn1JiMtj6Hrg36qlCF0YSQ4g/wsvyL3FizFwQEJ/+UUKDH5e3HNzACMhhDi8T60hcXFxEhERkWYhxBJ0yckSdT96hrufn/g1bEhBkhzBxL2hcqFWc5VOCQ+XBe9OfzCtLiGEEMdVauFPO2rUKClUqJDkzp1b+dsaLoRYQtyxY5IcGqrSuZs3F3dvbwqS5BiOP95DdPfdYapvWyUeCfH2LhIhhJCsKrVvvvmm/PvvvypWrY+Pj/z4448yadIkFc5r/vz55h6OEEXk/QkX9K4HhOQgwguXkMvVG6t0rqhwqbRvg72LRAghxBKfWkNWrVqllNdWrVrJ4MGD1ZS5FSpUkNKlS8uCBQukf//+5h6SuDBaN+6TK9ZK/vvbvooqJHHs3iU5jKNtekuZ47tVuvrWFZISN0bcfX3tXSxCCCGWWmoxLW65cuVUOk+ePGodtGjRgjOKEYvIHRYi+W+mziIWUqK8GnFOSE4jrEgpuVy9kUr7RYZJ2NLf7V0kQgghWVFqodBevHhRpatUqSJLlizRW3ADA6mMEPMpfvqgPn21CidcIDnbWqtxd/ZsSYmnby0hhDisUguXgyNHjqj0W2+9Jd9++634+vrKq6++Km+88YYtykicnBKnD+jT16nUkhzMvaJl5Eq11MgcScHBEvbHH/YuEiGEEEt9aqG8arRr105OnTolBw8eVH61tWrVMvdwxMXxTIiTov8dV+noPPkltGgZexeJkAw52rqXlDq5T6Xv/jBbAnv3ZrQOQghx9Di1oEyZMtKzZ08qtMQiip4/Jh5JiSp9rUo9ziJGcjyhxcvp3WSSbt2S8GXL7F0kQgghliq1GzdulCeffFLKly+vFqQ3bGCIG5I114NrVRpQhMThfGtDfvhBdAkJdi0PIYQQC5Ta7777Tjp27CgBAQHyyiuvqAVREDp37qz8awnJLLqUFCl+JnWQWJKXt9wqX4PCIw7B3RLlJXfLx1U66cZNCVu+3N5FIoQQl8dspfaTTz6RL7/8Un777Td5+eWX1bJw4UK1Db9ZApRhuDFgwFnjxo1l7969GeZfunSpiryA/DVr1pS//vorze9ubm4ml6lTp+rz4HzGv3/66acWlZ9YRtyJEyo0ErhZvqYke3EWMeI4FPzf//Tpu7O+p7WWEEIcTakNCwtTllpj2rdvL+Hh4WYXYPHixTJ27FiZOHGiGnBWu3Zt6dChgwQHB5vMv3PnTunXr58MGTJEDh06JD169FDL8eOpg43AzZs30yxz5sxRSmuvXr3SHOuDDz5Ik2/06NFml59YTtSmB7OIXavKUF7EschVu7bkfuwxlU68cYOREAghxNGU2m7dusmff/750PYVK1Yo31pzmTZtmgwbNkyFCqtWrZrMmjVL/Pz8lCJqiq+++kop1QgfVrVqVfnwww+lXr168s033+jzFClSJM2CsrVu3Vo/aYQGXCgM8+XOndvs8hPLidy8SZ++VrkeRUkcjoIvP/gQDvlupqTExtq1PIQQ4spkKqTX119/rU9D8fz4449l8+bN0rRpU7Vt9+7dsmPHDnnttdfMOnlCQoIcOHBAxo8fr9/m7u6uQoXt2rXL5D7YDsuuIbDsLk/Hp+327duyZs0amTdv3kO/wd0ASnGpUqXk2WefVeHKPD3NjnJGLCDx9m2JP3lKpUOKl5PYPNokuYQ4Drlq1hT/dm0lasNGSbpzR+4t/E3yDX7e3sUihBCXJFMaHPxlDcmXL5+cPHlSLRqYTQzW1XfffTfTJw8JCZHk5GQpXLhwmu1YP336tMl9bt26ZTI/tpsCyiwssgg7Zgh8gWHhzZ8/v3JpgGINFwRYjk0RHx+vFo2IiAj1PyUlRS22BMfX6XQ2P092EvnvAyvtdWWl1dnoTDqDhVB21mP8sqPqf2C1jtJ147/iptPJlW9nyVe5qsqI1mWc6nnNLpyxrcsuKDvKzpnqnKXHzJRSq02L64hA0e7fv78aVGaIobUXk0Z4e3vLiy++KJMnTxYfH5+HjoPtkyZNemj7nTt3JC4uTmwJbi78lVF5YMl2BqL++UefDqtaXQIlxmbn8heEW3Kz2fGdGcouExQJkuu1GkuJI7vFNyZS6u5YKWF1BzrV85pdOGNbl11QdpSdM9W5yMhIi/bLUl87LgRgEJYlBAUFiYeHh3IRMATr8HE1BbZnNv+2bdvkzJkzajDao0DUhaSkJLl06ZJUrlz5od9hyTVUhGGpLVmypBQsWFCFNLN1xYGMcS5naOjhdxh2MDWUV0xAPrlctIo15gFJh1QrbZjkomJL2dmMfe36SbFje8U9JUXKbV8neV5+XgoVKuQUz2t24mxtXXZC2VF2zlTnjA2RNlVq58+fr8JjnTt3Tq1XqlRJDdwaMGCAWceBdbR+/fpqMgdEMNCEhPVRo0aZ3Ad+vPh9zJgx+m3r16/X+/ca8tNPP6njI6LCozh8+LC6KXgRmQLWW1MWXOyTHY0vKk52ncvWRO/ZK7r7rhxqFjF3Dxuf0c1gIZSd9YksUFTO128tlfZtFO/4WIlftFjc33vXKZ7X7MaZ2rrshrKj7Jylzll6PLOVWvicvvfee0rpbN68udq2fft2eemll5SPLAZbmQOsn4MGDZIGDRpIo0aNZPr06RIdHa2iIYCBAwdK8eLFVfc/wGQPLVu2lC+++EK6dOkiixYtkv3798sPP/yQ5riwpCKeLfKZGmy2Z88eFREB/rZYR7mfe+455S9MbEvUZoNQXvenGyXE0TnaupeUP7hFPJKTJH7ZMkl66UXxNvL/J4QQYjvMVmpnzJghM2fOVMqmYZiv6tWry/vvv2+2UtunTx/llzphwgQ12KtOnTqydu1a/WCwK1eupNHYmzVrpiZ7wIC0t99+WypWrKgiH9SokXY2Kii7cI9ATFtjYHHF7ygvBn+VLVtWlds4qgKxPrgnmlLr5uOjJl0gxBmICQySM43bS7Wdf2Fkqdz9YbYUfS/zA2cJIYRkDTed5hhrhp8DJjqoUKFCmu1wRcDsXrYeNJVTgCU4b968ykk6O3xqMRmFM/joxZ44IZd69VZp/5Yt5bsOI218Rp0ahBYmfnQ/oOxsjm9kmDz1+WjxSowXNy8vKb/2b/EqXtz2J3YSnKmty24oO8rOmeqcpTqW2aWAMrtkyZKHtmMwFqymhGR2FjH/1q0oLOJUxAUEyulmnVRal5god76eYe8iEUKIy2C2+wHCWsFlYOvWrXqfWky8gMFbppRdQtLzp/Vv1Upk5x0KiDgVJx7vKrUObhRdZKSEr1wp+Z8fJL5Vq9q7WIQQ4vSYbant1auX7N27V4Xjgi8rFqSx7amnnrJNKYlTkHg7WOKOH1dpn6pVxSudsG2EODIJufzFd8BzqSs6nQRPnaoPf0gIISSHWGoTExPVBAWIfvDrr7/arlTEKYnaukWfDqDrAXFifHr0kKSVqyTx2jWJ3rlLordvF//HHrN3sQghxKkxy1Lr5eUlf/zxh+1KQ5yW8cuOyb4FK/Tr83Ql1TZCnBE3b28JGvOKfj34s6miS062a5kIIcTZMdv9AJMkwOWAEHPwjI+TYueP6mcRu1u8HAVInJZ5Oy/JlPiSElKivFqPP3dO5rz3jb2LRQghTo3ZA8UQ4eCDDz5Qg8MwW1fu3LnT/P7yyy9bs3zESSh27oh4JCWq9NWqDTBdiL2LRIhtcXOTAx0HSIcf31erdTYslpR3h4m7H8LLEUIIsbtSi6lnAwMD5cCBA2oxni6NSi0xRclT+/Tpq9UaUkjEJbhdrppcrVJfSp4+IH4R9yR03jwJGjHC3sUihBCnxGyl9uLFi7YpCXFaEK+zxOnUD6AEn1xyq1za2d8IcWYOduwvxc8eEveUFLk7+0cJfOYZ8SxQwN7FIoQQpyNLfcAIU8NQNeRRxBw4ID6x0Sp9vXJdSfE0+1uKEIclvFAJOdegjUqnxMTInW/oW0sIITlGqYULQo0aNdSUuViQ/vHHH61fOuIURG7YqE9frdbIrmUhxB4cafuMJHr7qHTYkqUSd/YsbwQhhNhbqZ0wYYK88sor0rVrV1m6dKlakH711VfVb4QYAkt+5MZUpTbZw0OuV6pDARGXnD73eMv7k9MkJ8vtTyazl4sQQqyM2f3AM2fOlNmzZ0u/fv3027p16ya1atWS0aNHq8gIhGjEnTwpSTdvqvSt8jUl0Zcjv4lrcrLFk9Lo5DZJvH5dYnbvlsj16yVP+/b2LhYhhLiupRazijVo0OCh7QjvlZSUZK1yESchauO/+rQK5UWIi5Ls5S2Fxr2pXw+e8pmkxMfbtUyEEOLSSu2AAQOUtdaYH374Qfr372+tchEnQXM9AFRqiasT8MQT4tekiUrDYhs6d669i0QIIU6Dp6UDxf755x9pcr9x3rNnj1y5ckUGDhwoY8eO1eebNm2a9UpKHI6Eq1cl/swZlb5TsqLE5slv7yIRYlcQy7vw2+Pl4lM9lW9tyPc/SN4ePcSrSBHeGUIIyW6l9vjx41KvXj2VvnDhgvofFBSkFvxm2HgT1yaNlZYTLhAi45cdU1Jo1PAJqbJ7rehiY+WfV96T7X1elsk9a1JChBCSnUrtpk2bsnI+4kJEGYTyulKVs4gRonG43TNS5ugO8Y2JlHJHtsu5hm1FhEotIYTYbfIFQtIjKTRUYg4eVGnvsmUlolBxCouQ+yT4+cuhJ/rq5dF4xY+iS0igfAghJAtQqSU2IWrTZpGUFJUOaAcrFCHEEFhn75SooNKBd67L3Z/nUUCEEJIFqNQSm/vTBrSlUkvIw62vu+zpMUxS7o8/CPnuO0m4dp2CIoQQC6FSS6wO5reP3rlTpT0KBolvrVqUMiEmCC1WVs406ajSurg4uf3xx5QTIYRYCJVaYvXR3d9PXaBe0OBk2Try9vITlDIh6XD4iT4SE5BPpaM2bUrTy0EIISTzUKklVqfM8V369JUaqbGMCSGmwdTR+7sM0q/f+vhjSYmOprgIIcRMqNQSq+KREC/Fz6RGPYjzC5BbZatRwoQ8gks1m0ruZk1VOunGTQn+6ivKjBBCHFGp/fbbb6VMmTLi6+srjRs3lr1792aYf+nSpVKlShWVv2bNmvLXX3+l+f35559Xkz8YLh07pvqtaYSGhqppffPkySOBgYEyZMgQiYqKssn1uRLFzh0Rr4R4/YQLOg+LJq0jxLVwc5Mi778vbr6+avXeL79KzKFD9i4VIYQ4FHZXahcvXqym1p04caIcPHhQateuLR06dJDg4GCT+Xfu3Cn9+vVTSuihQ4ekR48eajGczQxAib1586Z++e2339L8DoX2xIkTsn79elm9erVs3bpVhg8fbtNrdQVKH9+tT1+m6wEhmWbi/nDZ17p36opOJ0defkPeWZLa60EIIcQBlNpp06bJsGHDZPDgwVKtWjWZNWuW+Pn5yZw5c0zm/+qrr5TC+sYbb0jVqlXlww8/VNP2fvPNN2ny+fj4SJEiRfRLvnypAzHAqVOnZO3atfLjjz8qy3CLFi1kxowZsmjRIrlx44bNr9lZSYmPlxKnD6h0fK7ccrN8DXsXiRCH4lSzLhJSvLw+dm3NTcvsXSRCCHEY7KrUJiQkyIEDB6Rdu3YPCuTurtZ37Xow2MgQbDfMD2DZNc6/efNmKVSokFSuXFlGjBghd+/eTXMMuBw0aNBAvw3HxLn37NljxSt0LaJ37BTv+FiVvlqVrgeEmIvOw0N29nxJUtw91HrNLcsl7swZCpIQQjKBXR0eQ0JCJDk5WQoXLpxmO9ZPnz5tcp9bt26ZzI/tGrDk9uzZU8qWLSsXLlyQt99+Wzp16qSUWQ8PD5UXCq8hnp6ekj9//jTHMSQ+Pl4tGhEREep/SkqKWmwJjq/T6Wx+nqwSsW6tPn25RmO8osX+6AwWQtnl/DoXVrSUHGvZQ2pv+kPcU5Ll5jvvSKmFC8XN0/n90x2lrcuJUHaUnTPVOUuP6ZStZN++D+ZUx0CyWrVqSfny5ZX1tq2Fs1tNnjxZJk2a9ND2O3fuSNz9mKy2Ajc3PDxcVR5Yk3MiusREidyQGl8z0SeXxFYoL4ESIzkBf0nASBx7F8MhoezsI7errTtIueO7JODODYk7fkKuzJghufr3F2fHEdq6nAplR9k5U52LjIx0PKU2KChIWU5v376dZjvW4QdrCmw3Jz8oV66cOtf58+eVUou8xgPRkpKSVESE9I4zfvx4NaDN0FJbsmRJKViwoIqgYOuKgwgOOFdObeijtmyVsPuxNa9UbSChnnklZ5BqMQuTXFRsKTvHqXOeItt6jZCO308Qd51O4ub+LIU7dhTfqlXFmXGEti6nQtlRds5U5xDdyuGUWm9vb6lfv75s3LhRRTDQhIT1UaNGmdynadOm6vcxY8botyGCAbanx7Vr15RPbdGiRfXHCAsLU/68OD/4999/1bkxcMwUGHiGxRjcyOxofFFxsutclhC1fr0+fblm0xxmGXUzWAhl5xh1LqRUZTnxeHflVytJSXLrrfFS5o/fxd3bW5yZnN7W5WQoO8rOWeqcpceze6sB6+fs2bNl3rx5KioBBnVFR0eraAhg4MCBykqq8corr6jIBV988YXyu33//fdl//79eiUYsWYRGWH37t1y6dIlpQB3795dKlSooAaUAURNgN8toi4gJu6OHTvU/nBbKFasmJ0k4bgo14P7U3smevvKjQq17F0kQpyCI22fEZ8qVVQ6/tw5CZkxw95FIoSQHIvdldo+ffrI559/LhMmTJA6derI4cOHldKqDQa7cuWKijOr0axZM1m4cKH88MMPKqbt77//LsuXL5caNVLDR8Gd4ejRo9KtWzepVKmSimcLa+y2bdvSWFoXLFigJnCAO0Lnzp1VWC8ck5hP9K5dkhIertLXqtSTFC/ntiQRkl2keHpKsSmfinh5qfW7P/4kMQdSw+YRQghJi5sOHr7EbOBTmzdvXuUknR0+tfABRsSGnNgld2PcOAlfsVKlNz33hppJLOegUwPWwsSP7geUnUPWuck9a0rI7Nly54tpat2rZEkpt/xPcc+dW5yNnN7W5WQoO8rOmeqcpToWWw2SJVJiYyVy/YbUypQnj1yvVIcSJcSKjF92TKblayTBpSqr9cSrV2XNsNfVdkIIIQ+gUkuyRNSWLZISkxq6K+CJdpLimdpNSgixHjp3d9nx9Ejlsw4qHNwsZQ9vp4gJIcQAKrUkS0SsWaNP533ySUqTEBsRWaCI7Ok+VL/eeMVsSbhyhfImhJD7UKklFpMcESFRm7eotEfBIPFr1IjSJMSG/Ff3cblQ93GVxpTU18e+JroETPRACCGESi2xGPjSIpwXyNOxk7h5pM5XTwixHXu6DZGIAqkxt+OOH5fg6V9R3IQQQkstsZ7rQRcKk5BsIMknl2zt+4ok3/+IDJ0zR/m2E0KIq0NLLTEbjLqeNG+bRO7apdYj8xeWD867cTQ2IdlEaPFycrDjc/r162+Ok4Rr1yh/QohLQ6WWWESZY7vUnPTgYq1mmCuPkiQkGznVrLP4t2ur0pj85NrLL0tKXBzvASHEZaFSSyyi7JEH4YQu1WpOKRKS3bi5SbHJk8W7dGm1Gn/ylNz64EPhfDqEEFeFSi0xG//QYCl49ZxK3ytSSsKKlKIUCbED766/JL93Hy2JXqlTgIcvWyZz357Oe0EIcUmo1BKzKXdoqz59kVZaQuwKPip39XxRv95o5RyJPXrUrmUihBB7QKWWmIUuJUXKH9ycmnZzk//qPEYJEmJnLtVuIaeadlJpj+QkuTZylCTevm3vYhFCSLZCpZaYRcz+/RJwL1ilb5avKTGBQZQgITmAA50GyO0yVVU66c4duTbif5ISG2vvYhFCSLZBpZaYRfify/Xp8/VbUXqE5BBSPD1l87OvSWS+gmo97uRJufHWeNW7QgghrgCVWpJpUqKjJWLdOpVO8MklV6txWlxCchLx/nlk04Bx4p47t1qPXLdOQr751t7FIoSQbIFKLck0Eev+EV1MjD6MV7KXN6VHSA4cOFZ82hci7qnNe8h330n4qtX2LhYhhNgcKrUk04T/+ac+TdcDQnIu/i1bSqE339Cv33j7bYm+PwMgIYQ4K1RqSaZIuHpVYvbtU+nwoGISUrIiJUdIDp7K+vOAenKmUbvUDYmJcv6lkfLZN6vsXTRCCLEZVGqJ2QPELmCAGKfFJSRn4+Yme7sOkatVG6hV7/hYaTvvE0m4ds3eJSOEEJtApZY8EoyeDl9+X6l1d5cLdR6n1AhxAHQeHrK1zysSXKqSWveLDJOrQ4ZKUmiovYtGCCFWh0oteSQxe/dK4o0bKp27eXOJzZufUiPEQUj29pFNA8dJWMHiaj3h8mW5Omy4JEdE2LtohBBiVajUkkcStmSJPh34VA9KjBAHI94vQDY+/7bE5Mmn1uNOnJCrw1+U5KhoexeNEEKsBpVakuFgk0nztsm9df+o9djceWRKVBFKjBAHJDpfQVk/+F3xyJeq2MYePizXRozgrGOEEKeBSi3JkAoHN4tHcrJKX6jfWlI8vSgxQhyU8MIlpdTcOeKeN69aR0STayNHSUp8vL2LRgghWYZKLUmflBSpuHe9fvWsFh6IEOKwTDqZKKv6j1OzAoLonTtl49ODJSUuzt5FI4QQx1dqv/32WylTpoz4+vpK48aNZe/evRnmX7p0qVSpUkXlr1mzpvz111/63xITE2XcuHFqe+7cuaVYsWIycOBAuXF/oJMGzufm5pZm+fTTT212jY5IsfNHJeDeHZW+XrG2ROUvbO8iEUKswN0SFZSPbaK3j1ovcfaQXH1phJoKmxBCHBW7K7WLFy+WsWPHysSJE+XgwYNSu3Zt6dChgwQHB5vMv3PnTunXr58MGTJEDh06JD169FDL8ePH1e8xMTHqOO+99576v2zZMjlz5ox069btoWN98MEHcvPmTf0yevRom1+vI1FpT6ovLTjb+Am7loUQYl3ulK4sGweNl0RvX7Ues3u3XBk6TJIjIylqQohDYneldtq0aTJs2DAZPHiwVKtWTWbNmiV+fn4yZ84ck/m/+uor6dixo7zxxhtStWpV+fDDD6VevXryzTffqN/z5s0r69evl2eeeUYqV64sTZo0Ub8dOHBArly5kuZYAQEBUqRIEf0Cyy5JBSG8Spw+oNIYMX2tcn2KhhAnI7hsNVk/5D2J901t+2IPHZIrzw+WpHv37F00QghxLKU2ISFBKZvt2j3w1XR3d1fru9KZpxzbDfMDWHbTyw/Cw8OVe0FgYGCa7XA3KFCggNStW1emTp0qSUlJWb4mZ+HewoXirtOp9LkGbVUQd0KI84Epr/8ZOlEfFQHhvi4PGKCPTU0IIY6Cpz1PHhISIsnJyVK4cFpfTayfPn3a5D63bt0ymR/bTREXF6d8bOGykCdPHv32l19+WVl48+fPr1waxo8fr1wQYDk2RXx8vFo0Iu4HLk9JSVGLLcHxdTqdzc+jP19MjNxbslSlkz085YxyPUhVcB0PncFCKDvWOVPcK1ZaSs77Wc02lnznjiScvyCX+vaT4rNmim+VKtn24GR3W+dMUHaUnTPVOUuPaVel1tZg0BjcECD0mTNnpvkNfrwatWrVEm9vb3nxxRdl8uTJ4uOTOnjCEGyfNGnSQ9vv3LmjFGdbgpsLazOuA5ZsWxO/YqWk3Ffar9duLL4B3uIrMeKo+EuCiLjZuxgOCWXnOnL7+niM+A18XZr8/IX43w2WpOBgOd+vv+zrP0q6DOySLWXI7rbOmaDsKDtnqnORFvr221WpDQoKEg8PD7l9+3aa7ViHj6spsD0z+TWF9vLly/Lvv/+msdKaAlEX4H5w6dIl5YtrDCy5hoowLLUlS5aUggULPvLY1qg4cJ/AuWzd0OtSUuTSihX69aPNukqY+InjkmqlDZNcDqdk2B/KztXkFlagjKx58WNp88sUKXj1vHjFx0mTn78Un4r5JW/37jY/f3a2dc4GZUfZOVOdQ3Qrh1NqYR2tX7++bNy4UUUw0ISE9VGjRpncp2nTpur3MWPG6LdhYBi2Gyu0586dk02bNim/2Udx+PBhdVMKFSpk8ndYb01ZcLFPdjS+qDjZca6oHTsl4b//VPpWmaoSWqycOD5uBguh7FjnMiLeP6/8M2SiPL74Kyl5ar+4pyTLrfFvS8L581Jo7Fhxs7F/fXa1dc4IZUfZOUuds/R4dnc/gPVz0KBB0qBBA2nUqJFMnz5doqOjVTQEgBizxYsXV93/4JVXXpGWLVvKF198IV26dJFFixbJ/v375YcfftArtL1791bhvFavXq18djV/W/jPQpHGoLI9e/ZI69atVQQErL/66qvy3HPPSb77gyVcldB58/TpU82zp8uREJKzSPb2kc39X5eGq+ZIlfuh/UJ/miPxZ89J8c+nisf9GckIISQnYXeltk+fPsovdcKECUr5rFOnjqxdu1Y/GAxhuAw19mbNmsnChQvl3XfflbffflsqVqwoy5cvlxo1aqjfr1+/LitXrlRpHMsQWG1btWqlLK5Qht9//301+Kts2bJKqTV0L3BF4k6dkujt21Xaq3hxuVa1gb2LRAixEzp3d9nbbYiEFyohjf+aJ5KcLNHbtsnFZ56Rkt99Jz7ly/PeEEJyFG46ePgSs4FPLWLiwkk6O3xqMRkFXCNs2SV3fexYifjrb5Uu/N67MjVXLXF8dBIoMff9gul+QNmxzllC4f9OSMuF08Q3JnXwBiZs2PXUcHlx0giHbOucEcqOsnOmOmepjsVWgygSLl2SiLXrVNqjQAEJ7NWLkiGEKG6Xqy5rRk6W0CKl1bpXQpw8vvhrufneBEmxcfQXQgjJLFRqieLuTz/hs0ul8w8cKO4WjjwkhDgn0fkKydqXPpQLdR7TbwtbulQuPf2MxF+4YNeyEUIIoFLr4oxfdkw+mLtF7i77U60n+OSSrwNqq+2EEGJIkrev7Hh6lOzoNUKSvLzVtvhz5+Ri76cldOFCFa+SEELsBZVaItW3rRSP5GQliTNNOkiiryPHpSWE2BQ3N7lQv7Ws+d+n4lOxgtqki42V2x98qGYkS7x5kzeAEGIXqNS6OH5hIVJ573qVhuXlVLPO9i4SIcQBCC9cQsosWSKB/frqt0Xv3Cn/de0mYX8up9WWEJLtUKl1cWpt+kM8khJV+nTTjhIXEGjvIhFCHIR3/j4vX9fsKesHvyPRefKrbSlRUXJz/HhltU24fNneRSSEuBBUal0YvHAqHNiUmvbJJScet/00mIQQ5+Nmxdqy8pUv5ELdxx+y2t757jtJSUiwa/kIIa4BlVoX5s6Mb8T9fsSDky26SrxfgL2LRAhxUBJz5VaDyP4d8KZEBQapbbqEBAn5eoZc7N5DorZts3cRCSFODpVaFyXuzBmJWLMmNe0XICdbcEpcQkjWwUyEK1+ZJice6yop9wOyJ1y8KFeHDZcN3fpJ/PnzFDMhxCZQqXVBEHbn9ieTkVDrx1v2kCSfXPYuFiHESUjy8ZUDnQbI6pFTJLhUJf324mcPy3/de8jNSZMk6c4du5aREOJ8UKl1QSL/WS8xe/akpvMXltNNOti7SIQQJySsaGlZ++KHsrXPy3qXBElOlrDfFsn5J9rL7alTJSk01N7FJIQ4CVRqXQxMaRk8ZYp+fX/ngZJyP4g6IYRYHTc3uVS7hax4dbocbN9P3P1S42Dr4uIk9Kc5cr7dExL85XRJunePwieEZAkqtS44HW7ijRsqnbtZM7latYG9i0QIcQGSvbzleKunZNEr0+Vk886S7OmltutiYuTu99/L+TZtlVtU8q1b9i4qIcRBoVLrYiG87s7+MXXFw0MKvz1eWVEIISS7QCzs/V2el2WvzZDTjdtLsoeHflaysF9/lYhn+8uNN8dJ7PETvCmEELOgUusi6FJS5MY776guP5D/uf7iUyF1iktCCMluYvPml73dh8rysV/LqaYdxc3XN/WHlBSJXL1aLvXuLReffkbC/lgmKbGxvEGEkEfi+egsxBmY/+bn0mj/AZWOzFdIFpZpJ0nLjtm7WIQQFyc6X0HZ1/UFOdqmt1TevVaq7lorPjFR6re4Y8fk5rFjcnvKFAl8qocE9ukjPuXK2bvIhJAcCpVaFyDhyhWpu26hfn1nrxEq5A4hhOQU4nPnkaNtn5brj7WT/EcOSqU966XAjYvqt5SICAmdN18tvjVqSN6uT0qezp3Fs2BBexebEJKDoFLr5OgSE+XGuLfEKzFerSN81+1y1e1dLEIIMUmyt4+ca9hWzjVoK0HXzkulPf9IxRO7RRef2obFHT+ulttTPpPcTZpInq5dJaBtG/HIk4cSJcTFoVLr5CAOZOyhQyodma+gHOzQ395FIoSQR+PmJiElK6plf+dBUv7QFil3aKveegvf2+idO9Vy09NT/Bo0kIA2bcS/TRvxLlGcEibEBaFS68RE/PWX3Jv/i0one3jK1n6v0u2AEOJwJPj5y6nmXdSSN/ialD2yXcoe2SEBobdTMyQlSczu3Wq5/cknElqktFTs3lGFLcxVt464ezMWNyGuAJVaJyXu7Fm58e57+vV9Tz4vd0sw2gEhxLEJL1RCDj/RVw636yNBV89JmWM7peSpAw8UXER3uXVZxb7FgqgKfvXrS+6mTcSvaVPxrVJF3O6HESOEOBdUap2QhKtX5eqQoSqoOcjbvbucbfSEvYtFCCHWdU8oVUktcE+ABbfkqX1S8uR+KXjtvD4bwhhG79ihFoAZzXxr1xK/unUlV506kqt2bfHIm5d3hhAngEqtk5F4+7ZcGfyCJN25o9YxUrjI+xNF/n7QyBNCiFPh5ibhhUuq5XirnpIr4p4UuXBMil44LkUvHJPc4Xf1WVNiYiRm1261aIQHFZPQomWk0RNNxLdqVfGtWkU8g4LsdDGEEEuhUutEfPDzFnnipw8l8M51tR5WqISs6/GqxFOhJYS4ELF58snFuo+rRXQ6yRNyUym3hf87IYWunBG/iHtp8ucNuaGWO8d26rd5FAwS3ypVxadiRfEuW0Z8ypYV73LlxCNfPnHjTIyE5Eio1DoJ8efOSadZ74p/WIhaj8xfWNa/8K7E+wXYu2iEEGI/3NwkomAxtZxp0kEpubDcFrx8RgpeOauWfLcui0dyUprdku+ESPSdbRK9bVua7e5584pPmTLiXbaseJUsIV7FiotXsWLiVbyYeBUuLG5eXtl8gYSQHKXUfvvttzJ16lS5deuW1K5dW2bMmCGNGjVKN//SpUvlvffek0uXLknFihVlypQp0rlzZ/3vOp1OJk6cKLNnz5awsDBp3ry5zJw5U+XVCA0NldGjR8uqVavE3d1devXqJV999ZX4+/uLI4FrjVi5Um6+P0n8708lidBdUGhj8+S3d/EIISRn4eYm0YFBarlUu3nqpuQkyXvnhuS/eUny3bwk+W9ckvw3L4pPbPRDu6eEh0vskSNqeQh3d/EsVChVyS1WTDwLFxLPoILKlcEzqID674ElMJDWXkKcUaldvHixjB07VmbNmiWNGzeW6dOnS4cOHeTMmTNSqFChh/Lv3LlT+vXrJ5MnT5Ynn3xSFi5cKD169JCDBw9KjRo1VJ7PPvtMvv76a5k3b56ULVtWKcA45smTJ8X3/vzi/fv3l5s3b8r69eslMTFRBg8eLMOHD1fHcxQSLl2S259OkajNm/Xb7hYrKxsHjZe4gEC7lo0QQhwFnYenhBUppRaBy4LaqBO/8LtK2c0D9wT1/7r6b+ijm4aUFEm6dUstsQcPpn9CT0/xLFBAPArkF488edVANUwe4RGYV9zxX63nVevY7u7vrwa4YXHLlYsKMSHp4KaDqc+OQJFt2LChfPPNN2o9JSVFSpYsqayob7311kP5+/TpI9HR0bJ69Wr9tiZNmkidOnWUYozLKVasmLz22mvy+uuvq9/Dw8OlcOHC8vPPP0vfvn3l1KlTUq1aNdm3b580aNBA5Vm7dq2y9l67dk3t/ygiIiIkb9686th5bDyTDWQSHByslHy35GSJ2b9fwn7/QyLWrhVJTtbnO1+/lezpNlSSvRiT8QE6CZQYCRM/VHeb3ifng7Kj3FjnTOGZECcBd2+J/707kjsMS8j9dIhazxUdYTvBubnpFVyl5Ob2Ew+/3OLm5ycJHu6SK29ecffxFTcfbxWf183bR9x8sHiLO/7rt91f17YhzJmnp7hh8fBQ/+VRaScJjWb4jkXPLbG/3CzVsexqqU1ISJADBw7I+PHj9dsgmHbt2smuXbtM7oPtsOwaAivs8uXLVfrixYvKjQHH0IBgoDxjXyi1+B8YGKhXaAHy49x79uyRp556SnIKsceOSej8XyT27l2JjYyU+AsX9KG69Hn88ypl9kqNxnYrJyGEuApJ3r5yr2gZtZjCIyFeKbi5osIkV2SY+u8bFf5Q2icmQjwMDBOZQqeTlOhotZgiUbIRDJgzVHbxH9ug4Kj/buLm5p66rqXv/67Pp/KKQb77v+l/NziGm9uD37TBeoaD9vTbDDcZGjNM76MTnSQkJEoCJulQxza6RrWnqfOY2PbIcqSzjwNR7NPJ6oMqJ2JXpTYkJESSk5OVFdUQrJ8+fdrkPlBYTeXHdu13bVtGeYxdGzw9PSV//vz6PMbEx8erRQNfDwA+u/hasRVRFy/KzfsKuzFxfgFytlE7NfghycdXJCbSZuVwXHQSJ7ESL3hxOGYDYj8oO8qNdc5SYvzziGCBS0O6j5hOPBPixSsuWvnvesdFi3dM6n+sY7t3bIx4JcSqfJ7xceKVGCee8fHief8/fnO34TvokSSlHWBHnJ9cr7+m3GKg+8Ci6u3tbRNLLTDXmcDuPrWOAnx4J02a9ND20qVLi105elDkx8/sWwZCCCGEuAals0/viYyMVL3tDqHUBmEUqIeH3L79YHpDgPUiRYqY3AfbM8qv/ce2okWLpskDv1stD/xADElKSlIREdI7L1wkDN0e8IWC/AUKFLC50z6+WOBnfPXqVZv77zoblB1lxzrnOPB5pexY7xyHCBvqJrDQQqHNzBinHKPUwmRdv3592bhxo4pgoCmLWB81apTJfZo2bap+HzNmjH4bIhhgO0C0AyimyKMpsRA8fGVHjBihPwbcBuDPi/ODf//9V50bvrem8PHxUYsh8MvNTlBpqNRSdtkN6x3lxjrnOPB5peycpc6ZY6HNMe4HsH4OGjRIDdpCbFqE9EJ0A4TYAgMHDpTixYur7n/wyiuvSMuWLeWLL76QLl26yKJFi2T//v3yww8/qN9hNYXC+9FHH6m4tFpIL2j7muJctWpV6dixowwbNkxFTEBILyjRGERm7lcBIYQQQgixP3ZXahGi686dOzJhwgQ1SAvWVYTX0gZ6XblyJY0DcrNmzVQs2XfffVfefvttpbgi8oEWoxa8+eabSjFG3FlYZFu0aKGOqcWoBQsWLFCKbNu2bfWTLyC2LSGEEEIIcTzsrtQCKJfpuRtsNphYQOPpp59WS3rAWvvBBx+oJT0Q6cBRJlqA2wNmSDN2fyCUHetdzoPPK2XHeudY8Jl1HrnZffIFQgghhBBCsgqnziCEEEIIIQ4PlVpCCCGEEOLwUKklhBBCCCEOD5XaHMK3334rZcqUUREaECt37969GeZfunSpVKlSReWvWbOm/PXXX+JqIMxbw4YNJSAgQE17jJBtZ86cyXCfn3/+WQ0kNFwMo2K4Cu+///5DckB9ygjWuVTwnBrLDsvIkSNNys1V69zWrVula9euKkwirhlRagzBcA5EvcEkObly5ZJ27drJuXPnrN5WOpvsEIJy3Lhxqt3PnTu3yoPQlzdu3LD6M++M9e75559/SA4I8fkoXL3eAVPtHpapU6dKTql3VGpzAIsXL1bxejGK8ODBg1K7dm3p0KHDQ7OeaezcuVP69esnQ4YMkUOHDillDsvx48fFldiyZYtSJHbv3q0m4EBj3759exXOLSMQJPrmzZv65fLly+KKVK9ePY0ctm/fnm5e1rkH7Nu3L43cUPdARhFZXLHO4TlEWwZlwBSfffaZCqOIWOGYHAcKGtq9uLg4q7WVzii7mJgYde2Iv47/y5YtUx/z3bp1s+oz76z1DkCJNZTDb7/9luExWe9SMZQZljlz5iglFSFRc0y9Q/QDYl8aNWqkGzlypH49OTlZV6xYMd3kyZNN5n/mmWd0Xbp0SbOtcePGuhdffFHnygQHByOSh27Lli3p5pk7d64ub968Oldn4sSJutq1a2c6P+tc+rzyyiu68uXL61JSUkz+zjqnIuzo/vzzT71MIKsiRYropk6dqt8WFham8/Hx0f32229WayudUXam2Lt3r8p3+fJlqz3zziq7QYMG6bp3727WcVjvTAM5tmnTRpcR2V3vaKm1MwkJCWq6XnS9aWAyCKzv2rXL5D7YbpgfwFqRXn5XITw8XB+DOCOioqKkdOnSas7q7t27y4kTJ8QVQVcvupnKlSsn/fv3VxOdpAfrXPrP76+//iovvPCCslikB+tcWi5evKgm2zFsxzAlJrp102vHLGkrXantQ/171NTt5jzzzgzi38NlrXLlyjJixAi5e/duunlZ70xz+/ZtWbNmjeoxfhTZWe+o1NqZkJAQSU5O1s+gpoF1NPqmwHZz8rsCKSkpanrk5s2bp5ldzhg0YugyWbFihVJGsB9mqbt27Zq4ElAe4OuJmfZmzpyplIzHHntMIiMjTeZnnTMNfM4wayH89NKDdc50fQLmtGOWtJWuANw14GMLlzS4uVjrmXdW4Howf/582bhxo0yZMkW5sXXq1EnVLVOw3plm3rx5ajxLz549JSOyu97liBnFCMkq8K2FT/GjfHWaNm2qFg0otFWrVpXvv/9ePvzwQ5e5EWjENWrVqqUaHlivlyxZkqkvb5LKTz/9pGQJK0R6sM4RW4FxBM8884wadAeFISP4zKfSt29fvUww2A7tX/ny5ZX1tm3btqysmQTGIVhdHzXoNbvrHS21diYoKEg8PDyUKd8QrBcpUsTkPthuTn5nB1Msr169WjZt2iQlSpQwa18vLy+pW7eunD9/XlwZdFtWqlQpXTmwzj0MBntt2LBBhg4dapasWedS6xMwpx2zpK10BYUW9RCDFTOy0lryzLsK6BJH3UpPDqx3D7Nt2zY1ONHcti876h2VWjvj7e0t9evXV10hGugSx7qhRdEQbDfMD9CopZffWYF1Agrtn3/+Kf/++6+ULVvW7GOgy+nYsWMqrJArA5/PCxcupCsH1rmHmTt3rvLL69Kli1myZp0T9axCETVsxyIiIlQUhPTaMUvaSmdXaOGriA+rAgUKWP2ZdxXgegaf2vTkwHpnuocKzyKiTOS4epdtQ9JIuixatEiN+v355591J0+e1A0fPlwXGBiou3Xrlvp9wIABurfeekuff8eOHTpPT0/d559/rjt16pQaXejl5aU7duyYS0l5xIgRKpLB5s2bdTdv3tQvMTEx+jzGsps0aZJu3bp1ugsXLugOHDig69u3r87X11d34sQJnSvx2muvKbldvHhR1ad27drpgoKCVAQJwDqXMRh1X6pUKd24ceMe+o11LpXIyEjdoUOH1IJXzbRp01RaG6H/6aefqnZuxYoVuqNHj6qR1GXLltXFxsbqZYmR1TNmzMh0W+kKsktISNB169ZNV6JECd3hw4fTtH3x8fHpyu5Rz7wryA6/vf7667pdu3YpOWzYsEFXr149XcWKFXVxcXH6Y7DeHTL5zILw8HCdn5+fbubMmSblb+96R6U2h4BKgJekt7e3Ch+ye/du/W8tW7ZUYUgMWbJkia5SpUoqf/Xq1XVr1qzRuRp46EwtCKGUnuzGjBmjl3PhwoV1nTt31h08eFDnavTp00dXtGhRJYfixYur9fPnz+t/Z53LGHwYoa6dOXPmod9Y51LZtGmTyedTex4R1uu9995TzyEU1bZt2z4kz9KlS6uP9sy2la4gOygH6bV92C892T3qmXcF2cHg0b59e13BggWVIQgyGjZs2EMfRax3YvKZBd9//70uV65cKgSfKexd79zwxzY2YEIIIYQQQrIH+tQSQgghhBCHh0otIYQQQghxeKjUEkIIIYQQh4dKLSGEEEIIcXio1BJCCCGEEIeHSi0hhBBCCHF4qNQSQgghhBCHh0otIYQQQghxeKjUEkIIIYQQh4dKLSGEEEIIcXio1BJCiAvw/fffS4kSJaRt27YSHBxs7+IQQojVcdPpdDrrH5YQQkhOITIyUipXrizLli2TRYsWiY+Pj0yZMsXexSKEEKtCSy0hhGQzmzdvljJlylg9/927d6VQoUJy6dKlNNuhxAYGBkqFChWkePHikj9/frE1ffv2lS+++MLm5yGEEA1PfYoQQohD8/HHH0v37t0fUoC9vb1l8ODBUrhwYaXQXrt2zeT+yAOl96OPPspyWd599115/PHHZejQoZI3b94sH48QQh4FLbWEEOIExMTEyE8//SRDhgwx+fvOnTtl9OjREh0dLWfPnn3o9+TkZFm9erV069bNKuWpUaOGlC9fXn799VerHI8QQh4FlVpCCLEzcBn48ccf02zbt2+f+Pr6ysWLFzN1jL/++ku5GTRp0uSh3+7cuSNr1qyRESNGKKV17ty5JpVeLy8vadiwoVpv1aqVjBo1Si2wtAYFBcl7770nhsMwfv/9d6lZs6bkypVLChQoIO3atVNKs0bXrl2VDy8hhGQHVGoJIcTOQDE8efJkmm3jxo2TF198UcqWLZupY2zbtk3q169v8jdYS2vXrq0Giz333HOyYMECSUpKSpNn5cqVSgl1c3PTb5s3b554enrK3r175auvvpJp06bple+bN29Kv3795IUXXpBTp04pv9+ePXumUXobNWqk9o2PjzdLHoQQYgn0qSWEEDuDrnpDpXbdunWyf/9+WbJkSaaPcfnyZSlWrJjJ32CZ1dwSOnbsKCkpKcpyC/9bjRUrVsiXX36ZZr+SJUuqbVB0oRAfO3ZMrQ8bNkwptVCMociWLl1ar5wbgvIkJCTIrVu39HkIIcRW0FJLCCE5yFILS+f48ePljTfeUF3+mSU2Nla5Kxhz4MABdWxYVQEsr3369EnjggBL640bN1QMW0PgymBouW3atKmcO3dO+d/C8ov8KPvTTz8ts2fPlnv37qXZH24Jmr8vIYTYGlpqCSEkB1hqEZEgKipKVq1apaygY8eONesYUICNlUoA5RVKqKEVF4qzh4eH8rUtWLCgcj144oknTCrF6YH9169fr3xx//nnH5kxY4a88847smfPHr3LRGhoqPqPcxBCiK2hpZYQQnKAUguOHj2qBmNNmDBBcufObdYx6tat+5BfLnxZFy5cqOLFHj58WL8cOXJEKZ5aZAK4Hhi6ImhAQTVk9+7dUrFiRaXQAlhxmzdvLpMmTZJDhw6p0GF//vmnPv/x48fVLGbmWJwJIcRSaKklhBA74+/vr3xOX3vtNXF3d1c+q+bSoUMH5bYAa22+fPn0yiqiEcCf1jhWbO/evZUVt3///sp/F9ZaY65cuaIsxhiwdvDgQWWN1SZUgMK7ceNGad++vYregHVYfqtWrZpm8Bp+J4SQ7IBKLSGE5ADgmwrXAwwOg9+rJfvXq1dP7Q8lFEBpRZgtU5Mf9OrVSz755BP55ZdfVJQCU9bUgQMHKl9d/A7r7CuvvCLDhw9Xv+XJk0e2bt0q06dPl4iICKWUQ+Ht1KmT+j0uLk6WL18ua9eutUAahBBiPlRqCSEkB2DKUmoucFvAADNYemHx/fvvv9PNCwUYvrWIW5vehAuIWwuldebMmQ/9BotsRgorFGoow6bi5hJCiC2gUksIIU5Cly5dVHSC69evq3BcmaFFixb6yAjWBAox3BUIISS7oFJLCCFOxJgxY8zK/+abb9qkHEOHDrXJcQkhJD2o1BJCSDZTpkwZs5RPc/NbA8wQRgghjoSbznBOQ0IIIYQQQhwQxqklhBBCCCEOD5VaQgghhBDi8FCpJYQQQgghDg+VWkIIIYQQ4vBQqSWEEEIIIQ4PlVpCCCGEEOLwUKklhBBCCCEOD5VaQgghhBDi8FCpJYQQQgghDg+VWkIIIYQQ4vD8H+1ce4wAUea5AAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 700x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from ase import units as _ase_units\n",
+    "\n",
+    "# Per-atom velocity magnitudes from the LAMMPS dump (already in Å/ps).\n",
+    "v_mag = np.linalg.norm(lammps_vel, axis=2).ravel()       # shape (n_steps * n_atoms,)\n",
+    "v_mean = float(v_mag.mean())\n",
+    "v_std  = float(v_mag.std())\n",
+    "\n",
+    "# Extract T from <|v|^2> = 3 kT / m  →  T = m <|v|^2> / (3 kB).\n",
+    "# 1 Å/ps = 100 m/s; ASE's units module already has kB in eV/K.\n",
+    "m_si_amu = 28.0855  # u\n",
+    "kB_J_per_K = _ase_units.kB * _ase_units._e   # eV/K → J/K\n",
+    "m_si_kg = m_si_amu * 1.66053906660e-27\n",
+    "v_mean_m_per_s = np.mean(np.linalg.norm(lammps_vel, axis=2)**2) * (1e-10 / 1e-12)**2  # (Å/ps)² → (m/s)²\n",
+    "T_inferred = m_si_kg * v_mean_m_per_s / (3.0 * kB_J_per_K)\n",
+    "print(f\"⟨|v|⟩            = {v_mean:.3f} Å/ps\")\n",
+    "print(f\"σ_|v|            = {v_std:.3f} Å/ps\")\n",
+    "print(f\"T from ⟨|v|²⟩    = {T_inferred:.1f} K   (target 300 K)\")\n",
+    "\n",
+    "# Analytical Maxwell-Boltzmann |v| distribution at T_inferred.\n",
+    "v_grid = np.linspace(0, v_mag.max() * 1.05, 400)\n",
+    "a2 = kB_J_per_K * T_inferred / m_si_kg   # m²/s²\n",
+    "# convert v_grid (Å/ps) to m/s for the formula, then back to per-Å/ps density.\n",
+    "v_grid_mps = v_grid * 100.0\n",
+    "mb_pdf_mps = (\n",
+    "    np.sqrt(2.0 / np.pi)\n",
+    "    * (v_grid_mps**2 / a2**1.5)\n",
+    "    * np.exp(-v_grid_mps**2 / (2.0 * a2))\n",
+    ")\n",
+    "mb_pdf = mb_pdf_mps * 100.0   # density per (Å/ps)\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(7, 4))\n",
+    "ax.hist(v_mag, bins=80, density=True, alpha=0.6, color=\"C0\", label=\"LAMMPS MD\")\n",
+    "ax.plot(v_grid, mb_pdf, color=\"C3\", lw=2,\n",
+    "        label=f\"Maxwell-Boltzmann @ T={T_inferred:.0f} K\")\n",
+    "ax.set_xlabel(r\"$|v|$ (Å/ps)\")\n",
+    "ax.set_ylabel(\"probability density\")\n",
+    "ax.set_title(\"Per-atom velocity magnitude distribution (LAMMPS production trajectory)\")\n",
+    "ax.legend()\n",
+    "ax.grid(alpha=0.3)\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d03d7d5",
+   "metadata": {},
+   "source": [
+    "## 6. Notes & caveats\n",
+    "\n",
+    "- 50 000 production steps at 1 fs (50 ps trajectory) + 5 ps equilibration\n",
+    "  sits roughly 7× below the dynaphopy upstream Tersoff Si reference\n",
+    "  sample budget (500 000 × 0.7 fs ≈ 350 ps), which is enough to get\n",
+    "  well-separated optical peaks but still leaves visible width in the\n",
+    "  per-mode Lorentzian fits. Further extending `production_steps`\n",
+    "  toward ~200–500 k continues to tighten the fits at a roughly linear\n",
+    "  cost of GPU time (~4 min per additional 10 k steps on this hardware).\n",
+    "- At Γ on monatomic primitives, the three acoustic modes are degenerate\n",
+    "  at zero — dynaphopy's Lorentzian fit becomes ill-conditioned. The notebook\n",
+    "  demonstrates the workflow at q = X (0.5, 0, 0) where all 6 modes are\n",
+    "  non-degenerate. For Γ-point work, ensure the cell has a ≥ 2-atom basis\n",
+    "  and consider longer trajectories.\n",
+    "- Scale verified against the dynaphopy upstream Tersoff Si example\n",
+    "  (https://abelcarreras.github.io/DynaPhoPy/examples.html): Tersoff Si\n",
+    "  at 788 K shows ~0.5 THz frequency shifts (~3 %) on the ~15 THz optical\n",
+    "  mode. Our notebook on the same primitive (different FM, different T)\n",
+    "  should show shifts of similar order — values that look like a uniform\n",
+    "  ratio across all bands point at a units / convention issue rather than\n",
+    "  anharmonicity. (One such bug — feeding ASE-internal velocity values\n",
+    "  in `Å/AU_t` to dynaphopy as if they were `Å/ps` — was found and fixed\n",
+    "  while writing this notebook; the macro now passes `velocity=None` so\n",
+    "  dynaphopy reconstructs the velocity field cleanly from positions.)\n",
+    "- The macro auto-warns when `⟨T⟩` drifts by more than 3 % from the\n",
+    "  requested temperature. Short MD on small cells tends to overshoot\n",
+    "  the tolerance — this is expected and is documented in the macro's\n",
+    "  `MdPhononOutput.check_md_health()` method.\n",
+    "- For polar materials (LO–TO splitting), pass `born_charges` and\n",
+    "  `epsilon_inf` once the v2 BORN-correction follow-up lands. The\n",
+    "  `[phonons-md]` install extra already pulls in dynaphopy for this.\n",
+    "- To replace GRACE with another foundation model: swap `grace_fm(...)`\n",
+    "  for any ASE-compatible calculator (MACE, M3GNet, CHGNet, …) in\n",
+    "  Section A; for Section B, point `pair_style` and `pair_coeff` at\n",
+    "  the equivalent LAMMPS pair style."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py:percent"
+  },
+  "kernelspec": {
+   "display_name": "Python 3 (grace)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Adds `notebooks/dynaphopy_grace_example_long.ipynb`, a sibling of `dynaphopy_grace_example.ipynb` with the MD integrator step dropped from **1.0 fs to 0.7 fs**. Matches the dynaphopy upstream Tersoff Si example, which uses `-ts 0.0007`. All other knobs (50 k production steps, 5 k equilibration, 4-q-point band path Γ → X → K/W → L, Boltzmann velocity-distribution panel, FC2 from `_compute_fc2_from_scratch`) are unchanged.

Working directories are disjoint (`./_dynaphopy_grace_0p7fs/...`) so both notebooks can coexist without clobbering each other.

## Results

- ASE ⟨T⟩ = 294.5 K (drift 1.8%)
- LAMMPS ⟨T⟩ = 319.8 K (drift 6.6%, above the 3% auto-warn tolerance — flagged in the notebook output)
- Boltzmann analysis: T from ⟨|v|²⟩ = **299.3 K** (target 300, 0.2% — slightly tighter than the 1 fs sibling's 298.1 K)
- Renormalised dispersion: the ~13.5 THz cluster at zone-folded optical bands persists, same pattern as the 1 fs run. The fit-collapse is step-size-invariant — consistent with a dynaphopy peak-finder behaviour rather than integrator accuracy.

## Test plan

- [x] Notebook executed end-to-end on RTX 5070 Ti (sm_120), ~30 min wall clock total (10 min ASE + ~14 min LAMMPS + setup)
- [x] All 11 code cells produce outputs; all 3 plots regenerated (Section A dispersion + power spectrum, Section 4 side-by-side dispersion, Section 5 Boltzmann histogram)
- [x] Excluded from CI `build-notebooks` (same reasoning as the 1 fs sibling — custom env needed)
- [ ] CI green on this PR (only Python-style / docs checks active since notebook is in `.ci_support/exclude`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)