### PR TITLE
feat(free_energy): consolidate harmonic / QHA / anharmonic into physics.free_energy

### DIFF
--- a/docs/design/plans/2026-05-15-free-energy-consolidation.md
+++ b/docs/design/plans/2026-05-15-free-energy-consolidation.md
@@ -1,0 +1,2095 @@
+# Free-energy consolidation implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/design/specs/2026-05-15-free-energy-consolidation-design.md`
+
+**Goal:** Add four new pyiron_workflow macros under `physics/free_energy/` — `harmonic_free_energy`, `quasiharmonic_free_energy`, `anharmonic_free_energy_dynaphopy`, `anharmonic_free_energy_dynaphopy_tdi` — so the same package houses all three levels of solid free energy (harmonic / QHA / anharmonic) alongside the existing calphy nodes, plus a teaching notebook overlaying all four methods.
+
+**Architecture:** Import-and-wrap. `physics/phonons/{harmonic,anharmonic,md_renormalised}.py` are untouched; the new `free_energy/{harmonic,quasiharmonic,anharmonic_dynaphopy}.py` modules call into them. The existing `FreeEnergyOutput` dataclass is extended with optional fields per method; `mode` literal grows by four values. Reference engine is `ASEEngine(calculator=EMT())` for the EMT-friendly methods; calphy keeps its `LammpsEngine` requirement.
+
+**Tech Stack:** `pyiron_workflow` (function-nodes + macros), `phonopy` (harmonic + QHA), `dynaphopy` (anharmonic via MD projection), `calphy` (anharmonic via TI — unchanged), `ase` (EMT calculator), `pytest` (with `@pytest.mark.slow` markers, gated on `pytest.importorskip(...)` per package).
+
+**Test layout note:** The spec sketched `tests/unit/physics/free_energy/` (nested). The repo convention is flat: `tests/unit/physics/test_*.py`. This plan follows the repo convention.
+
+---
+
+## File structure
+
+**Create:**
+- `pyiron_workflow_atomistics/physics/free_energy/harmonic.py` — `harmonic_free_energy` macro + private helpers `_produce_fc2_view`, `_pack_harmonic_output`.
+- `pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py` — `quasiharmonic_free_energy` macro + `_fit_qha`, `_check_qha_volume_range`, `_pack_qha_output`.
+- `pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py` — `anharmonic_free_energy_dynaphopy` + `_tdi` macros + `_free_energy_from_spectrum`, `_pack_anharmonic_dynaphopy_output`, `_stack_tdi_outputs`.
+- `tests/unit/physics/test_free_energy_harmonic.py` — unit + Tier-2 EMT smoke.
+- `tests/unit/physics/test_free_energy_qha.py` — unit + Tier-2 EMT smoke.
+- `tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py` — unit + Tier-2 EMT smoke.
+- `notebooks/free_energy_solid.ipynb` — Al/EMT four-method overlay.
+
+**Modify:**
+- `pyiron_workflow_atomistics/physics/free_energy/outputs.py` — extend `FreeEnergyOutput` (new fields + extended `mode` literal + handle-aware `to_dict()`).
+- `pyiron_workflow_atomistics/physics/free_energy/__init__.py` — add four new exports.
+- `tests/unit/physics/test_free_energy.py` — additional pickle/asdict round-trip cases for the new `mode` values.
+
+---
+
+## Task 1 — Extend `FreeEnergyOutput`
+
+**Files:**
+- Modify: `pyiron_workflow_atomistics/physics/free_energy/outputs.py`
+- Test: `tests/unit/physics/test_free_energy.py`
+
+- [ ] **Step 1: Add failing tests for new fields + handle-skipping `to_dict()`**
+
+Append to `tests/unit/physics/test_free_energy.py`:
+
+```python
+def test_free_energy_output_accepts_harmonic_mode():
+    import numpy as np
+    from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+
+    out = FreeEnergyOutput(
+        mode="harmonic",
+        reference_phase="solid",
+        free_energy=-3.0,
+        free_energy_error=0.0,
+        temperature=0.0,
+        pressure=0.0,
+        n_atoms=4,
+        elements=["Al"],
+        simfolder="/tmp",
+        report={},
+        temperature_array=np.array([0.0, 300.0]),
+        free_energy_array=np.array([-3.0, -3.05]),
+        entropy_array=np.array([0.0, 1e-4]),
+        heat_capacity_array=np.array([0.0, 2e-4]),
+        entropy=0.0,
+        heat_capacity=0.0,
+    )
+    assert out.mode == "harmonic"
+    assert out.entropy_array.shape == (2,)
+
+
+def test_free_energy_output_accepts_qha_mode():
+    import numpy as np
+    from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+
+    out = FreeEnergyOutput(
+        mode="qha",
+        reference_phase="solid",
+        free_energy=-3.0,
+        free_energy_error=0.0,
+        temperature=0.0,
+        pressure=0.0,
+        n_atoms=4,
+        elements=["Al"],
+        simfolder="/tmp",
+        report={},
+        volumes=np.array([15.0, 16.0, 17.0]),
+        free_energy_volume_array=np.zeros((2, 3)),
+        equilibrium_volume_array=np.array([16.0, 16.1]),
+        gibbs_free_energy_array=np.array([-3.0, -3.1]),
+        bulk_modulus_array=np.array([70.0, 68.0]),
+        thermal_expansion_array=np.array([0.0, 2e-5]),
+    )
+    assert out.bulk_modulus_array[0] == 70.0
+
+
+def test_free_energy_output_accepts_anharmonic_dynaphopy_modes():
+    import numpy as np
+    from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+
+    out_single = FreeEnergyOutput(
+        mode="anharmonic_dynaphopy",
+        reference_phase="solid",
+        free_energy=-2.9,
+        free_energy_error=0.0,
+        temperature=300.0,
+        pressure=0.0,
+        n_atoms=4,
+        elements=["Al"],
+        simfolder="/tmp",
+        report={},
+        harmonic_frequencies=np.zeros((1, 12)),
+        renormalised_frequencies=np.zeros((1, 12)),
+        linewidths=np.zeros((1, 12)),
+        q_mesh=(7, 7, 7),
+    )
+    assert out_single.q_mesh == (7, 7, 7)
+
+    out_tdi = FreeEnergyOutput(
+        mode="anharmonic_dynaphopy_tdi",
+        reference_phase="solid",
+        free_energy=-2.9,
+        free_energy_error=0.0,
+        temperature=200.0,
+        pressure=0.0,
+        n_atoms=4,
+        elements=["Al"],
+        simfolder="/tmp",
+        report={},
+        temperature_array=np.array([200.0, 400.0]),
+        free_energy_array=np.array([-2.9, -3.0]),
+        renormalised_frequencies_per_T=np.zeros((2, 1, 12)),
+        linewidths_per_T=np.zeros((2, 1, 12)),
+    )
+    assert out_tdi.renormalised_frequencies_per_T.shape == (2, 1, 12)
+
+
+def test_to_dict_excludes_handle_fields():
+    from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+
+    sentinel = object()
+    out = FreeEnergyOutput(
+        mode="harmonic",
+        reference_phase="solid",
+        free_energy=-3.0,
+        free_energy_error=0.0,
+        temperature=0.0,
+        pressure=0.0,
+        n_atoms=4,
+        elements=["Al"],
+        simfolder="/tmp",
+        report={},
+        phonopy_handle=sentinel,
+        qha_handle=sentinel,
+        dynaphopy_handle=sentinel,
+    )
+    d = out.to_dict()
+    assert "phonopy_handle" not in d
+    assert "qha_handle" not in d
+    assert "dynaphopy_handle" not in d
+    assert d["mode"] == "harmonic"
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `pytest tests/unit/physics/test_free_energy.py::test_free_energy_output_accepts_harmonic_mode tests/unit/physics/test_free_energy.py::test_free_energy_output_accepts_qha_mode tests/unit/physics/test_free_energy.py::test_free_energy_output_accepts_anharmonic_dynaphopy_modes tests/unit/physics/test_free_energy.py::test_to_dict_excludes_handle_fields -v`
+
+Expected: all four FAIL. The first three fail because `mode` Literal does not include the new values and the new fields don't exist; the fourth fails because the current `to_dict()` (a plain `asdict`) includes every field.
+
+- [ ] **Step 3: Extend `FreeEnergyOutput`**
+
+Open `pyiron_workflow_atomistics/physics/free_energy/outputs.py`. Replace its current body with:
+
+```python
+"""Structured result of a free-energy calculation.
+
+Same shape across calphy + phonopy harmonic + phonopy QHA + dynaphopy modes;
+per-mode arrays are None when not applicable. Pickleable for plain-data
+fields; phonopy/dynaphopy handle fields (carried in memory when
+``keep_handles=True``) are excluded from ``to_dict()``.
+
+Unit conventions
+----------------
+``free_energy`` / ``free_energy_error`` / ``free_energy_array`` / ``gibbs_free_energy_array``
+/ ``einstein_free_energy``: eV/atom (calphy native).
+``temperature`` / ``temperature_array``: K.
+``pressure`` for calphy modes (fe, ts, tscale, pscale, melting_temperature,
+alchemy, composition_scaling): bar (calphy native).
+``pressure`` for ``qha``: GPa (phonopy.qha native).
+``bulk_modulus_array``: GPa.
+``thermal_expansion_array``: 1/K.
+``volumes`` / ``equilibrium_volume_array``: Å³/atom.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import Any, Literal
+
+import numpy as np
+
+_HANDLE_FIELDS = frozenset(
+    {"phonopy_handle", "qha_handle", "dynaphopy_handle", "band_structure", "phonon_dos"}
+)
+
+
+@dataclass
+class FreeEnergyOutput:
+    """Result of one free-energy calculation across calphy / phonopy / dynaphopy modes."""
+
+    mode: Literal[
+        "fe",
+        "ts",
+        "tscale",
+        "pscale",
+        "melting_temperature",
+        "alchemy",
+        "composition_scaling",
+        "harmonic",
+        "qha",
+        "anharmonic_dynaphopy",
+        "anharmonic_dynaphopy_tdi",
+    ]
+    reference_phase: Literal["solid", "liquid", "both"]
+    free_energy: float
+    free_energy_error: float
+    temperature: float
+    pressure: float
+    n_atoms: int
+    elements: list[str]
+    simfolder: str
+    report: dict[str, Any]
+
+    # existing optional fields
+    temperature_array: np.ndarray | None = None
+    free_energy_array: np.ndarray | None = None
+    pressure_array: np.ndarray | None = None
+    melting_temperature: float | None = None
+    melting_temperature_error: float | None = None
+    composition_path: list[dict[str, int]] | None = None
+    einstein_free_energy: float | None = None
+
+    # NEW — harmonic + dynaphopy (single T)
+    entropy: float | None = None
+    heat_capacity: float | None = None
+
+    # NEW — harmonic + qha + dynaphopy TDI (arrays over temperature_array)
+    entropy_array: np.ndarray | None = None
+    heat_capacity_array: np.ndarray | None = None
+
+    # NEW — qha specific
+    volumes: np.ndarray | None = None
+    free_energy_volume_array: np.ndarray | None = None
+    equilibrium_volume_array: np.ndarray | None = None
+    gibbs_free_energy_array: np.ndarray | None = None
+    bulk_modulus_array: np.ndarray | None = None
+    thermal_expansion_array: np.ndarray | None = None
+
+    # NEW — dynaphopy specific
+    harmonic_frequencies: np.ndarray | None = None
+    renormalised_frequencies: np.ndarray | None = None
+    linewidths: np.ndarray | None = None
+    renormalised_frequencies_per_T: np.ndarray | None = None
+    linewidths_per_T: np.ndarray | None = None
+    q_mesh: tuple[int, int, int] | None = None
+
+    # NEW — handles (always excluded from to_dict)
+    phonopy_handle: Any | None = None
+    qha_handle: Any | None = None
+    dynaphopy_handle: Any | None = None
+    band_structure: dict | None = None
+    phonon_dos: dict | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain dict of every non-handle field."""
+        return {
+            f.name: getattr(self, f.name)
+            for f in fields(self)
+            if f.name not in _HANDLE_FIELDS
+        }
+```
+
+- [ ] **Step 4: Run the four new tests to verify they pass**
+
+Run: `pytest tests/unit/physics/test_free_energy.py::test_free_energy_output_accepts_harmonic_mode tests/unit/physics/test_free_energy.py::test_free_energy_output_accepts_qha_mode tests/unit/physics/test_free_energy.py::test_free_energy_output_accepts_anharmonic_dynaphopy_modes tests/unit/physics/test_free_energy.py::test_to_dict_excludes_handle_fields -v`
+
+Expected: all four PASS.
+
+- [ ] **Step 5: Run the full pre-existing test_free_energy.py to check for regressions**
+
+Run: `pytest tests/unit/physics/test_free_energy.py -v`
+
+Expected: all existing tests still pass. If a pre-existing test relied on handles appearing in `to_dict()` (it shouldn't — `_HANDLE_FIELDS` are all newly introduced), update that test to assert their absence and document the change in the commit message.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyiron_workflow_atomistics/physics/free_energy/outputs.py tests/unit/physics/test_free_energy.py
+git commit -m "feat(free_energy): extend FreeEnergyOutput for harmonic/QHA/dynaphopy modes"
+```
+
+---
+
+## Task 2 — `_free_energy_from_spectrum` (pure helper)
+
+**Files:**
+- Create: `pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py`
+- Test: `tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py`
+
+- [ ] **Step 1: Write the failing test (Einstein-mode closed form)**
+
+Create `tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py`:
+
+```python
+"""Tests for pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+def _einstein_free_energy_per_mode(omega_THz: float, T_K: float) -> float:
+    """Closed-form F per mode for an Einstein oscillator. eV.
+
+    F = ℏω/2 + k_B T ln(1 − exp(−ℏω / k_B T))
+    """
+    import scipy.constants as c
+
+    omega_rad_s = omega_THz * 1e12 * 2 * np.pi
+    hbar_omega_eV = c.hbar * omega_rad_s / c.eV
+    if T_K == 0:
+        return 0.5 * hbar_omega_eV
+    kT_eV = c.Boltzmann * T_K / c.eV
+    x = hbar_omega_eV / kT_eV
+    return 0.5 * hbar_omega_eV + kT_eV * np.log1p(-np.exp(-x))
+
+
+def test_free_energy_from_spectrum_matches_einstein_closed_form():
+    from pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy import (
+        _free_energy_from_spectrum,
+    )
+
+    omega_THz = 5.0
+    frequencies = np.full((1, 3), omega_THz)  # 1 q, 3 bands, all identical
+    q_weights = np.array([1.0])
+    F, S, Cv = _free_energy_from_spectrum.node_function(
+        frequencies=frequencies,
+        q_weights=q_weights,
+        temperature=300.0,
+        n_atoms_primitive=1,
+    )
+
+    expected_per_atom = 3 * _einstein_free_energy_per_mode(omega_THz, 300.0)
+    assert F == pytest.approx(expected_per_atom, rel=1e-8)
+    assert Cv > 0
+
+
+def test_free_energy_from_spectrum_rejects_imaginary_modes():
+    from pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy import (
+        _free_energy_from_spectrum,
+    )
+
+    frequencies = np.array([[5.0, -1.0, 3.0]])  # one imaginary
+    q_weights = np.array([1.0])
+    with pytest.raises(ValueError, match="imaginary modes"):
+        _free_energy_from_spectrum.node_function(
+            frequencies=frequencies,
+            q_weights=q_weights,
+            temperature=300.0,
+            n_atoms_primitive=1,
+        )
+```
+
+- [ ] **Step 2: Run tests to confirm failure**
+
+Run: `pytest tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py::test_free_energy_from_spectrum_matches_einstein_closed_form tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py::test_free_energy_from_spectrum_rejects_imaginary_modes -v`
+
+Expected: FAIL (module does not exist yet).
+
+- [ ] **Step 3: Create `anharmonic_dynaphopy.py` with `_free_energy_from_spectrum`**
+
+```python
+"""Anharmonic free energy via dynaphopy MD-projection — single T and TDI over T."""
+
+from __future__ import annotations
+
+import numpy as np
+import pyiron_workflow as pwf
+
+
+@pwf.as_function_node("free_energy_per_atom", "entropy_per_atom", "cv_per_atom")
+def _free_energy_from_spectrum(
+    frequencies: np.ndarray,         # (n_q, n_band) THz
+    q_weights: np.ndarray,           # (n_q,), sums to 1
+    temperature: float,              # K
+    n_atoms_primitive: int,
+) -> tuple[float, float, float]:
+    """Harmonic free energy / entropy / Cv on a discrete (q, band) frequency grid.
+
+    F = sum_q w_q * sum_b [ ℏω_qb/2 + k_B T ln(1 − exp(−ℏω_qb / k_B T)) ]
+
+    Acoustic modes at Γ are zeroed upstream by dynaphopy's
+    `_project_with_dynaphopy` (positions[:3]=0 at q==0); any ω ≤ 0 remaining
+    is treated as imaginary and rejected.
+
+    Units
+    -----
+    Frequencies in THz. Returned F / S / Cv per primitive-cell atom, in
+    eV / (eV/K) / (eV/K) respectively.
+    """
+    import scipy.constants as c
+
+    freqs = np.asarray(frequencies, dtype=float)
+    weights = np.asarray(q_weights, dtype=float)
+    if not np.isclose(weights.sum(), 1.0):
+        raise ValueError(f"q_weights must sum to 1, got {weights.sum()}")
+    if freqs.ndim != 2 or freqs.shape[0] != weights.shape[0]:
+        raise ValueError(
+            f"frequencies shape {freqs.shape} incompatible with q_weights shape "
+            f"{weights.shape}"
+        )
+
+    # Acoustic-at-Γ modes (already zeroed upstream) are dropped from the sum.
+    is_acoustic_gamma = freqs == 0.0
+    active = freqs[~is_acoustic_gamma]
+    imag_mask = active < 0
+    if imag_mask.any():
+        raise ValueError(
+            f"Spectrum has {int(imag_mask.sum())} imaginary modes; "
+            "harmonic free energy is undefined for an unstable spectrum."
+        )
+
+    omega_rad_s = freqs * 1e12 * 2 * np.pi
+    hbar_omega_eV = c.hbar * omega_rad_s / c.eV  # (n_q, n_band)
+    if temperature <= 0:
+        # T=0: only zero-point energy contributes; S and Cv are zero.
+        F_modes = 0.5 * hbar_omega_eV
+        F_modes = np.where(is_acoustic_gamma, 0.0, F_modes)
+        F = (weights[:, None] * F_modes).sum() / n_atoms_primitive
+        return float(F), 0.0, 0.0
+
+    kT_eV = c.Boltzmann * temperature / c.eV
+    x = hbar_omega_eV / kT_eV
+    # ln(1 − exp(−x)) — stable; modes with x huge → ln(1) = 0.
+    log_term = np.where(is_acoustic_gamma, 0.0, np.log1p(-np.exp(-x)))
+    F_modes = 0.5 * hbar_omega_eV + kT_eV * log_term
+    F_modes = np.where(is_acoustic_gamma, 0.0, F_modes)
+
+    # Entropy per mode:  S = k_B [ x/(exp(x)−1) − ln(1 − exp(−x)) ]
+    kB_eV_per_K = c.Boltzmann / c.eV
+    with np.errstate(over="ignore", invalid="ignore"):
+        S_modes = kB_eV_per_K * (
+            np.where(is_acoustic_gamma, 0.0, x / np.expm1(x)) - log_term
+        )
+
+    # Cv per mode:  C_v = k_B (x^2 exp(x)) / (exp(x)−1)^2
+    with np.errstate(over="ignore", invalid="ignore"):
+        denom = np.expm1(x) ** 2
+        num = (x**2) * np.exp(x)
+        Cv_modes = kB_eV_per_K * np.where(
+            is_acoustic_gamma | (denom == 0), 0.0, num / denom
+        )
+
+    F = (weights[:, None] * F_modes).sum() / n_atoms_primitive
+    S = (weights[:, None] * S_modes).sum() / n_atoms_primitive
+    Cv = (weights[:, None] * Cv_modes).sum() / n_atoms_primitive
+    return float(F), float(S), float(Cv)
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `pytest tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py::test_free_energy_from_spectrum_matches_einstein_closed_form tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py::test_free_energy_from_spectrum_rejects_imaginary_modes -v`
+
+Expected: both PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py
+git commit -m "feat(free_energy): add _free_energy_from_spectrum helper"
+```
+
+---
+
+## Task 3 — `_produce_fc2_view` helper + `harmonic_free_energy` macro
+
+**Files:**
+- Create: `pyiron_workflow_atomistics/physics/free_energy/harmonic.py`
+- Test: `tests/unit/physics/test_free_energy_harmonic.py`
+
+- [ ] **Step 1: Write failing Tier-2 EMT smoke test**
+
+Create `tests/unit/physics/test_free_energy_harmonic.py`:
+
+```python
+"""Tests for pyiron_workflow_atomistics.physics.free_energy.harmonic."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+@pytest.mark.slow
+def test_harmonic_free_energy_emt_al_2x2x2(tmp_path):
+    pytest.importorskip("phonopy", reason="phonopy not installed")
+
+    from ase.build import bulk
+    from ase.calculators.emt import EMT
+
+    from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+    from pyiron_workflow_atomistics.physics.free_energy.harmonic import (
+        harmonic_free_energy,
+    )
+
+    structure = bulk("Al", "fcc", a=4.05, cubic=True)
+    engine = ASEEngine(
+        EngineInput=CalcInputStatic(),
+        calculator=EMT(),
+        working_directory=str(tmp_path),
+    )
+
+    wf = harmonic_free_energy(
+        structure=structure,
+        engine=engine,
+        fc2_supercell_matrix=2 * np.eye(3, dtype=int),
+        temperatures=(0.0, 300.0),
+        working_directory=str(tmp_path),
+        subdir="harmonic",
+    )
+    out = wf.run()
+
+    assert out.mode == "harmonic"
+    assert out.reference_phase == "solid"
+    # ZPE > 0 at T=0
+    assert out.free_energy_array[0] > 0.0
+    # F decreases with T (entropy dominates)
+    assert out.free_energy_array[1] < out.free_energy_array[0]
+    # Entropy at T=0 is zero
+    assert out.entropy_array[0] == pytest.approx(0.0, abs=1e-6)
+```
+
+- [ ] **Step 2: Run the test to confirm failure**
+
+Run: `pytest tests/unit/physics/test_free_energy_harmonic.py::test_harmonic_free_energy_emt_al_2x2x2 -v -m slow`
+
+Expected: FAIL (`harmonic_free_energy` not importable).
+
+- [ ] **Step 3: Implement `harmonic.py`**
+
+Create `pyiron_workflow_atomistics/physics/free_energy/harmonic.py`:
+
+```python
+"""Harmonic free energy via phonopy FC2 — single user-facing entry point.
+
+Built on top of phonopy via thin wrappers around the FC2 helpers in
+`physics.phonons.harmonic`. The κ(T) workflow continues to own those
+helpers; we import them here without behavioural change.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import numpy as np
+import pyiron_workflow as pwf
+from ase import Atoms
+from numpy.typing import ArrayLike
+
+from pyiron_workflow_atomistics.engine import Engine
+from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+from pyiron_workflow_atomistics.physics.phonons._compat import require_phonopy
+from pyiron_workflow_atomistics.physics.phonons.anharmonic import (
+    _check_all_converged,
+    _evaluate_supercells,
+    _stack_forces,
+)
+from pyiron_workflow_atomistics.physics.phonons.harmonic import (
+    _ase_to_phonopy,
+    _compute_harmonic_observables,
+    _generate_fc2_supercells,
+    _normalise_supercell_matrix,
+)
+
+
+@pwf.as_function_node("phonopy_view")
+def _produce_fc2_view(
+    structure: Atoms,
+    fc2_supercell_matrix: ArrayLike,
+    fc2_engine_outputs: list,
+    displacement_distance: float,
+    is_plusminus,
+):
+    """Build a phonopy.Phonopy with FC2 fitted from supercell forces."""
+    require_phonopy()
+    import phonopy
+
+    _check_all_converged(fc2_engine_outputs, label="FC2")
+    sc = _normalise_supercell_matrix(fc2_supercell_matrix)
+
+    unitcell = _ase_to_phonopy(structure)
+    phonon = phonopy.Phonopy(
+        unitcell=unitcell, supercell_matrix=sc, primitive_matrix="auto"
+    )
+    phonon.generate_displacements(
+        distance=displacement_distance, is_plusminus=is_plusminus
+    )
+    forces = _stack_forces(fc2_engine_outputs)
+    if forces.shape[0] != len(phonon.supercells_with_displacements):
+        raise RuntimeError(
+            f"FC2 force/supercell mismatch: {forces.shape[0]} forces vs "
+            f"{len(phonon.supercells_with_displacements)} expected supercells. "
+            "displacement kwargs likely drifted between generation and synthesis."
+        )
+    phonon.forces = forces
+    phonon.produce_force_constants()
+    return phonon
+
+
+@pwf.as_function_node("free_energy_output")
+def _pack_harmonic_output(
+    structure: Atoms,
+    phonopy_view,
+    temperatures: ArrayLike,
+    fc2_supercell_matrix: ArrayLike,
+    displacement_distance: float,
+    simfolder: str,
+    keep_handles: bool,
+) -> FreeEnergyOutput:
+    """Compute thermal properties from the FC2 view and pack into FreeEnergyOutput."""
+    T = np.asarray(temperatures, dtype=float)
+    band_structure, dos, free_energy_dict = _compute_harmonic_observables(
+        ph3=_Phono3pyShim(phonopy_view), temperatures=T
+    )
+    F = np.asarray(free_energy_dict["F"])
+    S = np.asarray(free_energy_dict["S"])
+    Cv = np.asarray(free_energy_dict["Cv"])
+
+    elements = list(dict.fromkeys(structure.get_chemical_symbols()))
+    return FreeEnergyOutput(
+        mode="harmonic",
+        reference_phase="solid",
+        free_energy=float(F[0]),
+        free_energy_error=0.0,
+        temperature=float(T[0]),
+        pressure=0.0,
+        n_atoms=len(structure),
+        elements=elements,
+        simfolder=simfolder,
+        report={
+            "method": "harmonic",
+            "fc2_supercell_matrix": _normalise_supercell_matrix(
+                fc2_supercell_matrix
+            ).tolist(),
+            "displacement_distance": float(displacement_distance),
+        },
+        temperature_array=T,
+        free_energy_array=F,
+        entropy=float(S[0]),
+        heat_capacity=float(Cv[0]),
+        entropy_array=S,
+        heat_capacity_array=Cv,
+        phonopy_handle=phonopy_view if keep_handles else None,
+        band_structure=band_structure if keep_handles else None,
+        phonon_dos=dos if keep_handles else None,
+    )
+
+
+class _Phono3pyShim:
+    """Minimal adapter exposing the four attributes _compute_harmonic_observables reads.
+
+    `_compute_harmonic_observables` was originally written against a Phono3py
+    object; for the harmonic-only path we hand it a Phonopy view with the
+    same four attributes. Keeps the helper signature unchanged.
+    """
+
+    def __init__(self, phonopy_view) -> None:
+        self.phonon_primitive = phonopy_view.primitive
+        self.phonon_supercell_matrix = phonopy_view.supercell_matrix
+        self.fc2 = phonopy_view.force_constants
+
+
+@pwf.api.as_macro_node("free_energy_output")
+def harmonic_free_energy(
+    wf,
+    *,
+    structure: Atoms,
+    engine: Engine,
+    fc2_supercell_matrix,
+    temperatures=(0.0, 100.0, 200.0, 300.0, 400.0, 500.0),
+    displacement_distance: float = 0.03,
+    is_plusminus="auto",
+    working_directory: str = ".",
+    subdir: str = "harmonic_free_energy",
+    keep_handles: bool = False,
+):
+    """Helmholtz free energy F(T), entropy S(T), heat capacity Cv(T) at fixed volume.
+
+    Returns
+    -------
+    FreeEnergyOutput
+        ``mode="harmonic"``, ``reference_phase="solid"``. The scalar
+        ``free_energy`` is the value at the *lowest* T in ``temperatures``
+        (typically T=0, i.e. zero-point energy). Curves are in
+        ``temperature_array`` / ``free_energy_array`` / ``entropy_array`` /
+        ``heat_capacity_array``.
+
+    See spec: docs/design/specs/2026-05-15-free-energy-consolidation-design.md
+    """
+    simfolder = os.path.abspath(os.path.join(working_directory, subdir))
+    os.makedirs(simfolder, exist_ok=True)
+
+    sub_engine = engine.with_working_directory(simfolder)
+
+    wf.fc2_supercells = _generate_fc2_supercells(
+        structure=structure,
+        fc2_supercell_matrix=fc2_supercell_matrix,
+        displacement_distance=displacement_distance,
+        is_plusminus=is_plusminus,
+    )
+    wf.fc2_eval = _evaluate_supercells(
+        supercells=wf.fc2_supercells.outputs.fc2_supercells,
+        engine=sub_engine,
+        prefix="fc2_disp_",
+    )
+    wf.fc2_view = _produce_fc2_view(
+        structure=structure,
+        fc2_supercell_matrix=fc2_supercell_matrix,
+        fc2_engine_outputs=wf.fc2_eval.outputs.engine_outputs,
+        displacement_distance=displacement_distance,
+        is_plusminus=is_plusminus,
+    )
+    wf.synthesis = _pack_harmonic_output(
+        structure=structure,
+        phonopy_view=wf.fc2_view.outputs.phonopy_view,
+        temperatures=temperatures,
+        fc2_supercell_matrix=fc2_supercell_matrix,
+        displacement_distance=displacement_distance,
+        simfolder=simfolder,
+        keep_handles=keep_handles,
+    )
+    return wf.synthesis.outputs.free_energy_output
+```
+
+- [ ] **Step 4: Run the EMT smoke test to verify pass**
+
+Run: `pytest tests/unit/physics/test_free_energy_harmonic.py::test_harmonic_free_energy_emt_al_2x2x2 -v -m slow`
+
+Expected: PASS. Runtime ~60-90 s.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyiron_workflow_atomistics/physics/free_energy/harmonic.py tests/unit/physics/test_free_energy_harmonic.py
+git commit -m "feat(free_energy): add harmonic_free_energy macro"
+```
+
+---
+
+## Task 4 — `_fit_qha` + `_check_qha_volume_range` helpers
+
+**Files:**
+- Create: `pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py`
+- Test: `tests/unit/physics/test_free_energy_qha.py`
+
+- [ ] **Step 1: Write failing unit tests**
+
+Create `tests/unit/physics/test_free_energy_qha.py`:
+
+```python
+"""Tests for pyiron_workflow_atomistics.physics.free_energy.quasiharmonic."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+def _synthetic_qha_inputs(n_T=5, n_V=7):
+    """Build a synthetic well-behaved QHA input grid (Vinet-like E(V), Einstein phonons)."""
+    V0 = 16.0  # Å³/atom
+    B0 = 70.0  # GPa, converted later
+    Bp = 4.0
+    volumes = V0 * np.linspace(0.95, 1.05, n_V)
+    # Murnaghan-like E(V) parametrisation in eV/atom
+    energies = (
+        -3.5
+        + 9 * V0 * B0 / 1602.176 / Bp / (Bp - 1)
+        * (volumes / V0) ** (1 - Bp) * ((volumes / V0) ** Bp - 1)
+    )
+    # Per-volume Einstein-like F(T): F(T,V) = -3 k_B T ln(...) — keep simple.
+    temperatures = np.linspace(0, 400, n_T)
+    F_TV = np.zeros((n_T, n_V))
+    S_TV = np.zeros((n_T, n_V))
+    Cv_TV = np.zeros((n_T, n_V))
+    for j, V in enumerate(volumes):
+        omega_THz = 5.0 * (V0 / V) ** 1.5
+        from pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy import (
+            _free_energy_from_spectrum,
+        )
+
+        for i, T in enumerate(temperatures):
+            F_TV[i, j], S_TV[i, j], Cv_TV[i, j] = (
+                _free_energy_from_spectrum.node_function(
+                    frequencies=np.full((1, 3), omega_THz),
+                    q_weights=np.array([1.0]),
+                    temperature=T,
+                    n_atoms_primitive=1,
+                )
+            )
+    return energies, volumes, temperatures, F_TV, S_TV, Cv_TV
+
+
+def test_fit_qha_produces_finite_arrays():
+    pytest.importorskip("phonopy.qha", reason="phonopy.qha not installed")
+    from pyiron_workflow_atomistics.physics.free_energy.quasiharmonic import _fit_qha
+
+    energies, volumes, T, F_TV, S_TV, Cv_TV = _synthetic_qha_inputs()
+    result = _fit_qha.node_function(
+        energies=energies,
+        volumes=volumes,
+        free_energy_per_T_V=F_TV,
+        entropy_per_T_V=S_TV,
+        cv_per_T_V=Cv_TV,
+        temperatures=T,
+        pressure_GPa=0.0,
+        eos_type="vinet",
+    )
+    for key in (
+        "equilibrium_volume_array",
+        "gibbs_free_energy_array",
+        "bulk_modulus_array",
+        "thermal_expansion_array",
+    ):
+        arr = result[key]
+        assert arr.shape == T.shape, f"{key} shape {arr.shape} != {T.shape}"
+        assert np.all(np.isfinite(arr[1:])), f"{key} has NaNs at finite T"
+
+
+def test_check_qha_volume_range_raises_on_nan_volume():
+    from pyiron_workflow_atomistics.physics.free_energy.quasiharmonic import (
+        _check_qha_volume_range,
+    )
+
+    V_T = np.array([16.0, 16.1, np.nan, np.nan])
+    T = np.array([0.0, 100.0, 200.0, 300.0])
+    volumes = np.array([15.5, 16.0, 16.5])
+    with pytest.raises(RuntimeError, match="QHA equilibrium volume undefined"):
+        _check_qha_volume_range(V_T, T, strain_range=(-0.03, 0.03), volumes=volumes)
+
+
+@pytest.mark.slow
+def test_quasiharmonic_free_energy_emt_al(tmp_path):
+    pytest.importorskip("phonopy.qha", reason="phonopy.qha not installed")
+
+    from ase.build import bulk
+    from ase.calculators.emt import EMT
+
+    from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+    from pyiron_workflow_atomistics.physics.free_energy.quasiharmonic import (
+        quasiharmonic_free_energy,
+    )
+
+    structure = bulk("Al", "fcc", a=4.05, cubic=True)
+    engine = ASEEngine(
+        EngineInput=CalcInputStatic(),
+        calculator=EMT(),
+        working_directory=str(tmp_path),
+    )
+
+    wf = quasiharmonic_free_energy(
+        structure=structure,
+        engine=engine,
+        fc2_supercell_matrix=2 * np.eye(3, dtype=int),
+        temperatures=(0.0, 300.0),
+        strain_range=(-0.03, 0.03),
+        num_volumes=5,
+        working_directory=str(tmp_path),
+        subdir="qha",
+    )
+    out = wf.run()
+
+    assert out.mode == "qha"
+    # Thermal expansion is positive on warming for Al/EMT
+    assert out.equilibrium_volume_array[1] > out.equilibrium_volume_array[0]
+    # Thermal expansion coefficient is finite and positive at 300 K
+    assert np.isfinite(out.thermal_expansion_array[1])
+    assert out.thermal_expansion_array[1] > 0
+```
+
+- [ ] **Step 2: Run the two unit tests; confirm both fail**
+
+Run: `pytest tests/unit/physics/test_free_energy_qha.py::test_fit_qha_produces_finite_arrays tests/unit/physics/test_free_energy_qha.py::test_check_qha_volume_range_raises_on_nan_volume -v`
+
+Expected: FAIL (module does not exist).
+
+- [ ] **Step 3: Implement `quasiharmonic.py` skeleton (helpers only, macro after)**
+
+Create `pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py`:
+
+```python
+"""Quasiharmonic free energy via phonopy.qha — single user-facing entry point.
+
+QHA recipe: EOS volume sweep + per-volume harmonic free energy → phonopy.qha.QHA
+gives G(T,P), V*(T,P), B(T,P), α(T,P). Reuses `harmonic_free_energy` per volume.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import numpy as np
+import pyiron_workflow as pwf
+from ase import Atoms
+
+from pyiron_workflow_atomistics.engine import Engine, calculate
+from pyiron_workflow_atomistics.physics.bulk import generate_structures
+from pyiron_workflow_atomistics.physics.free_energy.harmonic import (
+    harmonic_free_energy,
+)
+from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+from pyiron_workflow_atomistics.physics.phonons._compat import require_phonopy
+
+
+def _check_qha_volume_range(
+    V_T: np.ndarray,
+    temperatures: np.ndarray,
+    strain_range: tuple[float, float],
+    volumes: np.ndarray,
+) -> None:
+    """Raise if `phonopy.qha` returned NaN V*(T) anywhere — indicates V grid too narrow."""
+    nan_mask = ~np.isfinite(V_T)
+    if nan_mask.any():
+        bad_T = np.asarray(temperatures)[nan_mask].tolist()
+        raise RuntimeError(
+            f"QHA equilibrium volume undefined at T={bad_T} K — widen "
+            f"`strain_range` or extend it to include positive strain "
+            f"(current range: {strain_range}, current V grid: {volumes.tolist()} Å³/atom)."
+        )
+
+
+@pwf.as_function_node("qha_results")
+def _fit_qha(
+    energies,
+    volumes,
+    free_energy_per_T_V,
+    entropy_per_T_V,
+    cv_per_T_V,
+    temperatures,
+    pressure_GPa: float,
+    eos_type: str,
+) -> dict:
+    """Fit phonopy.qha.QHA on the (V, T) grid and return derived thermodynamics."""
+    require_phonopy()
+    from phonopy.qha import QHA
+
+    E = np.asarray(energies, dtype=float)
+    V = np.asarray(volumes, dtype=float)
+    T = np.asarray(temperatures, dtype=float)
+    F_TV = np.asarray(free_energy_per_T_V, dtype=float)
+    S_TV = np.asarray(entropy_per_T_V, dtype=float)
+    Cv_TV = np.asarray(cv_per_T_V, dtype=float)
+
+    qha = QHA(
+        volumes=V,
+        electronic_energies=E,
+        temperatures=T,
+        free_energy=F_TV,
+        cv=Cv_TV,
+        entropy=S_TV,
+        eos=eos_type,
+        pressure=pressure_GPa,
+    )
+    qha.run()
+    V_T = np.asarray(qha.get_volume_temperature())
+    _check_qha_volume_range(V_T, T, strain_range=(V.min(), V.max()), volumes=V)
+
+    return {
+        "equilibrium_volume_array": V_T,
+        "gibbs_free_energy_array": np.asarray(qha.get_gibbs_temperature()),
+        "bulk_modulus_array": np.asarray(qha.get_bulk_modulus_temperature()),
+        "thermal_expansion_array": np.asarray(qha.get_thermal_expansion()),
+        "qha_handle": qha,
+    }
+```
+
+- [ ] **Step 4: Run the two unit tests; verify they pass**
+
+Run: `pytest tests/unit/physics/test_free_energy_qha.py::test_fit_qha_produces_finite_arrays tests/unit/physics/test_free_energy_qha.py::test_check_qha_volume_range_raises_on_nan_volume -v`
+
+Expected: both PASS.
+
+- [ ] **Step 5: Commit the helpers**
+
+```bash
+git add pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py tests/unit/physics/test_free_energy_qha.py
+git commit -m "feat(free_energy): add _fit_qha + _check_qha_volume_range helpers"
+```
+
+---
+
+## Task 5 — `quasiharmonic_free_energy` macro
+
+**Files:**
+- Modify: `pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py`
+
+- [ ] **Step 1: The Tier-2 EMT test from Task 4 currently FAILS — confirm**
+
+Run: `pytest tests/unit/physics/test_free_energy_qha.py::test_quasiharmonic_free_energy_emt_al -v -m slow`
+
+Expected: FAIL (`quasiharmonic_free_energy` not yet defined).
+
+- [ ] **Step 2: Add per-volume helpers + the macro**
+
+Append to `pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py`:
+
+```python
+@pwf.as_function_node("energies_per_volume", "volumes")
+def _static_energies_per_volume(strained_structures: list[Atoms], engine: Engine):
+    """One-shot static energy per strained cell. Returns (energies, volumes)."""
+    energies, volumes = [], []
+    for i, s in enumerate(strained_structures):
+        sub_engine = engine.with_working_directory(f"vol_E_{i:03d}")
+        out = calculate.node_function(structure=s, engine=sub_engine)
+        if not out.converged:
+            raise RuntimeError(
+                f"Static-energy calc failed for strained cell {i} "
+                f"(volume {s.get_volume():.3f} Å³)."
+            )
+        energies.append(float(out.final_energy))
+        volumes.append(float(s.get_volume()) / len(s))
+    return np.asarray(energies), np.asarray(volumes)
+
+
+@pwf.as_function_node(
+    "free_energy_per_T_V", "entropy_per_T_V", "cv_per_T_V"
+)
+def _harmonic_grid_over_volumes(
+    strained_structures: list[Atoms],
+    engine: Engine,
+    fc2_supercell_matrix,
+    temperatures,
+    displacement_distance: float,
+    is_plusminus,
+    working_directory: str,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Run harmonic_free_energy at each strained cell, stack F/S/Cv along V axis."""
+    n_T = len(np.asarray(temperatures))
+    n_V = len(strained_structures)
+    F_TV = np.zeros((n_T, n_V))
+    S_TV = np.zeros((n_T, n_V))
+    Cv_TV = np.zeros((n_T, n_V))
+    for j, s in enumerate(strained_structures):
+        sub_engine = engine.with_working_directory(
+            os.path.join(working_directory, f"vol_{j:03d}")
+        )
+        sub_wf = harmonic_free_energy(
+            structure=s,
+            engine=sub_engine,
+            fc2_supercell_matrix=fc2_supercell_matrix,
+            temperatures=temperatures,
+            displacement_distance=displacement_distance,
+            is_plusminus=is_plusminus,
+            working_directory=os.path.join(working_directory, f"vol_{j:03d}"),
+            subdir="harmonic",
+        )
+        out = sub_wf.run()
+        F_TV[:, j] = out.free_energy_array
+        S_TV[:, j] = out.entropy_array
+        Cv_TV[:, j] = out.heat_capacity_array
+    return F_TV, S_TV, Cv_TV
+
+
+@pwf.as_function_node("free_energy_output")
+def _pack_qha_output(
+    structure: Atoms,
+    qha_results: dict,
+    energies: np.ndarray,
+    volumes: np.ndarray,
+    free_energy_per_T_V: np.ndarray,
+    entropy_per_T_V: np.ndarray,
+    cv_per_T_V: np.ndarray,
+    temperatures: np.ndarray,
+    pressure_GPa: float,
+    simfolder: str,
+    keep_handles: bool,
+) -> FreeEnergyOutput:
+    T = np.asarray(temperatures, dtype=float)
+    elements = list(dict.fromkeys(structure.get_chemical_symbols()))
+    return FreeEnergyOutput(
+        mode="qha",
+        reference_phase="solid",
+        free_energy=float(qha_results["gibbs_free_energy_array"][0]),
+        free_energy_error=0.0,
+        temperature=float(T[0]),
+        pressure=float(pressure_GPa),
+        n_atoms=len(structure),
+        elements=elements,
+        simfolder=simfolder,
+        report={
+            "method": "qha",
+            "n_volumes": int(volumes.size),
+            "pressure_GPa": float(pressure_GPa),
+        },
+        temperature_array=T,
+        free_energy_array=qha_results["gibbs_free_energy_array"],
+        entropy_array=entropy_per_T_V[:, entropy_per_T_V.shape[1] // 2],
+        heat_capacity_array=cv_per_T_V[:, cv_per_T_V.shape[1] // 2],
+        volumes=volumes,
+        free_energy_volume_array=free_energy_per_T_V,
+        equilibrium_volume_array=qha_results["equilibrium_volume_array"],
+        gibbs_free_energy_array=qha_results["gibbs_free_energy_array"],
+        bulk_modulus_array=qha_results["bulk_modulus_array"],
+        thermal_expansion_array=qha_results["thermal_expansion_array"],
+        qha_handle=qha_results["qha_handle"] if keep_handles else None,
+    )
+
+
+@pwf.api.as_macro_node("free_energy_output")
+def quasiharmonic_free_energy(
+    wf,
+    *,
+    structure: Atoms,
+    engine: Engine,
+    fc2_supercell_matrix,
+    temperatures=(0.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0),
+    pressure: float = 0.0,
+    strain_range: tuple[float, float] = (-0.03, 0.03),
+    num_volumes: int = 7,
+    displacement_distance: float = 0.03,
+    is_plusminus="auto",
+    eos_type: str = "vinet",
+    working_directory: str = ".",
+    subdir: str = "quasiharmonic_free_energy",
+    keep_handles: bool = False,
+):
+    """Gibbs free energy G(T,P), V*(T,P), B(T,P), α(T,P) via phonopy.qha.QHA.
+
+    Pressure is in **GPa** (phonopy.qha native). At ``pressure=0.0`` the
+    output is Helmholtz. See spec
+    ``docs/design/specs/2026-05-15-free-energy-consolidation-design.md``.
+    """
+    simfolder = os.path.abspath(os.path.join(working_directory, subdir))
+    os.makedirs(simfolder, exist_ok=True)
+
+    wf.strained_structures = generate_structures(
+        base_structure=structure,
+        axes=["iso"],
+        strain_range=strain_range,
+        num_points=num_volumes,
+    )
+    wf.static_E = _static_energies_per_volume(
+        strained_structures=wf.strained_structures.outputs.structure_list,
+        engine=engine.with_working_directory(simfolder),
+    )
+    wf.harmonic_grid = _harmonic_grid_over_volumes(
+        strained_structures=wf.strained_structures.outputs.structure_list,
+        engine=engine,
+        fc2_supercell_matrix=fc2_supercell_matrix,
+        temperatures=temperatures,
+        displacement_distance=displacement_distance,
+        is_plusminus=is_plusminus,
+        working_directory=simfolder,
+    )
+    wf.qha = _fit_qha(
+        energies=wf.static_E.outputs.energies_per_volume,
+        volumes=wf.static_E.outputs.volumes,
+        free_energy_per_T_V=wf.harmonic_grid.outputs.free_energy_per_T_V,
+        entropy_per_T_V=wf.harmonic_grid.outputs.entropy_per_T_V,
+        cv_per_T_V=wf.harmonic_grid.outputs.cv_per_T_V,
+        temperatures=temperatures,
+        pressure_GPa=pressure,
+        eos_type=eos_type,
+    )
+    wf.synthesis = _pack_qha_output(
+        structure=structure,
+        qha_results=wf.qha.outputs.qha_results,
+        energies=wf.static_E.outputs.energies_per_volume,
+        volumes=wf.static_E.outputs.volumes,
+        free_energy_per_T_V=wf.harmonic_grid.outputs.free_energy_per_T_V,
+        entropy_per_T_V=wf.harmonic_grid.outputs.entropy_per_T_V,
+        cv_per_T_V=wf.harmonic_grid.outputs.cv_per_T_V,
+        temperatures=temperatures,
+        pressure_GPa=pressure,
+        simfolder=simfolder,
+        keep_handles=keep_handles,
+    )
+    return wf.synthesis.outputs.free_energy_output
+```
+
+- [ ] **Step 3: Run the EMT smoke test to verify pass**
+
+Run: `pytest tests/unit/physics/test_free_energy_qha.py::test_quasiharmonic_free_energy_emt_al -v -m slow`
+
+Expected: PASS. Runtime ~3-5 min (5 volumes × FC2 supercell pipeline).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py
+git commit -m "feat(free_energy): add quasiharmonic_free_energy macro"
+```
+
+---
+
+## Task 6 — `anharmonic_free_energy_dynaphopy` macro (single T)
+
+**Files:**
+- Modify: `pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py`
+- Modify: `tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py`
+
+- [ ] **Step 1: Add the failing Tier-2 EMT smoke test**
+
+Append to `tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py`:
+
+```python
+@pytest.mark.slow
+def test_anharmonic_free_energy_dynaphopy_emt_al(tmp_path):
+    pytest.importorskip("dynaphopy", reason="dynaphopy not installed")
+    pytest.importorskip("phonopy", reason="phonopy not installed")
+
+    from ase.build import bulk
+    from ase.calculators.emt import EMT
+
+    from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+    from pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy import (
+        anharmonic_free_energy_dynaphopy,
+    )
+    from pyiron_workflow_atomistics.physics.free_energy.harmonic import (
+        harmonic_free_energy,
+    )
+
+    structure = bulk("Al", "fcc", a=4.05, cubic=True)
+    engine = ASEEngine(
+        EngineInput=CalcInputStatic(),
+        calculator=EMT(),
+        working_directory=str(tmp_path),
+    )
+
+    out_h = harmonic_free_energy(
+        structure=structure,
+        engine=engine,
+        fc2_supercell_matrix=2 * np.eye(3, dtype=int),
+        temperatures=(300.0,),
+        working_directory=str(tmp_path),
+        subdir="harmonic_ref",
+    ).run()
+
+    out_a = anharmonic_free_energy_dynaphopy(
+        structure=structure,
+        engine=engine,
+        fc2_supercell_matrix=2 * np.eye(3, dtype=int),
+        temperature=300.0,
+        production_steps=2000,
+        q_mesh=(5, 5, 5),
+        working_directory=str(tmp_path),
+        subdir="anharmonic_T300",
+    ).run()
+
+    assert out_a.mode == "anharmonic_dynaphopy"
+    assert out_a.temperature == 300.0
+    # Anharmonic and harmonic Al/EMT at 300 K should be within 50 meV/atom
+    assert abs(out_a.free_energy - out_h.free_energy) < 0.05
+    assert out_a.harmonic_frequencies.shape == out_a.renormalised_frequencies.shape
+```
+
+- [ ] **Step 2: Run the test; confirm failure**
+
+Run: `pytest tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py::test_anharmonic_free_energy_dynaphopy_emt_al -v -m slow`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Append the macro to `anharmonic_dynaphopy.py`**
+
+Append to `pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py`:
+
+```python
+import os
+
+from ase import Atoms
+
+from pyiron_workflow_atomistics.engine import Engine
+from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+from pyiron_workflow_atomistics.physics.phonons._compat import require_phonopy
+from pyiron_workflow_atomistics.physics.phonons.harmonic import (
+    _normalise_supercell_matrix,
+)
+from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
+    calculate_phonon_md_renormalisation,
+)
+
+
+def _commensurate_q_points(structure: Atoms, q_mesh) -> tuple[np.ndarray, np.ndarray]:
+    """Return (q_points, weights) on a commensurate Monkhorst-Pack mesh.
+
+    Phonopy's `GridPoints` lays out the mesh on the *primitive* cell that
+    phonopy infers via primitive_matrix="auto". We mirror that convention
+    here so the mesh is consistent with the FC2 view dynaphopy projects into.
+    Weights sum to 1.
+    """
+    require_phonopy()
+    import phonopy
+    from phonopy.structure.atoms import PhonopyAtoms
+
+    unitcell = PhonopyAtoms(
+        symbols=list(structure.get_chemical_symbols()),
+        positions=structure.get_positions(),
+        cell=np.asarray(structure.get_cell()),
+        masses=structure.get_masses(),
+    )
+    phonon = phonopy.Phonopy(
+        unitcell=unitcell,
+        supercell_matrix=np.eye(3, dtype=int),
+        primitive_matrix="auto",
+    )
+    phonon.run_mesh(mesh=list(q_mesh), is_mesh_symmetry=True)
+    md = phonon.get_mesh_dict()
+    q_points = np.asarray(md["qpoints"])
+    weights = np.asarray(md["weights"], dtype=float)
+    weights = weights / weights.sum()
+    return q_points, weights
+
+
+@pwf.as_function_node("free_energy_output")
+def _pack_anharmonic_dynaphopy_output(
+    structure: Atoms,
+    md_phonon_output,
+    q_weights: np.ndarray,
+    free_energy_per_atom: float,
+    entropy_per_atom: float,
+    cv_per_atom: float,
+    temperature: float,
+    q_mesh: tuple[int, int, int],
+    simfolder: str,
+    keep_handles: bool,
+) -> FreeEnergyOutput:
+    healthy, issues = md_phonon_output.check_md_health()
+    elements = list(dict.fromkeys(structure.get_chemical_symbols()))
+    return FreeEnergyOutput(
+        mode="anharmonic_dynaphopy",
+        reference_phase="solid",
+        free_energy=float(free_energy_per_atom),
+        free_energy_error=0.0,
+        temperature=float(temperature),
+        pressure=0.0,
+        n_atoms=len(structure),
+        elements=elements,
+        simfolder=simfolder,
+        report={
+            "method": "anharmonic_dynaphopy",
+            "n_md_steps": int(md_phonon_output.n_md_steps),
+            "time_step_fs": float(md_phonon_output.time_step_fs),
+            "md_temperature_mean": float(md_phonon_output.md_temperature_mean),
+            "md_temperature_std": float(md_phonon_output.md_temperature_std),
+            "md_health": {"healthy": bool(healthy), "issues": list(issues)},
+        },
+        entropy=float(entropy_per_atom),
+        heat_capacity=float(cv_per_atom),
+        harmonic_frequencies=np.asarray(md_phonon_output.harmonic_frequencies),
+        renormalised_frequencies=np.asarray(
+            md_phonon_output.renormalised_frequencies
+        ),
+        linewidths=np.asarray(md_phonon_output.linewidths),
+        q_mesh=tuple(int(x) for x in q_mesh),
+        dynaphopy_handle=(
+            md_phonon_output.quasiparticle if keep_handles else None
+        ),
+        phonopy_handle=md_phonon_output.phonopy if keep_handles else None,
+    )
+
+
+@pwf.api.as_macro_node("free_energy_output")
+def anharmonic_free_energy_dynaphopy(
+    wf,
+    *,
+    structure: Atoms,
+    engine: Engine,
+    fc2_supercell_matrix,
+    temperature: float,
+    equilibration_steps: int = 2000,
+    production_steps: int = 10000,
+    time_step: float = 1.0,
+    thermostat_time_constant: float = 100.0,
+    seed: int | None = None,
+    q_mesh=(11, 11, 11),
+    phono3py_output=None,
+    working_directory: str = ".",
+    subdir: str = "anharmonic_free_energy_dynaphopy",
+    keep_handles: bool = False,
+):
+    """Anharmonic free energy at one T via dynaphopy MD projection + harmonic-formula sum.
+
+    Engine must expose ``.calculator`` (inherited from
+    ``calculate_phonon_md_renormalisation``).
+    """
+    simfolder = os.path.abspath(os.path.join(working_directory, subdir))
+    os.makedirs(simfolder, exist_ok=True)
+    sub_engine = engine.with_working_directory(simfolder)
+
+    q_points, q_weights = _commensurate_q_points(structure, q_mesh)
+
+    wf.md_renorm = calculate_phonon_md_renormalisation(
+        structure=structure,
+        engine=sub_engine,
+        fc2_supercell_matrix=fc2_supercell_matrix,
+        temperature=temperature,
+        equilibration_steps=equilibration_steps,
+        production_steps=production_steps,
+        time_step=time_step,
+        thermostat_time_constant=thermostat_time_constant,
+        seed=seed,
+        q_points=q_points,
+        phono3py_output=phono3py_output,
+        power_spectra=False,
+        keep_handles=True,  # we need .phonopy / .quasiparticle handles to extract data
+    )
+    wf.spectrum = _free_energy_from_spectrum(
+        frequencies=wf.md_renorm.outputs.md_phonon_output.renormalised_frequencies,
+        q_weights=q_weights,
+        temperature=temperature,
+        n_atoms_primitive=len(structure),  # primitive equals unitcell for fcc cubic; OK for v1
+    )
+    wf.synthesis = _pack_anharmonic_dynaphopy_output(
+        structure=structure,
+        md_phonon_output=wf.md_renorm.outputs.md_phonon_output,
+        q_weights=q_weights,
+        free_energy_per_atom=wf.spectrum.outputs.free_energy_per_atom,
+        entropy_per_atom=wf.spectrum.outputs.entropy_per_atom,
+        cv_per_atom=wf.spectrum.outputs.cv_per_atom,
+        temperature=temperature,
+        q_mesh=q_mesh,
+        simfolder=simfolder,
+        keep_handles=keep_handles,
+    )
+    return wf.synthesis.outputs.free_energy_output
+```
+
+Note: the `n_atoms_primitive=len(structure)` value is correct only when `structure` already *is* the primitive cell. For non-primitive inputs, phonopy would infer a smaller primitive automatically — but using `len(structure)` here keeps the units consistent because `_compute_harmonic_observables` upstream produces F per *unitcell* atom, not per *primitive* atom. The dynaphopy `renormalised_frequencies` shape `(n_q, 3*n_atoms_unitcell)` is per-unitcell-atom; dividing by `len(structure)` gives per-atom-of-input-cell. Documented in the function docstring.
+
+- [ ] **Step 4: Run the EMT smoke; verify pass**
+
+Run: `pytest tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py::test_anharmonic_free_energy_dynaphopy_emt_al -v -m slow`
+
+Expected: PASS. Runtime ~3-5 min (FC2 + MD + projection).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py
+git commit -m "feat(free_energy): add anharmonic_free_energy_dynaphopy macro"
+```
+
+---
+
+## Task 7 — `anharmonic_free_energy_dynaphopy_tdi` macro (T grid)
+
+**Files:**
+- Modify: `pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py`
+- Modify: `tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py`
+
+- [ ] **Step 1: Add failing unit test for `_stack_tdi_outputs` + Tier-2 EMT smoke**
+
+Append to `tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py`:
+
+```python
+def test_stack_tdi_outputs_central_differences():
+    from pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy import (
+        _stack_tdi_outputs,
+    )
+    from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+
+    # Synthetic F(T) = a + b T + c T^2  → S = -∂F/∂T = -(b + 2cT)
+    a, b, c = -3.0, -1e-4, -1e-7
+    Ts = np.array([100.0, 200.0, 300.0, 400.0, 500.0])
+    Fs = a + b * Ts + c * Ts**2
+    per_T = [
+        FreeEnergyOutput(
+            mode="anharmonic_dynaphopy",
+            reference_phase="solid",
+            free_energy=float(F),
+            free_energy_error=0.0,
+            temperature=float(T),
+            pressure=0.0,
+            n_atoms=4,
+            elements=["Al"],
+            simfolder="/tmp",
+            report={},
+            harmonic_frequencies=np.zeros((1, 12)),
+            renormalised_frequencies=np.zeros((1, 12)),
+            linewidths=np.zeros((1, 12)),
+            q_mesh=(7, 7, 7),
+        )
+        for T, F in zip(Ts, Fs)
+    ]
+    structure = type("FakeAtoms", (), {"__len__": lambda self: 4})()
+    out = _stack_tdi_outputs.node_function(
+        per_T_outputs=per_T,
+        structure=structure,
+        temperatures=Ts,
+    )
+    # interior central-difference S at T=300:  -(b + 2 c * 300)
+    expected_S_300 = -(b + 2 * c * 300.0)
+    assert out.entropy_array[2] == pytest.approx(expected_S_300, rel=5e-2)
+    assert out.renormalised_frequencies_per_T.shape == (5, 1, 12)
+
+
+@pytest.mark.slow
+def test_anharmonic_free_energy_dynaphopy_tdi_emt_al(tmp_path):
+    pytest.importorskip("dynaphopy", reason="dynaphopy not installed")
+
+    from ase.build import bulk
+    from ase.calculators.emt import EMT
+
+    from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+    from pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy import (
+        anharmonic_free_energy_dynaphopy_tdi,
+    )
+
+    structure = bulk("Al", "fcc", a=4.05, cubic=True)
+    engine = ASEEngine(
+        EngineInput=CalcInputStatic(),
+        calculator=EMT(),
+        working_directory=str(tmp_path),
+    )
+
+    out = anharmonic_free_energy_dynaphopy_tdi(
+        structure=structure,
+        engine=engine,
+        fc2_supercell_matrix=2 * np.eye(3, dtype=int),
+        temperatures=(200.0, 400.0),
+        production_steps=2000,
+        q_mesh=(5, 5, 5),
+        working_directory=str(tmp_path),
+        subdir="anharmonic_tdi",
+    ).run()
+
+    assert out.mode == "anharmonic_dynaphopy_tdi"
+    assert out.temperature_array.shape == (2,)
+    assert out.free_energy_array.shape == (2,)
+    assert out.renormalised_frequencies_per_T.shape == (2, *out.renormalised_frequencies_per_T.shape[1:])
+```
+
+- [ ] **Step 2: Run both new tests; confirm failure**
+
+Run: `pytest tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py::test_stack_tdi_outputs_central_differences tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py::test_anharmonic_free_energy_dynaphopy_tdi_emt_al -v`
+
+Expected: both FAIL.
+
+- [ ] **Step 3: Append `_stack_tdi_outputs` and the TDI macro**
+
+Append to `pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py`:
+
+```python
+@pwf.as_function_node("free_energy_output")
+def _stack_tdi_outputs(
+    per_T_outputs: list,
+    structure,
+    temperatures,
+) -> FreeEnergyOutput:
+    """Aggregate independent-T dynaphopy free energies into one FreeEnergyOutput."""
+    T = np.asarray(temperatures, dtype=float)
+    F = np.asarray([o.free_energy for o in per_T_outputs], dtype=float)
+    n_T = T.size
+
+    if n_T >= 2:
+        dF_dT = np.gradient(F, T)
+        S = -dF_dT
+    else:
+        S = np.full(n_T, np.nan)
+    if n_T >= 3:
+        d2F_dT2 = np.gradient(dF_dT, T)
+        Cv = -T * d2F_dT2
+    else:
+        Cv = np.full(n_T, np.nan)
+
+    elements = list(dict.fromkeys(structure.get_chemical_symbols())) if hasattr(
+        structure, "get_chemical_symbols"
+    ) else ["?"]
+    renorm = np.stack(
+        [np.asarray(o.renormalised_frequencies) for o in per_T_outputs], axis=0
+    )
+    lw = np.stack([np.asarray(o.linewidths) for o in per_T_outputs], axis=0)
+
+    derivative_warning = n_T < 3
+    return FreeEnergyOutput(
+        mode="anharmonic_dynaphopy_tdi",
+        reference_phase="solid",
+        free_energy=float(F[0]),
+        free_energy_error=0.0,
+        temperature=float(T[0]),
+        pressure=0.0,
+        n_atoms=len(structure),
+        elements=elements,
+        simfolder=per_T_outputs[0].simfolder if per_T_outputs else "",
+        report={
+            "method": "anharmonic_dynaphopy_tdi",
+            "derivative_warning": bool(derivative_warning),
+            "per_T_md_health": [o.report.get("md_health") for o in per_T_outputs],
+        },
+        temperature_array=T,
+        free_energy_array=F,
+        entropy_array=S,
+        heat_capacity_array=Cv,
+        renormalised_frequencies_per_T=renorm,
+        linewidths_per_T=lw,
+    )
+
+
+@pwf.api.as_macro_node("free_energy_output")
+def anharmonic_free_energy_dynaphopy_tdi(
+    wf,
+    *,
+    structure: Atoms,
+    engine: Engine,
+    fc2_supercell_matrix,
+    temperatures=(100.0, 200.0, 300.0, 400.0, 500.0),
+    equilibration_steps: int = 2000,
+    production_steps: int = 10000,
+    time_step: float = 1.0,
+    thermostat_time_constant: float = 100.0,
+    seed: int | None = None,
+    q_mesh=(11, 11, 11),
+    working_directory: str = ".",
+    subdir: str = "anharmonic_free_energy_dynaphopy_tdi",
+    keep_handles: bool = False,
+):
+    """Anharmonic F_anharm(T) on a T grid — renormalised-harmonic at each T.
+
+    See spec ``docs/design/specs/2026-05-15-free-energy-consolidation-design.md``
+    (renormalised-harmonic-over-T, not full ⟨∂H/∂λ⟩ TI).
+    """
+    simfolder = os.path.abspath(os.path.join(working_directory, subdir))
+    os.makedirs(simfolder, exist_ok=True)
+
+    per_T_outputs: list = []
+    for i, T in enumerate(temperatures):
+        sub_wf = anharmonic_free_energy_dynaphopy(
+            structure=structure,
+            engine=engine,
+            fc2_supercell_matrix=fc2_supercell_matrix,
+            temperature=float(T),
+            equilibration_steps=equilibration_steps,
+            production_steps=production_steps,
+            time_step=time_step,
+            thermostat_time_constant=thermostat_time_constant,
+            seed=(None if seed is None else seed + i),
+            q_mesh=q_mesh,
+            working_directory=simfolder,
+            subdir=f"T_{i:03d}_{T:.1f}K",
+            keep_handles=False,
+        )
+        per_T_outputs.append(sub_wf.run())
+
+    setattr(wf, "stack", _stack_tdi_outputs(
+        per_T_outputs=per_T_outputs,
+        structure=structure,
+        temperatures=temperatures,
+    ))
+    return wf.stack.outputs.free_energy_output
+```
+
+- [ ] **Step 4: Run both tests; verify pass**
+
+Run: `pytest tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py::test_stack_tdi_outputs_central_differences tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py::test_anharmonic_free_energy_dynaphopy_tdi_emt_al -v`
+
+Expected: both PASS. The slow test runs ~6-10 min (2 × single-T cost).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py
+git commit -m "feat(free_energy): add anharmonic_free_energy_dynaphopy_tdi macro"
+```
+
+---
+
+## Task 8 — Public exports
+
+**Files:**
+- Modify: `pyiron_workflow_atomistics/physics/free_energy/__init__.py`
+- Test: `tests/unit/physics/test_free_energy.py`
+
+- [ ] **Step 1: Write failing import-surface test**
+
+Append to `tests/unit/physics/test_free_energy.py`:
+
+```python
+def test_public_free_energy_exports():
+    import pyiron_workflow_atomistics.physics.free_energy as fe
+
+    expected = {
+        "FreeEnergyOutput",
+        "LammpsPotential",
+        "alchemy",
+        "composition_scaling",
+        "free_energy",
+        "melting_temperature",
+        "reversible_scaling_pressure",
+        "reversible_scaling_temperature",
+        "harmonic_free_energy",
+        "quasiharmonic_free_energy",
+        "anharmonic_free_energy_dynaphopy",
+        "anharmonic_free_energy_dynaphopy_tdi",
+    }
+    assert expected.issubset(set(fe.__all__))
+    for name in expected:
+        assert hasattr(fe, name), f"missing public export: {name}"
+```
+
+- [ ] **Step 2: Run; confirm failure**
+
+Run: `pytest tests/unit/physics/test_free_energy.py::test_public_free_energy_exports -v`
+
+Expected: FAIL.
+
+- [ ] **Step 3: Update `__init__.py`**
+
+Replace `pyiron_workflow_atomistics/physics/free_energy/__init__.py` with:
+
+```python
+"""Free-energy workflows: calphy + phonopy harmonic / QHA + dynaphopy anharmonic.
+
+Public API
+----------
+Dataclasses:
+    LammpsPotential  - calphy-only: pair_style + pair_coeff + optional potential_file
+    FreeEnergyOutput - typed result of every node
+
+calphy function-nodes (one per mode):
+    free_energy, reversible_scaling_temperature, reversible_scaling_pressure,
+    melting_temperature, alchemy, composition_scaling
+
+Phonon free-energy macros (NEW):
+    harmonic_free_energy             - phonopy FC2 at a fixed volume
+    quasiharmonic_free_energy        - phonopy.qha.QHA on top of harmonic_free_energy
+    anharmonic_free_energy_dynaphopy - dynaphopy renormalised harmonic at one T
+    anharmonic_free_energy_dynaphopy_tdi - dynaphopy renormalised harmonic over a T grid
+
+All node-and-adapter imports defer ``calphy`` / ``phonopy`` / ``dynaphopy`` /
+``pyiron_workflow_lammps`` imports to node-body call time, so importing this
+subpackage does not require any specific optional extra.
+"""
+
+from pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy import (
+    anharmonic_free_energy_dynaphopy,
+    anharmonic_free_energy_dynaphopy_tdi,
+)
+from pyiron_workflow_atomistics.physics.free_energy.calphy import (
+    alchemy,
+    composition_scaling,
+    free_energy,
+    melting_temperature,
+    reversible_scaling_pressure,
+    reversible_scaling_temperature,
+)
+from pyiron_workflow_atomistics.physics.free_energy.harmonic import (
+    harmonic_free_energy,
+)
+from pyiron_workflow_atomistics.physics.free_energy.inputs import LammpsPotential
+from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+from pyiron_workflow_atomistics.physics.free_energy.quasiharmonic import (
+    quasiharmonic_free_energy,
+)
+
+__all__ = [
+    "FreeEnergyOutput",
+    "LammpsPotential",
+    "alchemy",
+    "anharmonic_free_energy_dynaphopy",
+    "anharmonic_free_energy_dynaphopy_tdi",
+    "composition_scaling",
+    "free_energy",
+    "harmonic_free_energy",
+    "melting_temperature",
+    "quasiharmonic_free_energy",
+    "reversible_scaling_pressure",
+    "reversible_scaling_temperature",
+]
+```
+
+- [ ] **Step 4: Run; verify pass**
+
+Run: `pytest tests/unit/physics/test_free_energy.py::test_public_free_energy_exports -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyiron_workflow_atomistics/physics/free_energy/__init__.py tests/unit/physics/test_free_energy.py
+git commit -m "feat(free_energy): expose harmonic/QHA/dynaphopy entry points from the package"
+```
+
+---
+
+## Task 9 — Notebook `free_energy_solid.ipynb`
+
+**Files:**
+- Create: `notebooks/free_energy_solid.ipynb`
+
+- [ ] **Step 1: Create the notebook skeleton**
+
+Run:
+
+```bash
+cd /home/liger/pyiron_workflow_atomistics/notebooks
+jupyter nbconvert --to notebook --new free_energy_solid.ipynb 2>/dev/null || true
+```
+
+(If `jupyter nbconvert --new` is unavailable in your jupyter version, create an empty notebook with `jupyter notebook free_energy_solid.ipynb` and immediately close it, or write `{"cells":[],"metadata":{"kernelspec":{"name":"python3","display_name":"Python 3"}},"nbformat":4,"nbformat_minor":5}` to that path.)
+
+- [ ] **Step 2: Author the seven sections**
+
+Open `notebooks/free_energy_solid.ipynb` and add cells in this order. Each markdown header is a separate markdown cell; each code block is a separate code cell.
+
+```markdown
+# Free energy of a solid: harmonic vs quasiharmonic vs anharmonic
+
+This notebook computes the free energy of fcc Al with four methods:
+
+1. **Harmonic** — phonopy FC2 at the reference volume
+2. **Quasiharmonic** — phonopy.qha.QHA across a volume sweep
+3. **Anharmonic (dynaphopy)** — MD-projected renormalised harmonic over a T grid
+4. **Anharmonic (calphy)** — Frenkel–Ladd thermodynamic integration
+
+All four are entry points under `pyiron_workflow_atomistics.physics.free_energy`.
+```
+
+```python
+# Section 1 — Setup
+import numpy as np
+from ase.build import bulk
+from ase.calculators.emt import EMT
+
+from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+
+structure = bulk("Al", "fcc", a=4.05, cubic=True)
+ase_engine = ASEEngine(
+    EngineInput=CalcInputStatic(),
+    calculator=EMT(),
+    working_directory="_runs",
+)
+fc2_sc = 2 * np.eye(3, dtype=int)
+T_grid = np.arange(0, 1001, 50)
+```
+
+```python
+# Section 2 — Harmonic
+from pyiron_workflow_atomistics.physics.free_energy import harmonic_free_energy
+
+out_harm = harmonic_free_energy(
+    structure=structure,
+    engine=ase_engine,
+    fc2_supercell_matrix=fc2_sc,
+    temperatures=T_grid,
+    working_directory="_runs",
+    subdir="harmonic",
+).run()
+
+import matplotlib.pyplot as plt
+fig, (a1, a2, a3) = plt.subplots(1, 3, figsize=(12, 3.5))
+a1.plot(out_harm.temperature_array, out_harm.free_energy_array)
+a1.set_xlabel("T (K)"); a1.set_ylabel("F (eV/atom)"); a1.set_title("Harmonic F(T)")
+a2.plot(out_harm.temperature_array, out_harm.entropy_array)
+a2.set_xlabel("T (K)"); a2.set_ylabel("S (eV/K/atom)"); a2.set_title("S(T)")
+a3.plot(out_harm.temperature_array, out_harm.heat_capacity_array)
+a3.set_xlabel("T (K)"); a3.set_ylabel("Cv (eV/K/atom)"); a3.set_title("Cv(T)")
+plt.tight_layout(); plt.show()
+```
+
+```python
+# Section 3 — Quasiharmonic (QHA)
+from pyiron_workflow_atomistics.physics.free_energy import quasiharmonic_free_energy
+
+out_qha = quasiharmonic_free_energy(
+    structure=structure,
+    engine=ase_engine,
+    fc2_supercell_matrix=fc2_sc,
+    temperatures=T_grid,
+    strain_range=(-0.03, 0.03),
+    num_volumes=7,
+    pressure=0.0,   # GPa
+    working_directory="_runs",
+    subdir="qha",
+).run()
+
+fig, (a1, a2) = plt.subplots(1, 2, figsize=(9, 3.5))
+a1.plot(out_qha.temperature_array, out_qha.equilibrium_volume_array)
+a1.set_xlabel("T (K)"); a1.set_ylabel("V* (Å³/atom)"); a1.set_title("QHA V*(T)")
+a2.plot(out_harm.temperature_array, out_harm.free_energy_array, label="harmonic")
+a2.plot(out_qha.temperature_array, out_qha.gibbs_free_energy_array, label="QHA G(T,P=0)")
+a2.set_xlabel("T (K)"); a2.set_ylabel("F or G (eV/atom)"); a2.legend()
+plt.tight_layout(); plt.show()
+```
+
+```python
+# Section 4 — Anharmonic (dynaphopy) — single T
+from pyiron_workflow_atomistics.physics.free_energy import (
+    anharmonic_free_energy_dynaphopy,
+)
+
+out_anh_T = anharmonic_free_energy_dynaphopy(
+    structure=structure,
+    engine=ase_engine,
+    fc2_supercell_matrix=fc2_sc,
+    temperature=300.0,
+    production_steps=5_000,   # bump to ≥30_000 for production
+    q_mesh=(7, 7, 7),         # bump to (11,11,11) or denser
+    working_directory="_runs",
+    subdir="anharmonic_T300",
+).run()
+
+print(f"F_anharm(300 K) = {out_anh_T.free_energy:.4f} eV/atom")
+print(f"F_harmonic(300 K) = {np.interp(300.0, out_harm.temperature_array, out_harm.free_energy_array):.4f}")
+
+fig, ax = plt.subplots(figsize=(6, 3.5))
+ax.plot(out_anh_T.harmonic_frequencies.ravel(), out_anh_T.renormalised_frequencies.ravel(), "o", ms=3)
+lim = (
+    min(out_anh_T.harmonic_frequencies.min(), out_anh_T.renormalised_frequencies.min()),
+    max(out_anh_T.harmonic_frequencies.max(), out_anh_T.renormalised_frequencies.max()),
+)
+ax.plot(lim, lim, "k--", lw=1)
+ax.set_xlabel("ω_harmonic (THz)"); ax.set_ylabel("ω_renorm (THz)")
+ax.set_title("Dynaphopy mode renormalisation at 300 K")
+plt.tight_layout(); plt.show()
+```
+
+```python
+# Section 5 — Anharmonic (dynaphopy) — TDI over T grid
+from pyiron_workflow_atomistics.physics.free_energy import (
+    anharmonic_free_energy_dynaphopy_tdi,
+)
+
+out_anh_tdi = anharmonic_free_energy_dynaphopy_tdi(
+    structure=structure,
+    engine=ase_engine,
+    fc2_supercell_matrix=fc2_sc,
+    temperatures=(200, 400, 600, 800),
+    production_steps=5_000,
+    q_mesh=(7, 7, 7),
+    working_directory="_runs",
+    subdir="anharmonic_tdi",
+).run()
+```
+
+```python
+# Section 6 — Anharmonic (calphy TI) — needs [free-energy] extras + lmp on PATH
+try:
+    from pyiron_workflow_lammps.engine import LammpsEngine
+    from pyiron_workflow_atomistics.physics.free_energy import (
+        LammpsPotential,
+        reversible_scaling_temperature,
+    )
+    lammps_engine = LammpsEngine(command="lmp")
+    potential = LammpsPotential(
+        pair_style="eam/alloy",
+        pair_coeff="* * Al99.eam.alloy Al",
+        potential_file="Al99.eam.alloy",
+    )
+    out_calphy = reversible_scaling_temperature(
+        structure=structure,
+        lammps_engine=lammps_engine,
+        potential=potential,
+        temperature_range=(100.0, 800.0),
+        reference_phase="solid",
+        working_directory="_runs",
+        subdir="calphy_ts",
+    ).run()
+except Exception as exc:
+    print(f"calphy step skipped: {exc}")
+    out_calphy = None
+```
+
+```python
+# Section 7 — Composite overlay
+fig, ax = plt.subplots(figsize=(7, 4))
+ax.plot(out_harm.temperature_array, out_harm.free_energy_array, label="harmonic")
+ax.plot(out_qha.temperature_array, out_qha.gibbs_free_energy_array, label="QHA")
+ax.plot(out_anh_tdi.temperature_array, out_anh_tdi.free_energy_array, "o-", label="dynaphopy TDI")
+if out_calphy is not None and out_calphy.temperature_array is not None:
+    ax.plot(out_calphy.temperature_array, out_calphy.free_energy_array, label="calphy TI")
+ax.set_xlabel("T (K)"); ax.set_ylabel("F or G (eV/atom)")
+ax.legend(); ax.set_title("Free energy of fcc Al — four methods")
+plt.tight_layout(); plt.show()
+```
+
+```markdown
+## Notes
+
+- **Harmonic** has a fixed reference volume — it overestimates F at high T because the lattice cannot expand.
+- **Quasiharmonic** captures thermal expansion → typically falls below harmonic at high T.
+- **Dynaphopy renormalised** captures soft-mode renormalisation (classical, fixed-V here — combine with QHA in a follow-up).
+- **Calphy TI** is the reference: full anharmonicity, classical, most expensive.
+
+For production-grade Al, bump `production_steps` to ≥30 000, `q_mesh` to (11, 11, 11) or denser, the supercell to 3×3×3 or 4×4×4, and `num_volumes` to ≥9.
+```
+
+- [ ] **Step 3: Run the notebook end-to-end (smoke)**
+
+```bash
+jupyter nbconvert --to notebook --execute notebooks/free_energy_solid.ipynb --output free_energy_solid.executed.ipynb --ExecutePreprocessor.timeout=900
+```
+
+Expected: notebook executes without errors. Calphy section may print a skip message if the `[free-energy]` extra or `lmp` is not installed. Delete the `.executed.ipynb` byproduct after verification — do not commit it.
+
+```bash
+rm notebooks/free_energy_solid.executed.ipynb
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add notebooks/free_energy_solid.ipynb
+git commit -m "docs(notebooks): free-energy of a solid — harmonic / QHA / dynaphopy / calphy overlay"
+```
+
+---
+
+## Task 10 — Final cross-check pass
+
+- [ ] **Step 1: Run full test suite**
+
+```bash
+pytest tests/unit/physics/test_free_energy.py \
+       tests/unit/physics/test_free_energy_harmonic.py \
+       tests/unit/physics/test_free_energy_qha.py \
+       tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py \
+       -v
+```
+
+Expected: every test PASSES, including the four `@pytest.mark.slow` Tier-2 EMT smokes. Total runtime budget ≤15 min.
+
+- [ ] **Step 2: Run the non-free-energy phonons tests to check no regressions**
+
+```bash
+pytest tests/unit/physics/test_phonons.py tests/unit/physics/test_phonons_helpers.py tests/unit/physics/test_bulk_workflows.py -v
+```
+
+Expected: no regressions. The phonons modules were not modified; this is a paranoia check.
+
+- [ ] **Step 3: Lint / style check**
+
+```bash
+ruff check pyiron_workflow_atomistics/physics/free_energy/
+ruff format --check pyiron_workflow_atomistics/physics/free_energy/ tests/unit/physics/test_free_energy_*.py
+```
+
+Expected: clean. Fix any reported issues and amend the relevant commit (do **not** use `git commit --amend` for already-merged commits — squash via a follow-up commit instead).
+
+- [ ] **Step 4: Final commit (only if any lint fixes were needed)**
+
+```bash
+git add -A
+git commit -m "style: ruff format pass on free-energy consolidation"
+```
+
+---
+
+## Self-review
+
+**1. Spec coverage:**
+- `FreeEnergyOutput` extension → Task 1 ✓
+- `_free_energy_from_spectrum` → Task 2 ✓
+- `_produce_fc2_view` + `harmonic_free_energy` → Task 3 ✓
+- `_fit_qha` + `_check_qha_volume_range` → Task 4 ✓
+- `quasiharmonic_free_energy` → Task 5 ✓
+- `anharmonic_free_energy_dynaphopy` + `_commensurate_q_points` + `_pack_anharmonic_dynaphopy_output` → Task 6 ✓
+- `anharmonic_free_energy_dynaphopy_tdi` + `_stack_tdi_outputs` → Task 7 ✓
+- `__init__.py` public exports → Task 8 ✓
+- Demo notebook `free_energy_solid.ipynb` → Task 9 ✓
+- Tests: per-method unit + Tier-2 EMT smokes ✓ (Tasks 1, 2, 3, 4, 5, 6, 7, 8)
+
+**2. Placeholder scan:** Every step has concrete code blocks or commands. No "TODO" / "TBD" / "implement later". One legitimate non-placeholder is the calphy section in the notebook (Section 6), which falls back gracefully if extras are missing — that's intended behaviour, not a placeholder.
+
+**3. Type consistency:**
+- `FreeEnergyOutput.mode` Literal extended in Task 1 includes exactly the four new values used in Tasks 3, 5, 6, 7.
+- `_free_energy_from_spectrum` returns `(F, S, Cv)` in Task 2 — consumed with that triple unpack by Task 6's `wf.spectrum.outputs.{free_energy_per_atom, entropy_per_atom, cv_per_atom}`.
+- `_fit_qha` returns a dict in Task 4 — Task 5's `_pack_qha_output` reads the same keys.
+- `_stack_tdi_outputs` populates `renormalised_frequencies_per_T` and `linewidths_per_T` — fields declared in Task 1's dataclass.
+- Engine constraint string ("must expose `.calculator`") is inherited from `calculate_phonon_md_renormalisation` — not re-validated in the new macros to avoid double-error-message noise.
+
+---
+
+## Execution handoff
+
+**Plan complete and saved to `docs/design/plans/2026-05-15-free-energy-consolidation.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using `superpowers:executing-plans`, batch execution with checkpoints.
+
+**Which approach?**

--- a/docs/design/specs/2026-05-15-free-energy-consolidation-design.md
+++ b/docs/design/specs/2026-05-15-free-energy-consolidation-design.md
@@ -1,0 +1,538 @@
+# Free-energy consolidation (harmonic / quasiharmonic / anharmonic)
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Date | 2026-05-15 |
+| Repo | `pyiron/pyiron_workflow_atomistics` |
+| Branch | `tests/improve-coverage` |
+| Scope | New free-energy entry points wrapping `phonopy` (harmonic + QHA), `dynaphopy` (renormalised harmonic at one T, plus a T-grid sweep), and the existing calphy nodes — all reachable from `physics.free_energy` |
+| Out of scope (v1) | Liquid free energies via phonons; non-analytic correction (BORN + ε∞); full ⟨∂H/∂λ⟩ dynaphopy TI; bespoke physical relocation of `phonons/*` modules; refactoring the κ(T) workflow |
+
+## Problem
+
+`physics.free_energy` is currently a calphy-only subpackage: six public nodes producing `FreeEnergyOutput` for `fe`, `ts`, `pscale`, `melting_temperature`, `alchemy`, `composition_scaling`. It is therefore the *home* of free energy in this repo, but the repo also already contains:
+
+- A fully-working phonopy FC2 force-evaluation pipeline (`physics/phonons/harmonic.py`) whose `_compute_harmonic_observables` helper already returns F(T), S(T), Cv(T) at fixed reference volume. Today that data is **hidden** — accessible only when a user passes `harmonic_observables=True` into `calculate_phonon_thermal_conductivity`, the κ(T) macro. There is no user-facing "harmonic free energy" node.
+- A dynaphopy MD-projection workflow (`physics/phonons/md_renormalised.py`) producing renormalised phonon frequencies and linewidths at finite T. Useful spectroscopically, but does **not** currently produce a free energy.
+- A reusable EOS volume sweep + EOS fit (`physics/bulk.py:eos_volume_scan`). Suitable as the volume-grid backbone for QHA, but currently used only for lattice-parameter optimisation.
+- No quasiharmonic / QHA support anywhere.
+
+What needs design: (a) the public node surface that turns those three packages into a coherent free-energy story for solids; (b) where the new nodes live without disturbing the κ(T) workflow; (c) how the existing calphy-shaped `FreeEnergyOutput` extends to accommodate harmonic, QHA, and dynaphopy outputs; (d) the demo + tests that make the picture believable end-to-end.
+
+The user-facing story we are scoping for: "compute the Helmholtz/Gibbs free energy of a solid at finite T, by your choice of level — harmonic, quasiharmonic, or anharmonic (dynaphopy at one T, dynaphopy over a T grid, or calphy TI)."
+
+## Approach
+
+A consolidation by re-export, not relocation. Four new public macros land under `physics.free_energy`, each wrapping helpers that already exist in `physics.phonons` and `physics.bulk` via thin import-and-wrap glue. `physics.phonons.{harmonic,anharmonic,md_renormalised}` are not moved — they remain the canonical home of FC2/FC3 plumbing and dynaphopy MD projection, since the κ(T) workflow continues to import from them.
+
+```
+pyiron_workflow_atomistics/physics/
+├── bulk.py                                 # unchanged; eos_volume_scan reused by QHA
+├── phonons/                                # unchanged in structure
+│   ├── harmonic.py                         #   no behaviour changes
+│   ├── anharmonic.py                       #   no behaviour changes
+│   └── md_renormalised.py                  #   no behaviour changes
+└── free_energy/
+    ├── __init__.py                         # extended export list
+    ├── _compat.py                          # unchanged
+    ├── inputs.py                           # unchanged
+    ├── outputs.py                          # FreeEnergyOutput extended (see § FreeEnergyOutput)
+    ├── calphy.py                           # unchanged
+    ├── _calphy_adapter.py                  # unchanged
+    ├── harmonic.py                         # NEW
+    ├── quasiharmonic.py                    # NEW
+    └── anharmonic_dynaphopy.py             # NEW (single-T + TDI-over-T)
+```
+
+Four deliberate API-shape decisions, each motivated below:
+
+- **Separate nodes per method, no dispatcher.** Matches the existing per-mode calphy layout (`free_energy / reversible_scaling_temperature / ...`). A dispatcher was considered and rejected: each method's required kwargs are sufficiently different (`temperatures` vs `temperature_range`, `strain_range` vs none, `q_mesh` vs none) that a `method="..."` enum would either silently accept wrong kwargs or duplicate every signature in a typing-overload tower. The user is expected to import the specific node they want.
+
+- **Import-and-wrap, no physical relocation.** `physics.phonons` remains the home of FC2/FC3 plumbing because `calculate_phonon_thermal_conductivity` needs it there. The new `free_energy/harmonic.py` imports `_generate_fc2_supercells`, `_evaluate_supercells`, `_compute_harmonic_observables`, `_ase_to_phonopy`, `_phonopy_to_ase` from `physics.phonons.harmonic` and treats them as the consolidated FC2 building blocks. This keeps the design diff small and the κ(T) workflow untouched.
+
+- **One `FreeEnergyOutput` dataclass, extended.** Every new mode returns the same `FreeEnergyOutput` type with method-specific arrays populated and the rest `None`. Rationale: keeps the import surface flat (one type to learn), and `to_dict()` continues to work as a homogeneous serialiser across calphy + harmonic + QHA + dynaphopy. Per-method typing is preserved via the discriminator field `mode`, which extends to `"harmonic" | "qha" | "anharmonic_dynaphopy" | "anharmonic_dynaphopy_tdi"`.
+
+- **Dynaphopy TDI is renormalised-harmonic over a T grid, not full ⟨∂H/∂λ⟩ TI.** Each T in the grid runs an independent NVT trajectory through `calculate_phonon_md_renormalisation`, then F_anharm(T) is computed as the harmonic free energy on the renormalised spectrum. This is the simpler, well-scoped formulation. Full λ-integration is documented as a v2 follow-up; it requires MD plumbing dynaphopy does not directly expose and is out of scope for this round.
+
+## Components
+
+### `harmonic.py` — `harmonic_free_energy`
+
+```python
+@pwf.api.as_macro_node("free_energy_output")
+def harmonic_free_energy(
+    wf,
+    *,
+    structure: Atoms,
+    engine: Engine,
+    fc2_supercell_matrix,                    # int / (3,) / (3,3)
+    temperatures=(0.0, 100.0, 200.0, 300.0, 400.0, 500.0),  # K
+    displacement_distance: float = 0.03,     # Å
+    is_plusminus: str | bool = "auto",
+    working_directory: str = ".",
+    subdir: str = "harmonic_free_energy",
+    keep_handles: bool = False,
+) -> FreeEnergyOutput: ...
+```
+
+Returns F(T), S(T), Cv(T) at fixed reference volume on the supplied temperature grid. `mode="harmonic"`, `reference_phase="solid"`, scalar `free_energy` = `free_energy_array[0]` (lowest T) for convenience.
+
+Internal graph:
+
+```
+structure ──┐
+            ├──▶ _generate_fc2_supercells ──▶ list[Atoms]
+fc2_sc_mat ─┘                                  │
+                                                ▼
+                                  _evaluate_supercells(engine, prefix="fc2_disp_")
+                                                │
+                                                ▼
+                              _produce_fc2_view  (NEW small helper)
+                                                │
+                                                ▼
+                _compute_harmonic_observables (T-grid)  ──▶ (band, dos, free_energy_dict)
+                                                │
+                                                ▼
+                                        _pack_harmonic_output
+                                                │
+                                                ▼
+                                        FreeEnergyOutput
+```
+
+`_produce_fc2_view` builds a bare `phonopy.Phonopy` (no phono3py) from the FC2 supercell matrix and stacked forces, calls `produce_force_constants()`, and returns the `Phonopy` instance. Lives in `free_energy/harmonic.py`; ~10 LOC.
+
+`_pack_harmonic_output` writes:
+- `mode="harmonic"`, `reference_phase="solid"`
+- `temperature = temperatures[0]` (lowest T)
+- `pressure = 0.0` (harmonic FE is at fixed reference V; pressure is not a control variable here)
+- `free_energy = F[0]` (eV/atom)
+- `free_energy_error = 0.0` (no statistical error in deterministic FD)
+- `n_atoms`, `elements`, `simfolder`, `report = {"method": "harmonic", "fc2_supercell_matrix": ..., "displacement_distance": ...}`
+- `temperature_array`, `free_energy_array`, `entropy_array`, `heat_capacity_array`
+- When `keep_handles=True`: `phonopy_handle`, `band_structure`, `phonon_dos`
+
+**Engine constraint:** any `Engine` Protocol implementation.
+
+**Error handling:**
+- `_check_all_converged(fc2_engine_outputs, label="FC2")` (reused from `phonons/anharmonic.py`) raises a `RuntimeError` listing failed-supercell working directories.
+- FC2 force / supercell count mismatch raises `RuntimeError("FC2 force/supercell mismatch: ...")` — same message family as `_run_phono3py_thermal_conductivity` (a documented invariant that displacement kwargs not drift between generation and synthesis).
+
+### `quasiharmonic.py` — `quasiharmonic_free_energy`
+
+```python
+@pwf.api.as_macro_node("free_energy_output")
+def quasiharmonic_free_energy(
+    wf,
+    *,
+    structure: Atoms,                        # equilibrium reference cell
+    engine: Engine,
+    fc2_supercell_matrix,
+    temperatures=(0.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0),
+    pressure: float = 0.0,                   # GPa (Gibbs branch); 0 → Helmholtz
+    strain_range: tuple[float, float] = (-0.03, 0.03),
+    num_volumes: int = 7,
+    displacement_distance: float = 0.03,
+    is_plusminus="auto",
+    eos_type: str = "vinet",                 # phonopy.qha.QHA: vinet | birch_murnaghan | murnaghan
+    working_directory: str = ".",
+    subdir: str = "quasiharmonic_free_energy",
+    keep_handles: bool = False,
+) -> FreeEnergyOutput: ...
+```
+
+Runs `harmonic_free_energy` at `num_volumes` isotropically-strained cells, then `phonopy.qha.QHA` to give G(T,P), V*(T,P), B(T,P), α(T,P). `mode="qha"`, `reference_phase="solid"`.
+
+Internal graph:
+
+```
+structure ─▶ generate_structures(axes=["iso"], strain_range, num_points=num_volumes)
+                          │
+                          ▼
+                  list[Atoms] (n_V strained cells)
+                          │
+                          ├── evaluate_structures(engine, prefix="vol_E_")
+                          │           │   (one-shot static energy per volume)
+                          │           ▼
+                          │   energies_per_volume  (n_V,)
+                          │   volumes              (n_V,)
+                          │
+                          └── for each strained cell:
+                                  harmonic_free_energy(strained_cell, fc2_supercell_matrix,
+                                                       temperatures, subdir=f"vol_{i:03d}/harmonic")
+                                  → F_phonon_per_T(V_i)
+                          │
+                          ▼
+                _fit_qha(energies, volumes, F_phonon[T,V], T-grid, P_GPa, eos_type)
+                          │  uses phonopy.qha.QHA
+                          ▼
+                FreeEnergyOutput with QHA fields populated
+```
+
+`evaluate_structures` (from `physics/bulk.py`) is reused for the per-volume static energies. The per-volume `harmonic_free_energy` macros each create their own subdirectory `vol_{i:03d}_{strain:+.3f}/harmonic_free_energy/`.
+
+`_fit_qha` is a function-node:
+
+```python
+@pwf.as_function_node("qha_results")
+def _fit_qha(
+    energies, volumes, free_energy_per_T_V, entropy_per_T_V, cv_per_T_V,
+    temperatures, pressure_GPa, eos_type,
+):
+    from phonopy.qha import QHA
+    qha = QHA(
+        volumes=np.asarray(volumes),
+        electronic_energies=np.asarray(energies),
+        temperatures=np.asarray(temperatures),
+        free_energy=np.asarray(free_energy_per_T_V),    # (n_T, n_V)
+        cv=np.asarray(cv_per_T_V),
+        entropy=np.asarray(entropy_per_T_V),
+        eos=eos_type,
+        pressure=pressure_GPa,                          # GPa native to phonopy.qha
+    )
+    qha.run()
+    return {
+        "equilibrium_volume_array": np.asarray(qha.get_volume_temperature()),
+        "gibbs_free_energy_array":  np.asarray(qha.get_gibbs_temperature()),
+        "bulk_modulus_array":       np.asarray(qha.get_bulk_modulus_temperature()),
+        "thermal_expansion_array":  np.asarray(qha.get_thermal_expansion()),
+        "qha_handle": qha,
+    }
+```
+
+`_pack_qha_output` writes:
+- `mode="qha"`, `reference_phase="solid"`
+- `temperature = temperatures[0]`, `pressure = pressure_GPa` (in GPa for QHA results)
+- `free_energy = gibbs_free_energy_array[0]`, `free_energy_error = 0.0`
+- `temperature_array`, `free_energy_array = gibbs_free_energy_array`,
+  `entropy_array`, `heat_capacity_array`, `volumes`, `free_energy_volume_array`,
+  `equilibrium_volume_array`, `gibbs_free_energy_array`, `bulk_modulus_array`,
+  `thermal_expansion_array`
+- When `keep_handles=True`: `qha_handle`, plus the inner harmonic `phonopy_handle` from one representative volume
+
+**Engine constraint:** any `Engine` Protocol implementation.
+
+**Error handling:**
+- `_check_qha_volume_range` (new helper in `free_energy/quasiharmonic.py`, called inside `_fit_qha`): if `qha.get_volume_temperature()` returns NaN for any T, raise `RuntimeError` with the message "QHA equilibrium volume undefined at T=... K — widen `strain_range` or extend it to include positive strain (current range: ..., current V grid: ...)."
+- Energy-vs-volume curve sanity: if energies are non-monotonic in V on both sides of the minimum, warn but proceed (numerical noise is recoverable by `phonopy.qha`; structural issues are not, but we can't distinguish here).
+
+### `anharmonic_dynaphopy.py` — `anharmonic_free_energy_dynaphopy` (single T)
+
+```python
+@pwf.api.as_macro_node("free_energy_output")
+def anharmonic_free_energy_dynaphopy(
+    wf,
+    *,
+    structure: Atoms,
+    engine: Engine,                          # MUST expose .calculator (ASE engine)
+    fc2_supercell_matrix,
+    temperature: float,                      # K, single T
+    equilibration_steps: int = 2000,
+    production_steps: int = 10000,
+    time_step: float = 1.0,                  # fs
+    thermostat_time_constant: float = 100.0, # fs
+    seed: int | None = None,
+    q_mesh=(11, 11, 11),                     # commensurate mesh for the F-sum
+    phono3py_output=None,                    # optional FC2 reuse from κ(T) macro
+    working_directory: str = ".",
+    subdir: str = "anharmonic_free_energy_dynaphopy",
+    keep_handles: bool = False,
+) -> FreeEnergyOutput: ...
+```
+
+Internal graph:
+
+```
+structure ─┐
+           ├──▶ calculate_phonon_md_renormalisation
+engine ────┤        q_points = commensurate(q_mesh, primitive_cell)
+fc2_sc_mat ┘        temperature, MD plumbing, fc2 source
+                                  │
+                                  ▼
+                          MdPhononOutput  ──▶ ω_renorm at commensurate q
+                                  │
+                                  ▼
+                _free_energy_from_spectrum(ω_renorm, q_weights, T, n_atoms_primitive)
+                                  │
+                                  ▼
+                          FreeEnergyOutput (mode="anharmonic_dynaphopy")
+```
+
+`q_points = commensurate(q_mesh, primitive_cell)` is the commensurate-q grid for the supplied mesh — dynaphopy projects correctly only on q-points commensurate with the supercell. Computed via `phonopy.structure.grid_points.GridPoints` (or `phonopy.harmonic.dynamical_matrix.get_commensurate_points` — implementation chooses based on phonopy version available).
+
+`_free_energy_from_spectrum` is a function-node (~30 LOC, numpy only):
+
+```python
+@pwf.as_function_node("free_energy_per_atom", "entropy_per_atom", "cv_per_atom")
+def _free_energy_from_spectrum(
+    frequencies: np.ndarray,         # (n_q, n_band) THz
+    q_weights: np.ndarray,           # (n_q,) summing to 1
+    temperature: float,              # K
+    n_atoms_primitive: int,
+):
+    """Harmonic free energy formula on a discrete (q, band) frequency grid.
+
+    F = sum_q w_q * sum_b [ ℏω_qb/2 + k_B·T·ln(1 − exp(−ℏω_qb / k_B·T)) ]
+
+    Acoustic modes at Γ are zeroed by dynaphopy's _project_with_dynaphopy
+    (it clamps positions[:3]=0 at q==0), so no extra masking is needed here.
+    Modes with ω ≤ 0 (imaginary) raise ValueError — F is undefined for an
+    unstable spectrum.
+    """
+```
+
+`_pack_anharmonic_dynaphopy_output` writes:
+- `mode="anharmonic_dynaphopy"`, `reference_phase="solid"`
+- `temperature`, `pressure = 0.0`
+- `free_energy`, `entropy`, `heat_capacity` (scalars at the supplied T)
+- `harmonic_frequencies`, `renormalised_frequencies`, `linewidths`, `q_mesh`
+- `report = {"method": "anharmonic_dynaphopy", "n_md_steps": ..., "md_temperature_mean": ..., "md_temperature_std": ..., "md_health": <check_md_health()>}`
+- When `keep_handles=True`: `dynaphopy_handle`, `phonopy_handle`
+
+**Engine constraint:** `engine.calculator` must exist (inherited from `calculate_phonon_md_renormalisation`).
+
+**Error handling:**
+- MD health (`MdPhononOutput.check_md_health()`) issues are surfaced into `report["md_health"]` and re-emitted as warnings at the free-energy node level.
+- Any NaN frequencies (failed Lorentzian fits) → `RuntimeError("Lorentzian fit failed for {n}/{N} (q, band) pairs; F_anharm cannot be computed. Inspect MdPhononOutput.linewidths / .renormalised_frequencies to debug.")`.
+- Imaginary modes (ω ≤ 0) → `ValueError("Spectrum has {n} imaginary modes; harmonic free energy is undefined for an unstable spectrum.")`.
+
+### `anharmonic_dynaphopy.py` — `anharmonic_free_energy_dynaphopy_tdi` (T grid)
+
+```python
+@pwf.api.as_macro_node("free_energy_output")
+def anharmonic_free_energy_dynaphopy_tdi(
+    wf,
+    *,
+    structure: Atoms,
+    engine: Engine,
+    fc2_supercell_matrix,
+    temperatures=(100.0, 200.0, 300.0, 400.0, 500.0),
+    equilibration_steps: int = 2000,
+    production_steps: int = 10000,
+    time_step: float = 1.0,
+    thermostat_time_constant: float = 100.0,
+    seed: int | None = None,
+    q_mesh=(11, 11, 11),
+    working_directory: str = ".",
+    subdir: str = "anharmonic_free_energy_dynaphopy_tdi",
+    keep_handles: bool = False,
+) -> FreeEnergyOutput: ...
+```
+
+Loops `anharmonic_free_energy_dynaphopy` over each T in `temperatures` (independent NVT runs per T). Each iteration uses `subdir=f"T_{i:03d}_{T:.1f}K"`. A synthesis node aggregates:
+
+```python
+@pwf.as_function_node("free_energy_output")
+def _stack_tdi_outputs(
+    per_T_outputs: list[FreeEnergyOutput],
+    structure, temperatures,
+) -> FreeEnergyOutput:
+    """Aggregate independent-T dynaphopy free energies into a single output."""
+```
+
+The stacked output has:
+- `mode="anharmonic_dynaphopy_tdi"`, `reference_phase="solid"`
+- `temperature = temperatures[0]`, `pressure = 0.0`
+- `free_energy = free_energy_array[0]`, `free_energy_error = 0.0` (single-trajectory; bootstrap uncertainty is a v2 follow-up)
+- `temperature_array`, `free_energy_array` (stacked)
+- `entropy_array`, `heat_capacity_array` — central finite differences on `free_energy_array`; endpoints use forward/backward differences; if `len(temperatures) < 3`, only fill at interior points and set `report["derivative_warning"] = True`.
+- `renormalised_frequencies_per_T`, `linewidths_per_T` (shape `(n_T, n_q, n_band)`) — separate fields from the single-T `renormalised_frequencies` / `linewidths` to keep each field's shape contract stable.
+- `report["per_T_md_health"] = [out.report["md_health"] for out in per_T_outputs]`.
+
+**Engine constraint:** `engine.calculator` required (inherited).
+
+### `outputs.py` — `FreeEnergyOutput` extension
+
+The dataclass remains pickleable (plain types + numpy + None-default handles). Changes summarised below; everything else is unchanged.
+
+**`mode` literal extends to:**
+```python
+Literal[
+    # calphy (existing)
+    "fe", "ts", "tscale", "pscale", "melting_temperature",
+    "alchemy", "composition_scaling",
+    # NEW
+    "harmonic", "qha",
+    "anharmonic_dynaphopy", "anharmonic_dynaphopy_tdi",
+]
+```
+
+**New scalar fields:**
+
+| Field | Type / unit | Populated by |
+|---|---|---|
+| `entropy: float \| None` | eV/K/atom | harmonic (T₀), anharmonic_dynaphopy |
+| `heat_capacity: float \| None` | eV/K/atom | harmonic (T₀), anharmonic_dynaphopy |
+
+**New array fields (paired with `temperature_array`):**
+
+| Field | Shape / unit | Populated by |
+|---|---|---|
+| `entropy_array` | (n_T,) eV/K/atom | harmonic, qha, anharmonic_dynaphopy_tdi |
+| `heat_capacity_array` | (n_T,) eV/K/atom | harmonic, qha, anharmonic_dynaphopy_tdi |
+
+**QHA-specific fields:**
+
+| Field | Shape / unit | Notes |
+|---|---|---|
+| `volumes` | (n_V,) Å³/atom | per-strain volumes |
+| `free_energy_volume_array` | (n_T, n_V) eV/atom | F(T,V) before volume minimisation |
+| `equilibrium_volume_array` | (n_T,) Å³/atom | V*(T) at the requested P |
+| `gibbs_free_energy_array` | (n_T,) eV/atom | G(T,P) = min_V[F(T,V) + PV] |
+| `bulk_modulus_array` | (n_T,) GPa | B(T) at V*(T) |
+| `thermal_expansion_array` | (n_T,) 1/K | α(T) at the requested P |
+
+**Dynaphopy-specific fields:**
+
+| Field | Shape / unit | Notes |
+|---|---|---|
+| `harmonic_frequencies` | (n_q, n_band) THz | reference (pre-renormalisation) |
+| `renormalised_frequencies` | (n_q, n_band) THz | dynaphopy, single T |
+| `linewidths` | (n_q, n_band) THz FWHM | dynaphopy, single T |
+| `renormalised_frequencies_per_T` | (n_T, n_q, n_band) THz | dynaphopy TDI |
+| `linewidths_per_T` | (n_T, n_q, n_band) THz | dynaphopy TDI |
+| `q_mesh` | tuple[int, int, int] | mesh actually used for the F-sum |
+
+**`keep_handles=True` extras (non-pickleable, dropped by `to_dict()`):**
+
+| Field | Type | Populated by |
+|---|---|---|
+| `phonopy_handle: Any \| None` | `phonopy.Phonopy` | harmonic, qha |
+| `qha_handle: Any \| None` | `phonopy.qha.QHA` | qha |
+| `dynaphopy_handle: Any \| None` | `dynaphopy.Quasiparticle` | anharmonic_dynaphopy |
+| `band_structure: dict \| None` | — | harmonic |
+| `phonon_dos: dict \| None` | — | harmonic, qha |
+
+**Unit conventions reaffirmed:**
+- Energies: eV/atom (calphy native).
+- Temperatures: K.
+- Pressure: bar for calphy modes (`fe`, `ts`, `pscale`, `melting_temperature`, `alchemy`, `composition_scaling`). **GPa** for QHA-output fields (`bulk_modulus_array`, the `pressure` kwarg in `quasiharmonic_free_energy`). The unit discrepancy is documented in `FreeEnergyOutput`'s class docstring with an explicit per-mode table.
+
+**`to_dict()`** continues to return plain dicts. Handle fields (`phonopy_handle`, `qha_handle`, `dynaphopy_handle`) are **always** excluded from the returned dict — including when they are populated — because the underlying phonopy/dynaphopy objects are not generally pickleable. This is a small change to the existing implementation: the `asdict` call is replaced with a field-by-field copy that explicitly skips a known set of handle fields. The dataclass instance still carries those handles in memory for callers that asked for `keep_handles=True`.
+
+### `__init__.py` — public exports
+
+```python
+# additions to the existing __all__
+from pyiron_workflow_atomistics.physics.free_energy.harmonic import (
+    harmonic_free_energy,
+)
+from pyiron_workflow_atomistics.physics.free_energy.quasiharmonic import (
+    quasiharmonic_free_energy,
+)
+from pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy import (
+    anharmonic_free_energy_dynaphopy,
+    anharmonic_free_energy_dynaphopy_tdi,
+)
+
+__all__ = [
+    "FreeEnergyOutput",
+    "LammpsPotential",
+    # calphy (existing)
+    "alchemy",
+    "composition_scaling",
+    "free_energy",
+    "melting_temperature",
+    "reversible_scaling_pressure",
+    "reversible_scaling_temperature",
+    # NEW
+    "harmonic_free_energy",
+    "quasiharmonic_free_energy",
+    "anharmonic_free_energy_dynaphopy",
+    "anharmonic_free_energy_dynaphopy_tdi",
+]
+```
+
+## Data flow & engine constraints — summary
+
+| Method | Macro | Engine constraint | Force calls per run |
+|---|---|---|---|
+| Harmonic | `harmonic_free_energy` | any `Engine` | n_fc2_supercells |
+| Quasiharmonic | `quasiharmonic_free_energy` | any `Engine` | `num_volumes × (1 + n_fc2_supercells)` |
+| Anharmonic (1 T) | `anharmonic_free_energy_dynaphopy` | needs `engine.calculator` | n_fc2 + `production_steps` MD calls |
+| Anharmonic (T grid) | `anharmonic_free_energy_dynaphopy_tdi` | needs `engine.calculator` | `n_T × (n_fc2 + production_steps)` |
+| Anharmonic (calphy TI) | `free_energy`, `reversible_scaling_temperature` | `LammpsEngine` only | calphy-controlled |
+
+The engine constraint is validated at runtime inside the macro (`hasattr(engine, "calculator")` for dynaphopy paths) with a clear error message pointing at the existing `ASEEngine`/`LammpsEngine` docstrings.
+
+## Demo notebook — `notebooks/free_energy_solid.ipynb`
+
+Single notebook, one solid (fcc Al), one composite figure at the end overlaying all four free-energy curves. Sections:
+
+1. **Setup.** Build `Al` (fcc, a₀≈4.05 Å). Two engine instances:
+   - `ase_engine = ASEEngine(calculator=EMT())` — for harmonic / QHA / dynaphopy.
+   - `lammps_engine = LammpsEngine(command=...)` + `LammpsPotential(pair_style="eam/alloy", pair_coeff="* * Al99.eam.alloy Al", potential_file="Al99.eam.alloy")` — for calphy. Cell guards on `[free-energy]` extras availability and a `lmp` binary on `PATH`; falls back to a skip notice if unavailable.
+2. **Harmonic.** `harmonic_free_energy(structure=Al, engine=ase_engine, fc2_supercell_matrix=2*np.eye(3, dtype=int), temperatures=np.arange(0, 1001, 50))`. Plot F(T), S(T), Cv(T). Discussion: fixed-volume, zero-point energy included.
+3. **Quasiharmonic.** `quasiharmonic_free_energy(..., temperatures=np.arange(0, 1001, 50), strain_range=(-0.03, 0.03), num_volumes=7)`. Plot G(T,P=0), V*(T), α(T), B(T). Compare F_harmonic vs G_QHA on one panel.
+4. **Anharmonic — dynaphopy single T.** `anharmonic_free_energy_dynaphopy(..., temperature=300.0, production_steps=5_000, q_mesh=(7,7,7))`. Print scalar F_anharm at 300 K. Plot ω_harmonic vs ω_renorm along an auto band path.
+5. **Anharmonic — dynaphopy TDI.** `anharmonic_free_energy_dynaphopy_tdi(..., temperatures=[200, 400, 600, 800], production_steps=5_000, q_mesh=(7,7,7))`. Plot F_anharm(T) on top of F_harmonic(T) and G_QHA(T).
+6. **Anharmonic — calphy TI.** `free_energy(..., reference_phase="solid", temperature=300, ...)` for one point, then `reversible_scaling_temperature(..., temperature_range=(100, 800), ...)` for the curve. Overlay onto panel 5.
+7. **Composite plot + discussion.** F(T) for all four methods on one axis. Discussion notes:
+   - Harmonic underestimates F at high T (no V relaxation).
+   - QHA captures thermal expansion → typically drops below harmonic at high T.
+   - dynaphopy renormalised → captures soft-mode renormalisation, classical.
+   - calphy TI → reference, full anharmonicity, classical, most expensive.
+
+Runtime budget for default notebook cells: target ~5 min on a developer laptop with EMT. A `# %% TUTORIAL` comment block calls out which parameters to bump for production-grade results (longer MD, denser T grid, larger supercell, denser q_mesh).
+
+## Tests
+
+Layout matches `tests/{unit,integration}` convention.
+
+**Unit tests — `tests/unit/physics/free_energy/`:**
+
+- `test_harmonic_output_shape.py` — `_free_energy_from_spectrum` on a synthetic 1-band, 1-q Einstein spectrum reproduces the closed-form `F = ℏω/2 + k_BT·ln(1−exp(−ℏω/k_BT))` at multiple T (tolerance 1e-10).
+- `test_freeenergyoutput_pickleable.py` — round-trip every new `mode` through `pickle.dumps`/`pickle.loads`; assert `to_dict()` is JSON-friendly (every value is `None` / `int` / `float` / `str` / `list` / nested-dict / `numpy.ndarray`).
+- `test_qha_volume_range_guard.py` — feed `_fit_qha` a synthetic too-narrow volume grid (NaN V*(T) at high T) and assert `RuntimeError` with the actionable message fires.
+- `test_tdi_derivatives.py` — `_stack_tdi_outputs` on an analytic Debye-model F(T) gives entropy / Cv within 1% over an interior region; endpoints flagged via `report["derivative_warning"]` when `n_T < 3`.
+- `test_freeenergyoutput_to_dict_drops_handles.py` — `to_dict()` excludes `phonopy_handle`, `qha_handle`, `dynaphopy_handle` when populated.
+
+**Integration tests — `tests/integration/physics/free_energy/`:**
+
+- `test_harmonic_free_energy_emt.py` — Al/EMT, `fc2_supercell_matrix=2*np.eye(3, dtype=int)`, T=[0, 300]. Asserts F(0) > 0 (zero-point), monotonically-decreasing F(T), S(0) ≈ 0 within 1e-6.
+- `test_quasiharmonic_free_energy_emt.py` — Al/EMT, 2×2×2, `num_volumes=5`, T=[0, 300]. Asserts V*(300) > V*(0) (positive thermal expansion), α(300) > 0, B(0) within ±20 % of the harmonic-FE V*0 cell's bulk modulus.
+- `test_anharmonic_dynaphopy_free_energy_emt.py` — Al/EMT, 2×2×2, T=300, `production_steps=2000`, `q_mesh=(5,5,5)`. Asserts `|F_anharm − F_harmonic| < 50 meV/atom` at 300 K (sanity bound on Al/EMT, not physical accuracy).
+- `test_anharmonic_dynaphopy_tdi_emt.py` — same setup, T=[200, 400]. Asserts the `(n_T,)` shape contract on all `*_array` fields and `(n_T, n_q, n_band)` on `renormalised_frequencies_per_T`.
+
+**Gating:**
+- All integration tests use the existing `@pytest.mark.integration` marker.
+- Dynaphopy tests skip if `dynaphopy` is not importable.
+- QHA tests skip if `phonopy.qha` is not importable.
+- No new pytest markers introduced; calphy integration tests unchanged (already gated behind `[free-energy]` extras).
+
+**CI runtime budget:** the four new integration tests aim for ≤3 min combined on the existing GitHub Actions runner — Al/EMT/small supercell/short MD.
+
+## Engine reuse — what stays public-vs-private
+
+The following helpers in `physics.phonons.{harmonic,anharmonic,md_renormalised}` are imported by the new `free_energy/` modules and are part of the de-facto consolidation surface:
+
+- `phonons.harmonic._generate_fc2_supercells` — pwf function-node
+- `phonons.harmonic._compute_harmonic_observables` — plain helper
+- `phonons.harmonic._ase_to_phonopy`, `phonons.harmonic._phonopy_to_ase` — plain helpers
+- `phonons.harmonic._normalise_supercell_matrix` — plain helper
+- `phonons.anharmonic._evaluate_supercells` — pwf function-node (already shared)
+- `phonons.anharmonic._check_all_converged`, `phonons.anharmonic._stack_forces` — plain helpers
+- `phonons.md_renormalised.calculate_phonon_md_renormalisation` — pwf macro (public)
+
+They keep their leading-underscore "private-ish" status. The design doc flags them as the shared internal API; the only stable public commitments are the four new top-level macros + the existing calphy entry points + `calculate_phonon_thermal_conductivity` + `calculate_phonon_md_renormalisation`.
+
+## Follow-ups (v2)
+
+- **Full ⟨∂H/∂λ⟩ dynaphopy TI.** Requires bespoke MD plumbing that emits the integrand at each step. Out of scope for v1 — flagged in `anharmonic_free_energy_dynaphopy_tdi` docstring with a pointer to this spec section.
+- **Bootstrap uncertainty on dynaphopy TDI.** Multiple independent NVT seeds per T → standard error on F_anharm(T). Currently `free_energy_error=0.0` for dynaphopy modes.
+- **Liquid-phase QHA / dynaphopy.** Out of scope — liquid free energies remain the calphy `reference_phase="liquid"` branch.
+- **Non-analytic correction (BORN + ε∞).** Mirrors the v2 follow-up tracked in the phono3py and dynaphopy specs; same NAC plumbing would apply here.
+- **Volume-by-volume QHA at finite anharmonic T.** Coupling dynaphopy renormalisation with QHA volume minimisation. Substantially heavier; flagged as v3.
+
+## Decision log
+
+| Decision | Choice | Alternative considered | Why this one |
+|---|---|---|---|
+| API layout | Separate node per method | Single dispatch macro | Matches existing per-mode calphy layout; avoids signature-merging that hides per-method required kwargs |
+| Code relocation | Import-and-wrap | Physically move `phonons/{harmonic,md_renormalised}` into `free_energy/` | κ(T) workflow still needs FC2 plumbing in `phonons/`; relocation has high blast radius for no functional gain |
+| Output type | Extend `FreeEnergyOutput` | One dataclass per method | Single import surface; `to_dict()` stays homogeneous; method discriminator via `mode` literal |
+| QHA architecture | Compose `harmonic_free_energy` per volume | Fused macro that inlines FC2 + F + QHA | Independent testability; smaller code surface; matches the pwf macro idiom |
+| Dynaphopy TDI scope | Renormalised-harmonic over T grid | Full ⟨∂H/∂λ⟩ TI | Well-scoped, scientifically honest; full TI needs MD plumbing dynaphopy doesn't expose |
+| Pressure units in QHA | GPa | bar (matches calphy elsewhere) | QHA outputs are thermo quantities; bar is a LAMMPS pressure-control convention. Documented in the dataclass docstring with a per-mode table |
+| Demo format | One overlay notebook | Three method-specific notebooks | Side-by-side comparison of all four methods is the main teaching value |
+| Test gating | Per-package importorskip + existing `@pytest.mark.integration` | New pytest markers | No new markers needed; matches the calphy / dynaphopy / phonopy gating already in tests/ |

--- a/notebooks/free_energy_solid.ipynb
+++ b/notebooks/free_energy_solid.ipynb
@@ -1,0 +1,463 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "caa371bc",
+   "metadata": {},
+   "source": [
+    "# Free energy of a solid: harmonic vs quasiharmonic vs anharmonic\n",
+    "\n",
+    "This notebook computes the free energy of fcc Al with four methods:\n",
+    "\n",
+    "1. **Harmonic** — phonopy FC2 at the reference volume.\n",
+    "2. **Quasiharmonic** — `phonopy.qha.QHA` across a volume sweep.\n",
+    "3. **Anharmonic (dynaphopy)** — MD-projected renormalised harmonic, one *T* and a *T* grid.\n",
+    "4. **Anharmonic (calphy)** — Frenkel–Ladd thermodynamic integration (skipped if `lmp` is unavailable).\n",
+    "\n",
+    "All four are entry points under `pyiron_workflow_atomistics.physics.free_energy`.\n",
+    "\n",
+    "> **Defaults are tuned for teaching speed**, *not* publication accuracy. The final cell\n",
+    "> lists exactly which knobs to bump for production-grade results.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa2c0661",
+   "metadata": {},
+   "source": [
+    "## 1. Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa4f6e73",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T20:30:59.672328Z",
+     "iopub.status.busy": "2026-05-15T20:30:59.671856Z",
+     "iopub.status.idle": "2026-05-15T20:31:02.648371Z",
+     "shell.execute_reply": "2026-05-15T20:31:02.645229Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from ase.build import bulk\n",
+    "from ase.calculators.emt import EMT\n",
+    "\n",
+    "from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic\n",
+    "\n",
+    "# fcc Al conventional cell (phonopy primitivises to a 1-atom primitive).\n",
+    "structure = bulk(\"Al\", \"fcc\", a=4.05, cubic=True)\n",
+    "\n",
+    "ase_engine = ASEEngine(\n",
+    "    EngineInput=CalcInputStatic(),\n",
+    "    calculator=EMT(),\n",
+    "    working_directory=\"_runs\",\n",
+    ")\n",
+    "\n",
+    "# Small FC2 supercell (2x2x2 = 32 atoms) keeps wall time low for teaching.\n",
+    "fc2_sc = 2 * np.eye(3, dtype=int)\n",
+    "\n",
+    "# 9-point T grid from 0 K to 800 K (100 K spacing) — coarse but adequate to\n",
+    "# eyeball the F(T)/S(T)/Cv(T) curves.\n",
+    "T_grid = np.arange(0, 801, 100)\n",
+    "\n",
+    "print(f\"structure: {structure.symbols}, n_atoms={len(structure)}\")\n",
+    "print(f\"T grid: {T_grid}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b69f06c8",
+   "metadata": {},
+   "source": [
+    "## 2. Harmonic free energy\n",
+    "\n",
+    "Fixed-volume FC2 phonons via phonopy. Returns `F(T)`, `S(T)`, `C_v(T)` at the input\n",
+    "reference volume. F at the lowest T is the zero-point energy.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "030b65ef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T20:31:02.652233Z",
+     "iopub.status.busy": "2026-05-15T20:31:02.651658Z",
+     "iopub.status.idle": "2026-05-15T20:31:06.149192Z",
+     "shell.execute_reply": "2026-05-15T20:31:06.146246Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from pyiron_workflow_atomistics.physics.free_energy import harmonic_free_energy\n",
+    "\n",
+    "wf_h = harmonic_free_energy(\n",
+    "    structure=structure,\n",
+    "    engine=ase_engine,\n",
+    "    fc2_supercell_matrix=fc2_sc,\n",
+    "    temperatures=T_grid,\n",
+    "    working_directory=\"_runs\",\n",
+    "    subdir=\"harmonic\",\n",
+    ")\n",
+    "out_harm = wf_h.run()\n",
+    "out_harm = out_harm[\"free_energy_output\"] if isinstance(out_harm, dict) else out_harm\n",
+    "\n",
+    "print(f\"mode={out_harm.mode}, n_atoms={out_harm.n_atoms}, n_primitive=\"\n",
+    "      f\"{out_harm.report['n_atoms_primitive']}\")\n",
+    "print(f\"F(0 K) = {out_harm.free_energy_array[0]:.4f} eV/atom (zero-point energy)\")\n",
+    "print(f\"F(300 K) ≈ {np.interp(300, out_harm.temperature_array, out_harm.free_energy_array):.4f} eV/atom\")\n",
+    "\n",
+    "fig, (a1, a2, a3) = plt.subplots(1, 3, figsize=(12, 3.5))\n",
+    "a1.plot(out_harm.temperature_array, out_harm.free_energy_array)\n",
+    "a1.set_xlabel(\"T (K)\"); a1.set_ylabel(\"F (eV/atom)\"); a1.set_title(\"Harmonic F(T)\")\n",
+    "a2.plot(out_harm.temperature_array, out_harm.entropy_array)\n",
+    "a2.set_xlabel(\"T (K)\"); a2.set_ylabel(\"S (eV/K/atom)\"); a2.set_title(\"S(T)\")\n",
+    "a3.plot(out_harm.temperature_array, out_harm.heat_capacity_array)\n",
+    "a3.set_xlabel(\"T (K)\"); a3.set_ylabel(\"Cv (eV/K/atom)\"); a3.set_title(\"Cv(T)\")\n",
+    "plt.tight_layout(); plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2283e28e",
+   "metadata": {},
+   "source": [
+    "## 3. Quasiharmonic free energy (QHA)\n",
+    "\n",
+    "Volume sweep + per-volume harmonic free energy → `phonopy.qha.QHA` gives\n",
+    "`G(T,P)`, `V*(T,P)`, `B(T,P)`, `α(T,P)`. At `pressure=0`, `gibbs_free_energy_array`\n",
+    "is the Helmholtz free energy at the thermally expanded volume.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15ea6d33",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T20:31:06.153086Z",
+     "iopub.status.busy": "2026-05-15T20:31:06.152706Z",
+     "iopub.status.idle": "2026-05-15T20:31:18.851305Z",
+     "shell.execute_reply": "2026-05-15T20:31:18.847796Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from pyiron_workflow_atomistics.physics.free_energy import quasiharmonic_free_energy\n",
+    "\n",
+    "wf_q = quasiharmonic_free_energy(\n",
+    "    structure=structure,\n",
+    "    engine=ase_engine,\n",
+    "    fc2_supercell_matrix=fc2_sc,\n",
+    "    temperatures=T_grid,\n",
+    "    strain_range=(-0.03, 0.03),\n",
+    "    num_volumes=5,        # teaching default; bump to >=7 for production\n",
+    "    pressure=0.0,         # GPa\n",
+    "    working_directory=\"_runs\",\n",
+    "    subdir=\"qha\",\n",
+    ")\n",
+    "out_qha = wf_q.run()\n",
+    "out_qha = out_qha[\"free_energy_output\"] if isinstance(out_qha, dict) else out_qha\n",
+    "\n",
+    "print(f\"mode={out_qha.mode}\")\n",
+    "print(f\"V*(0 K)   = {out_qha.equilibrium_volume_array[0]:.4f} Å³/atom\")\n",
+    "print(f\"V*(800 K) = {out_qha.equilibrium_volume_array[-1]:.4f} Å³/atom\")\n",
+    "print(f\"α(300 K)  ≈ {np.interp(300, out_qha.temperature_array, out_qha.thermal_expansion_array):.3e} 1/K\")\n",
+    "\n",
+    "fig, (a1, a2) = plt.subplots(1, 2, figsize=(9, 3.5))\n",
+    "a1.plot(out_qha.temperature_array, out_qha.equilibrium_volume_array)\n",
+    "a1.set_xlabel(\"T (K)\"); a1.set_ylabel(\"V* (Å³/atom)\"); a1.set_title(\"QHA equilibrium volume V*(T)\")\n",
+    "a2.plot(out_harm.temperature_array, out_harm.free_energy_array, label=\"harmonic (fixed V)\")\n",
+    "a2.plot(out_qha.temperature_array, out_qha.gibbs_free_energy_array, label=\"QHA G(T, P=0)\")\n",
+    "a2.set_xlabel(\"T (K)\"); a2.set_ylabel(\"F or G (eV/atom)\"); a2.legend()\n",
+    "a2.set_title(\"Harmonic vs QHA\")\n",
+    "plt.tight_layout(); plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d784075",
+   "metadata": {},
+   "source": [
+    "## 4. Anharmonic free energy (dynaphopy, single *T*)\n",
+    "\n",
+    "MD trajectory + dynaphopy projection at one temperature gives the *renormalised*\n",
+    "harmonic spectrum, which we sum into a Bose–Einstein free energy. Captures\n",
+    "soft-mode renormalisation at the cost of one finite-*T* MD run.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf0f28aa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T20:31:18.855648Z",
+     "iopub.status.busy": "2026-05-15T20:31:18.855239Z",
+     "iopub.status.idle": "2026-05-15T20:33:41.880172Z",
+     "shell.execute_reply": "2026-05-15T20:33:41.876292Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from pyiron_workflow_atomistics.physics.free_energy import (\n",
+    "    anharmonic_free_energy_dynaphopy,\n",
+    ")\n",
+    "\n",
+    "wf_a = anharmonic_free_energy_dynaphopy(\n",
+    "    structure=structure,\n",
+    "    engine=ase_engine,\n",
+    "    fc2_supercell_matrix=fc2_sc,\n",
+    "    temperature=300.0,\n",
+    "    production_steps=2000,    # teaching default; bump to >=30_000 for production\n",
+    "    q_mesh=(5, 5, 5),         # teaching default; bump to (11, 11, 11) or denser\n",
+    "    working_directory=\"_runs\",\n",
+    "    subdir=\"anharmonic_T300\",\n",
+    ")\n",
+    "out_anh_T = wf_a.run()\n",
+    "out_anh_T = out_anh_T[\"free_energy_output\"] if isinstance(out_anh_T, dict) else out_anh_T\n",
+    "\n",
+    "F_harm_300 = float(np.interp(300.0, out_harm.temperature_array, out_harm.free_energy_array))\n",
+    "print(f\"F_harmonic(300 K)         = {F_harm_300:.4f} eV/atom\")\n",
+    "print(f\"F_anharm (dynaphopy 300K) = {out_anh_T.free_energy:.4f} eV/atom\")\n",
+    "print(f\"Δ (anharm - harm)         = {out_anh_T.free_energy - F_harm_300:+.4f} eV/atom\")\n",
+    "print(f\"n_guarded_modes           = {out_anh_T.report.get('n_guarded_modes', 'n/a')}\")\n",
+    "\n",
+    "# Mode-by-mode renormalisation: ω_harmonic vs ω_renormalised\n",
+    "fig, ax = plt.subplots(figsize=(6, 3.5))\n",
+    "ax.plot(out_anh_T.harmonic_frequencies.ravel(),\n",
+    "        out_anh_T.renormalised_frequencies.ravel(), \"o\", ms=3)\n",
+    "lim = (\n",
+    "    float(min(out_anh_T.harmonic_frequencies.min(), out_anh_T.renormalised_frequencies.min())),\n",
+    "    float(max(out_anh_T.harmonic_frequencies.max(), out_anh_T.renormalised_frequencies.max())),\n",
+    ")\n",
+    "ax.plot(lim, lim, \"k--\", lw=1, label=\"ω_renorm = ω_harm\")\n",
+    "ax.set_xlabel(\"ω_harmonic (THz)\")\n",
+    "ax.set_ylabel(\"ω_renormalised (THz)\")\n",
+    "ax.set_title(\"Dynaphopy mode renormalisation at 300 K\")\n",
+    "ax.legend()\n",
+    "plt.tight_layout(); plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f087edc",
+   "metadata": {},
+   "source": [
+    "## 5. Anharmonic free energy (dynaphopy, T-grid)\n",
+    "\n",
+    "Renormalised-harmonic at each *T*, stacked into `F(T)` with `S(T)`/`Cv(T)`\n",
+    "recovered by finite-differencing. Each *T* is an independent MD + dynaphopy\n",
+    "projection, so this scales linearly with the number of temperatures.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08c3f4bc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T20:33:41.885839Z",
+     "iopub.status.busy": "2026-05-15T20:33:41.885046Z",
+     "iopub.status.idle": "2026-05-15T20:38:25.617321Z",
+     "shell.execute_reply": "2026-05-15T20:38:25.614717Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from pyiron_workflow_atomistics.physics.free_energy import (\n",
+    "    anharmonic_free_energy_dynaphopy_tdi,\n",
+    ")\n",
+    "\n",
+    "wf_tdi = anharmonic_free_energy_dynaphopy_tdi(\n",
+    "    structure=structure,\n",
+    "    engine=ase_engine,\n",
+    "    fc2_supercell_matrix=fc2_sc,\n",
+    "    temperatures=(300.0, 600.0),     # teaching default; bump to (200, 400, 600, 800) for a finer sweep\n",
+    "    production_steps=2000,           # teaching default\n",
+    "    q_mesh=(5, 5, 5),                # teaching default\n",
+    "    working_directory=\"_runs\",\n",
+    "    subdir=\"anharmonic_tdi\",\n",
+    ")\n",
+    "out_anh_tdi = wf_tdi.run()\n",
+    "out_anh_tdi = out_anh_tdi[\"free_energy_output\"] if isinstance(out_anh_tdi, dict) else out_anh_tdi\n",
+    "\n",
+    "print(f\"mode={out_anh_tdi.mode}\")\n",
+    "print(f\"temperatures = {out_anh_tdi.temperature_array}\")\n",
+    "print(f\"F_anharm(T)  = {out_anh_tdi.free_energy_array}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3819ad69",
+   "metadata": {},
+   "source": [
+    "## 6. Anharmonic free energy (calphy, Frenkel–Ladd TI)\n",
+    "\n",
+    "Full anharmonic free energy via thermodynamic integration from an Einstein-crystal\n",
+    "reference. Requires the `[free-energy]` extras *and* a working `lmp` binary on `PATH`.\n",
+    "The cell is wrapped in `try/except` so it skips gracefully when either is missing.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b1721555",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T20:38:25.622190Z",
+     "iopub.status.busy": "2026-05-15T20:38:25.621722Z",
+     "iopub.status.idle": "2026-05-15T20:38:25.703075Z",
+     "shell.execute_reply": "2026-05-15T20:38:25.700117Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Section 6 — Anharmonic (calphy TI) — needs [free-energy] extras + lmp on PATH\n",
+    "out_calphy = None\n",
+    "try:\n",
+    "    from shutil import which\n",
+    "    if which(\"lmp\") is None:\n",
+    "        raise RuntimeError(\"`lmp` binary not on PATH\")\n",
+    "    from pyiron_workflow_lammps.engine import LammpsEngine\n",
+    "    from pyiron_workflow_atomistics.physics.free_energy import (\n",
+    "        LammpsPotential,\n",
+    "        reversible_scaling_temperature,\n",
+    "    )\n",
+    "    lammps_engine = LammpsEngine(command=\"lmp\")\n",
+    "    potential = LammpsPotential(\n",
+    "        pair_style=\"eam/alloy\",\n",
+    "        pair_coeff=\"* * Al99.eam.alloy Al\",\n",
+    "        potential_file=\"Al99.eam.alloy\",\n",
+    "    )\n",
+    "    wf_c = reversible_scaling_temperature(\n",
+    "        structure=structure,\n",
+    "        lammps_engine=lammps_engine,\n",
+    "        potential=potential,\n",
+    "        temperature_range=(200.0, 600.0),\n",
+    "        reference_phase=\"solid\",\n",
+    "        working_directory=\"_runs\",\n",
+    "        subdir=\"calphy_ts\",\n",
+    "    )\n",
+    "    out_calphy = wf_c.run()\n",
+    "    out_calphy = out_calphy[\"free_energy_output\"] if isinstance(out_calphy, dict) else out_calphy\n",
+    "    print(f\"calphy F(300 K) = \"\n",
+    "          f\"{np.interp(300, out_calphy.temperature_array, out_calphy.free_energy_array):.4f} eV/atom\")\n",
+    "except Exception as exc:\n",
+    "    print(f\"calphy step skipped: {exc}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1ceee11",
+   "metadata": {},
+   "source": [
+    "## 7. Composite overlay — `F(T)` from every available method"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3af0a0be",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-15T20:38:25.708673Z",
+     "iopub.status.busy": "2026-05-15T20:38:25.708204Z",
+     "iopub.status.idle": "2026-05-15T20:38:26.020687Z",
+     "shell.execute_reply": "2026-05-15T20:38:26.018058Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(7, 4.2))\n",
+    "\n",
+    "ax.plot(out_harm.temperature_array, out_harm.free_energy_array,\n",
+    "        label=\"harmonic (fixed V)\", lw=2)\n",
+    "ax.plot(out_qha.temperature_array, out_qha.gibbs_free_energy_array,\n",
+    "        label=\"QHA G(T, P=0)\", lw=2)\n",
+    "\n",
+    "# Single-T anharmonic point\n",
+    "ax.plot([out_anh_T.temperature], [out_anh_T.free_energy], \"s\",\n",
+    "        ms=9, label=\"dynaphopy (single T=300 K)\")\n",
+    "\n",
+    "# T-grid anharmonic curve\n",
+    "ax.plot(out_anh_tdi.temperature_array, out_anh_tdi.free_energy_array, \"o-\",\n",
+    "        label=\"dynaphopy T-grid\")\n",
+    "\n",
+    "if out_calphy is not None and out_calphy.temperature_array is not None:\n",
+    "    ax.plot(out_calphy.temperature_array, out_calphy.free_energy_array,\n",
+    "            label=\"calphy TI\", lw=2)\n",
+    "\n",
+    "ax.set_xlabel(\"T (K)\"); ax.set_ylabel(\"F or G (eV/atom)\")\n",
+    "ax.set_title(\"Free energy of fcc Al — four methods\")\n",
+    "ax.legend()\n",
+    "plt.tight_layout(); plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b608d91",
+   "metadata": {},
+   "source": [
+    "## Notes — what each curve captures, and how to push to production\n",
+    "\n",
+    "### Physical interpretation\n",
+    "\n",
+    "- **Harmonic** uses a fixed reference volume — it tends to *over*estimate `F` at high `T`\n",
+    "  because the lattice cannot expand with temperature. Best for `T ≲ Θ_D/2`.\n",
+    "- **Quasiharmonic (QHA)** lets the lattice expand isobarically; the QHA curve should\n",
+    "  fall *below* the harmonic curve at high `T`. Captures thermal expansion exactly,\n",
+    "  but still uses harmonic phonons at each volume.\n",
+    "- **Dynaphopy renormalised** captures finite-T soft-mode renormalisation through the\n",
+    "  MD-projected spectrum, at fixed reference volume. Combine with QHA in a follow-up\n",
+    "  workflow to get *both* thermal expansion *and* mode renormalisation.\n",
+    "- **Calphy TI** is the reference: full classical anharmonicity via Frenkel–Ladd\n",
+    "  thermodynamic integration. Most expensive, no harmonic approximation anywhere.\n",
+    "\n",
+    "### Production knobs\n",
+    "\n",
+    "The defaults above are tuned for fast execution under CI (~10 min total). For\n",
+    "publication-grade accuracy bump the following:\n",
+    "\n",
+    "| section                       | knob                 | teaching | production              |\n",
+    "|-------------------------------|----------------------|----------|-------------------------|\n",
+    "| Harmonic / QHA                | `T_grid`             | 9 pts    | `np.arange(0, 1001, 50)` (21 pts) |\n",
+    "| Harmonic / QHA                | `fc2_supercell_matrix` | 2x2x2 (32 at) | 3x3x3 (108 at) or 4x4x4 (256 at) |\n",
+    "| QHA                           | `num_volumes`        | 5        | 7–9                     |\n",
+    "| Dynaphopy (single T + T-grid) | `production_steps`   | 2000     | >=30_000                |\n",
+    "| Dynaphopy (single T + T-grid) | `q_mesh`             | (5,5,5)  | (11,11,11) or denser    |\n",
+    "| Dynaphopy T-grid              | `temperatures`       | 2 pts    | >=4 (e.g. 200/400/600/800) |\n",
+    "| Calphy TI                     | `temperature_range`  | 200–600  | full range of interest  |\n",
+    "\n",
+    "For genuinely large supercells, you will also want to parallelise the dynaphopy MD\n",
+    "trajectories per *T* — each one is independent.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyiron_workflow_atomistics/physics/free_energy/__init__.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/__init__.py
@@ -1,25 +1,30 @@
-"""calphy-backed free-energy workflows.
+"""Free-energy workflows: calphy + phonopy harmonic / QHA + dynaphopy anharmonic.
 
 Public API
 ----------
-
 Dataclasses:
-    LammpsPotential  - pair_style + pair_coeff + optional potential_file
+    LammpsPotential  - calphy-only: pair_style + pair_coeff + optional potential_file
     FreeEnergyOutput - typed result of every node
 
-Function-nodes (one per calphy mode):
-    free_energy                       - mode='fe'
-    reversible_scaling_temperature    - mode='ts'
-    reversible_scaling_pressure       - mode='pscale'
-    melting_temperature               - mode='melting_temperature'
-    alchemy                           - mode='alchemy'
-    composition_scaling               - mode='composition_scaling'
+calphy function-nodes (one per mode):
+    free_energy, reversible_scaling_temperature, reversible_scaling_pressure,
+    melting_temperature, alchemy, composition_scaling
 
-All node-and-adapter imports defer ``calphy`` and ``pyiron_workflow_lammps``
-imports to node-body call time, so importing this subpackage does not
-require the ``[free-energy]`` extra.
+Phonon free-energy macros (NEW):
+    harmonic_free_energy             - phonopy FC2 at a fixed volume
+    quasiharmonic_free_energy        - phonopy.qha.QHA on top of harmonic_free_energy
+    anharmonic_free_energy_dynaphopy - dynaphopy renormalised harmonic at one T
+    anharmonic_free_energy_dynaphopy_tdi - dynaphopy renormalised harmonic over a T grid
+
+All node-and-adapter imports defer ``calphy`` / ``phonopy`` / ``dynaphopy`` /
+``pyiron_workflow_lammps`` imports to node-body call time, so importing this
+subpackage does not require any specific optional extra.
 """
 
+from pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy import (
+    anharmonic_free_energy_dynaphopy,
+    anharmonic_free_energy_dynaphopy_tdi,
+)
 from pyiron_workflow_atomistics.physics.free_energy.calphy import (
     alchemy,
     composition_scaling,
@@ -28,16 +33,26 @@ from pyiron_workflow_atomistics.physics.free_energy.calphy import (
     reversible_scaling_pressure,
     reversible_scaling_temperature,
 )
+from pyiron_workflow_atomistics.physics.free_energy.harmonic import (
+    harmonic_free_energy,
+)
 from pyiron_workflow_atomistics.physics.free_energy.inputs import LammpsPotential
 from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+from pyiron_workflow_atomistics.physics.free_energy.quasiharmonic import (
+    quasiharmonic_free_energy,
+)
 
 __all__ = [
     "FreeEnergyOutput",
     "LammpsPotential",
     "alchemy",
+    "anharmonic_free_energy_dynaphopy",
+    "anharmonic_free_energy_dynaphopy_tdi",
     "composition_scaling",
     "free_energy",
+    "harmonic_free_energy",
     "melting_temperature",
+    "quasiharmonic_free_energy",
     "reversible_scaling_pressure",
     "reversible_scaling_temperature",
 ]

--- a/pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py
@@ -17,9 +17,9 @@ from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
 
 @pwf.as_function_node("free_energy_per_atom", "entropy_per_atom", "cv_per_atom")
 def _free_energy_from_spectrum(
-    frequencies: np.ndarray,         # (n_q, n_band) THz
-    q_weights: np.ndarray,           # (n_q,), sums to 1
-    temperature: float,              # K
+    frequencies: np.ndarray,  # (n_q, n_band) THz
+    q_weights: np.ndarray,  # (n_q,), sums to 1
+    temperature: float,  # K
     n_atoms_primitive: int,
 ) -> tuple[float, float, float]:
     """Harmonic free energy / entropy / Cv on a discrete (q, band) frequency grid.
@@ -80,9 +80,7 @@ def _free_energy_from_spectrum(
         with np.errstate(over="ignore", invalid="ignore"):
             expm1_x = np.expm1(x)
             # Guard expm1 underflow for ultra-soft modes (same condition Cv uses).
-            bose_term = np.where(
-                is_acoustic_gamma | (expm1_x == 0), 0.0, x / expm1_x
-            )
+            bose_term = np.where(is_acoustic_gamma | (expm1_x == 0), 0.0, x / expm1_x)
             S_modes = kB_eV_per_K * (bose_term - log_term)
 
         # Cv per mode:  C_v = k_B (x^2 exp(x)) / (exp(x)−1)^2
@@ -280,14 +278,10 @@ def _pack_anharmonic_dynaphopy_output(
         entropy=float(entropy_per_atom),
         heat_capacity=float(cv_per_atom),
         harmonic_frequencies=np.asarray(md_phonon_output.harmonic_frequencies),
-        renormalised_frequencies=np.asarray(
-            md_phonon_output.renormalised_frequencies
-        ),
+        renormalised_frequencies=np.asarray(md_phonon_output.renormalised_frequencies),
         linewidths=np.asarray(md_phonon_output.linewidths),
         q_mesh=q_mesh_tuple,
-        dynaphopy_handle=(
-            md_phonon_output.quasiparticle if keep_handles else None
-        ),
+        dynaphopy_handle=(md_phonon_output.quasiparticle if keep_handles else None),
         phonopy_handle=md_phonon_output.phonopy if keep_handles else None,
     )
 

--- a/pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py
@@ -1,0 +1,88 @@
+"""Anharmonic free energy via dynaphopy MD-projection — single T and TDI over T."""
+
+from __future__ import annotations
+
+import numpy as np
+import pyiron_workflow as pwf
+
+
+@pwf.as_function_node("free_energy_per_atom", "entropy_per_atom", "cv_per_atom")
+def _free_energy_from_spectrum(
+    frequencies: np.ndarray,         # (n_q, n_band) THz
+    q_weights: np.ndarray,           # (n_q,), sums to 1
+    temperature: float,              # K
+    n_atoms_primitive: int,
+) -> tuple[float, float, float]:
+    """Harmonic free energy / entropy / Cv on a discrete (q, band) frequency grid.
+
+    F = sum_q w_q * sum_b [ ℏω_qb/2 + k_B T ln(1 − exp(−ℏω_qb / k_B T)) ]
+
+    Acoustic modes at Γ are zeroed upstream by dynaphopy's
+    `_project_with_dynaphopy` (positions[:3]=0 at q==0); any ω ≤ 0 remaining
+    is treated as imaginary and rejected.
+
+    Units
+    -----
+    Frequencies in THz. Returned F / S / Cv per primitive-cell atom, in
+    eV / (eV/K) / (eV/K) respectively.
+    """
+    import scipy.constants as c
+
+    freqs = np.asarray(frequencies, dtype=float)
+    weights = np.asarray(q_weights, dtype=float)
+    if not np.isclose(weights.sum(), 1.0):
+        raise ValueError(f"q_weights must sum to 1, got {weights.sum()}")
+    if freqs.ndim != 2 or freqs.shape[0] != weights.shape[0]:
+        raise ValueError(
+            f"frequencies shape {freqs.shape} incompatible with q_weights shape "
+            f"{weights.shape}"
+        )
+
+    # Acoustic-at-Γ modes (already zeroed upstream) are dropped from the sum.
+    is_acoustic_gamma = freqs == 0.0
+    active = freqs[~is_acoustic_gamma]
+    imag_mask = active < 0
+    if imag_mask.any():
+        raise ValueError(
+            f"Spectrum has {int(imag_mask.sum())} imaginary modes; "
+            "harmonic free energy is undefined for an unstable spectrum."
+        )
+
+    omega_rad_s = freqs * 1e12 * 2 * np.pi
+    hbar_omega_eV = c.hbar * omega_rad_s / c.eV  # (n_q, n_band)
+
+    if temperature <= 0:
+        # T=0: only zero-point energy contributes; S and Cv are zero.
+        F_modes = 0.5 * hbar_omega_eV
+        F_modes = np.where(is_acoustic_gamma, 0.0, F_modes)
+        F = float((weights[:, None] * F_modes).sum() / n_atoms_primitive)
+        S = 0.0
+        Cv = 0.0
+    else:
+        kT_eV = c.Boltzmann * temperature / c.eV
+        x = hbar_omega_eV / kT_eV
+        # ln(1 − exp(−x)) — stable; modes with x huge → ln(1) = 0.
+        log_term = np.where(is_acoustic_gamma, 0.0, np.log1p(-np.exp(-x)))
+        F_modes = 0.5 * hbar_omega_eV + kT_eV * log_term
+        F_modes = np.where(is_acoustic_gamma, 0.0, F_modes)
+
+        # Entropy per mode:  S = k_B [ x/(exp(x)−1) − ln(1 − exp(−x)) ]
+        kB_eV_per_K = c.Boltzmann / c.eV
+        with np.errstate(over="ignore", invalid="ignore"):
+            S_modes = kB_eV_per_K * (
+                np.where(is_acoustic_gamma, 0.0, x / np.expm1(x)) - log_term
+            )
+
+        # Cv per mode:  C_v = k_B (x^2 exp(x)) / (exp(x)−1)^2
+        with np.errstate(over="ignore", invalid="ignore"):
+            denom = np.expm1(x) ** 2
+            num = (x**2) * np.exp(x)
+            Cv_modes = kB_eV_per_K * np.where(
+                is_acoustic_gamma | (denom == 0), 0.0, num / denom
+            )
+
+        F = float((weights[:, None] * F_modes).sum() / n_atoms_primitive)
+        S = float((weights[:, None] * S_modes).sum() / n_atoms_primitive)
+        Cv = float((weights[:, None] * Cv_modes).sum() / n_atoms_primitive)
+
+    return F, S, Cv

--- a/pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py
@@ -390,3 +390,168 @@ def anharmonic_free_energy_dynaphopy(
         keep_handles=keep_handles,
     )
     return wf.synthesis.outputs.free_energy_output
+
+
+@pwf.as_function_node("per_T_outputs")
+def _sweep_dynaphopy_over_T(
+    structure: Atoms,
+    engine: Engine,
+    fc2_supercell_matrix,
+    temperatures,
+    equilibration_steps: int,
+    production_steps: int,
+    time_step: float,
+    thermostat_time_constant: float,
+    seed,
+    q_mesh,
+    working_directory: str,
+) -> list:
+    """Run ``anharmonic_free_energy_dynaphopy`` at each T; return list of outputs.
+
+    The loop over ``temperatures`` lives in a function-node (rather than the
+    macro body) so it executes with concrete values at run time instead of
+    against pyiron_workflow ``UserInput`` proxies at graph-build time.
+    """
+    outputs: list = []
+    for i, T in enumerate(temperatures):
+        sub_seed = None if seed is None else int(seed) + i
+        sub_wf = anharmonic_free_energy_dynaphopy(
+            structure=structure,
+            engine=engine,
+            fc2_supercell_matrix=fc2_supercell_matrix,
+            temperature=float(T),
+            equilibration_steps=equilibration_steps,
+            production_steps=production_steps,
+            time_step=time_step,
+            thermostat_time_constant=thermostat_time_constant,
+            seed=sub_seed,
+            q_mesh=q_mesh,
+            working_directory=working_directory,
+            subdir=f"T_{i:03d}_{float(T):.1f}K",
+            keep_handles=False,
+        )
+        result = sub_wf.run()
+        # Unwrap DotDict if pyiron_workflow returned the macro output that way.
+        if isinstance(result, dict):
+            result = result["free_energy_output"]
+        outputs.append(result)
+    return outputs
+
+
+@pwf.as_function_node("free_energy_output")
+def _stack_tdi_outputs(
+    per_T_outputs: list,
+    structure,
+    temperatures,
+) -> FreeEnergyOutput:
+    """Aggregate independent-T dynaphopy free energies into one FreeEnergyOutput.
+
+    Computes S(T) = -∂F/∂T and Cv(T) = -T ∂²F/∂T² via ``np.gradient`` central
+    differences over the supplied ``temperatures``. With <2 temperatures S is
+    NaN; with <3, Cv is NaN and ``report["derivative_warning"]`` is True.
+    """
+    T = np.asarray(temperatures, dtype=float)
+    F = np.asarray([o.free_energy for o in per_T_outputs], dtype=float)
+    n_T = T.size
+
+    dF_dT = None
+    if n_T >= 2:
+        dF_dT = np.gradient(F, T)
+        S = -dF_dT
+    else:
+        S = np.full(n_T, np.nan)
+    if n_T >= 3 and dF_dT is not None:
+        d2F_dT2 = np.gradient(dF_dT, T)
+        Cv = -T * d2F_dT2
+    else:
+        Cv = np.full(n_T, np.nan)
+
+    elements = (
+        list(dict.fromkeys(structure.get_chemical_symbols()))
+        if hasattr(structure, "get_chemical_symbols")
+        else ["?"]
+    )
+    renorm = np.stack(
+        [np.asarray(o.renormalised_frequencies) for o in per_T_outputs], axis=0
+    )
+    lw = np.stack([np.asarray(o.linewidths) for o in per_T_outputs], axis=0)
+
+    derivative_warning = n_T < 3
+    return FreeEnergyOutput(
+        mode="anharmonic_dynaphopy_tdi",
+        reference_phase="solid",
+        free_energy=float(F[0]),
+        free_energy_error=0.0,
+        temperature=float(T[0]),
+        pressure=0.0,
+        n_atoms=len(structure),
+        elements=elements,
+        simfolder=per_T_outputs[0].simfolder if per_T_outputs else "",
+        report={
+            "method": "anharmonic_dynaphopy_tdi",
+            "derivative_warning": bool(derivative_warning),
+            "per_T_md_health": [o.report.get("md_health") for o in per_T_outputs],
+        },
+        temperature_array=T,
+        free_energy_array=F,
+        entropy_array=S,
+        heat_capacity_array=Cv,
+        renormalised_frequencies_per_T=renorm,
+        linewidths_per_T=lw,
+    )
+
+
+@pwf.api.as_macro_node("free_energy_output")
+def anharmonic_free_energy_dynaphopy_tdi(
+    wf,
+    structure: Atoms,
+    engine: Engine,
+    fc2_supercell_matrix,
+    temperatures=(100.0, 200.0, 300.0, 400.0, 500.0),
+    equilibration_steps: int = 2000,
+    production_steps: int = 10000,
+    time_step: float = 1.0,
+    thermostat_time_constant: float = 100.0,
+    seed: int | None = None,
+    q_mesh=(11, 11, 11),
+    working_directory: str = ".",
+    subdir: str = "anharmonic_free_energy_dynaphopy_tdi",
+    keep_handles: bool = False,
+):
+    """Anharmonic F_anharm(T) on a T grid — renormalised-harmonic at each T.
+
+    Runs ``anharmonic_free_energy_dynaphopy`` independently at each requested
+    temperature (each T gets its own MD trajectory + dynaphopy projection +
+    harmonic-formula sum on the renormalised spectrum), then stacks the
+    per-T results into a single ``FreeEnergyOutput`` and derives S(T) and
+    Cv(T) by finite-differencing F(T) with ``np.gradient``.
+
+    Despite the ``_tdi`` suffix, this is *not* a full ⟨∂H/∂λ⟩ thermodynamic
+    integration over a coupling parameter — see spec
+    ``docs/design/specs/2026-05-15-free-energy-consolidation-design.md`` for
+    the renormalised-harmonic-over-T justification.
+    """
+    wf.paths = _resolve_simfolder(
+        engine=engine,
+        working_directory=working_directory,
+        subdir=subdir,
+    )
+    wf.sweep = _sweep_dynaphopy_over_T(
+        structure=structure,
+        engine=engine,
+        fc2_supercell_matrix=fc2_supercell_matrix,
+        temperatures=temperatures,
+        equilibration_steps=equilibration_steps,
+        production_steps=production_steps,
+        time_step=time_step,
+        thermostat_time_constant=thermostat_time_constant,
+        seed=seed,
+        q_mesh=q_mesh,
+        working_directory=wf.paths.outputs.simfolder,
+    )
+    wf.stack = _stack_tdi_outputs(
+        per_T_outputs=wf.sweep.outputs.per_T_outputs,
+        structure=structure,
+        temperatures=temperatures,
+    )
+    return wf.stack.outputs.free_energy_output

--- a/pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py
@@ -69,13 +69,16 @@ def _free_energy_from_spectrum(
         # Entropy per mode:  S = k_B [ x/(exp(x)−1) − ln(1 − exp(−x)) ]
         kB_eV_per_K = c.Boltzmann / c.eV
         with np.errstate(over="ignore", invalid="ignore"):
-            S_modes = kB_eV_per_K * (
-                np.where(is_acoustic_gamma, 0.0, x / np.expm1(x)) - log_term
+            expm1_x = np.expm1(x)
+            # Guard expm1 underflow for ultra-soft modes (same condition Cv uses).
+            bose_term = np.where(
+                is_acoustic_gamma | (expm1_x == 0), 0.0, x / expm1_x
             )
+            S_modes = kB_eV_per_K * (bose_term - log_term)
 
         # Cv per mode:  C_v = k_B (x^2 exp(x)) / (exp(x)−1)^2
         with np.errstate(over="ignore", invalid="ignore"):
-            denom = np.expm1(x) ** 2
+            denom = expm1_x**2
             num = (x**2) * np.exp(x)
             Cv_modes = kB_eV_per_K * np.where(
                 is_acoustic_gamma | (denom == 0), 0.0, num / denom

--- a/pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py
@@ -4,6 +4,15 @@ from __future__ import annotations
 
 import numpy as np
 import pyiron_workflow as pwf
+from ase import Atoms
+
+from pyiron_workflow_atomistics.engine import Engine
+from pyiron_workflow_atomistics.physics.free_energy.harmonic import _resolve_simfolder
+from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+from pyiron_workflow_atomistics.physics.phonons._compat import require_phonopy
+from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
+    calculate_phonon_md_renormalisation,
+)
 
 
 @pwf.as_function_node("free_energy_per_atom", "entropy_per_atom", "cv_per_atom")
@@ -89,3 +98,262 @@ def _free_energy_from_spectrum(
         Cv = float((weights[:, None] * Cv_modes).sum() / n_atoms_primitive)
 
     return F, S, Cv
+
+
+def _commensurate_q_points(structure: Atoms, q_mesh) -> tuple[np.ndarray, np.ndarray]:
+    """Return (q_points, weights) on a commensurate Monkhorst-Pack mesh.
+
+    Phonopy's `GridPoints` lays out the mesh on the *primitive* cell that
+    phonopy infers via primitive_matrix="auto". We mirror that convention
+    here so the mesh is consistent with the FC2 view dynaphopy projects into.
+    Weights sum to 1.
+
+    Uses ``phonopy.structure.grid_points.GridPoints`` directly so the mesh
+    can be built before force constants exist — ``Phonopy.run_mesh`` requires
+    a built dynamical matrix, which we do not have at this stage.
+    """
+    require_phonopy()
+    import phonopy
+    from phonopy.structure.atoms import PhonopyAtoms
+    from phonopy.structure.grid_points import GridPoints
+
+    unitcell = PhonopyAtoms(
+        symbols=list(structure.get_chemical_symbols()),
+        positions=structure.get_positions(),
+        cell=np.asarray(structure.get_cell()),
+        masses=structure.get_masses(),
+    )
+    phonon = phonopy.Phonopy(
+        unitcell=unitcell,
+        supercell_matrix=np.eye(3, dtype=int),
+        primitive_matrix="auto",
+    )
+    primitive = phonon.primitive
+    # phonopy reciprocal-lattice convention: column vectors a*, b*, c*.
+    reciprocal_lattice = np.linalg.inv(np.asarray(primitive.cell)).T
+    rotations = phonon.primitive_symmetry.pointgroup_operations
+
+    gp = GridPoints(
+        mesh_numbers=np.asarray(list(q_mesh), dtype="int64"),
+        reciprocal_lattice=reciprocal_lattice,
+        rotations=rotations,
+        is_mesh_symmetry=True,
+        is_gamma_center=True,
+    )
+    q_points = np.asarray(gp.qpoints, dtype=float)
+    weights = np.asarray(gp.weights, dtype=float)
+    weights = weights / weights.sum()
+    return q_points, weights
+
+
+@pwf.as_function_node("q_points", "q_weights")
+def _commensurate_q_points_node(structure: Atoms, q_mesh):
+    """Function-node wrapper for `_commensurate_q_points`.
+
+    Runs the phonopy mesh resolution at execution time rather than at graph
+    construction time, so the macro body never touches proxy ``UserInput``
+    arguments when computing the q-mesh.
+    """
+    q_points, q_weights = _commensurate_q_points(structure, q_mesh)
+    return q_points, q_weights
+
+
+@pwf.as_function_node("n_atoms")
+def _n_atoms_node(structure: Atoms) -> int:
+    """Return ``len(structure)`` at execution time.
+
+    Function-node wrapper so the macro body never calls ``len`` on a proxy
+    ``UserInput`` object — pyiron_workflow proxies don't support ``len``.
+    """
+    return len(structure)
+
+
+@pwf.as_function_node("guarded_frequencies")
+def _guard_unphysical_frequencies(
+    renormalised_frequencies: np.ndarray,
+    harmonic_frequencies: np.ndarray,
+    max_relative_shift: float = 0.5,
+) -> np.ndarray:
+    """Fall back to harmonic frequencies for clearly-unphysical renorm fits.
+
+    dynaphopy fits each (q, band) Lorentzian independently. With short MD
+    trajectories or noisy power spectra, the fit can produce peak positions
+    far from the harmonic value — even at >2x the true frequency — which
+    would inflate the harmonic-formula free energy spuriously.
+
+    Any band whose renormalised frequency differs from its harmonic value by
+    more than ``max_relative_shift`` (default 50%) is replaced by the
+    harmonic value. NaN renormalised entries are also replaced. The check
+    runs per-(q, band) so good fits are preserved.
+    """
+    renorm = np.asarray(renormalised_frequencies, dtype=float)
+    harm = np.asarray(harmonic_frequencies, dtype=float)
+    if renorm.shape != harm.shape:
+        raise ValueError(
+            f"renormalised shape {renorm.shape} != harmonic shape {harm.shape}"
+        )
+
+    out = renorm.copy()
+    # Clamp tiny numerical noise around the acoustic-at-Γ branches (phonopy
+    # leaves these as ~1e-6 THz of either sign). dynaphopy already pins
+    # `renormalised_frequencies[:3]` to 0 at q==0; mirror that on the
+    # harmonic side so the fallback path does not reintroduce sub-µeV
+    # imaginary modes that would trip `_free_energy_from_spectrum`.
+    near_zero_atol = 1e-3  # THz; well below any physical phonon band.
+    harm = np.where(np.abs(harm) < near_zero_atol, 0.0, harm)
+
+    abs_harm = np.abs(harm)
+    relative_shift = np.where(
+        abs_harm > 0,
+        np.abs(renorm - harm) / np.where(abs_harm > 0, abs_harm, 1.0),
+        0.0,
+    )
+    bad = ~np.isfinite(renorm) | (relative_shift > max_relative_shift)
+    out = np.where(bad, harm, out)
+    return out
+
+
+@pwf.as_function_node("free_energy_output")
+def _pack_anharmonic_dynaphopy_output(
+    structure: Atoms,
+    md_phonon_output,
+    q_weights: np.ndarray,
+    free_energy_per_atom: float,
+    entropy_per_atom: float,
+    cv_per_atom: float,
+    temperature: float,
+    q_mesh,
+    simfolder: str,
+    keep_handles: bool,
+) -> FreeEnergyOutput:
+    """Pack F/S/Cv (eV/atom; (eV/K)/atom) plus dynaphopy outputs into FreeEnergyOutput.
+
+    Units follow the ``FreeEnergyOutput`` spec: ``free_energy`` in eV/atom,
+    ``entropy`` / ``heat_capacity`` in (eV/K)/atom. ``_free_energy_from_spectrum``
+    already produces values in these units, so no conversion is needed here.
+    """
+    healthy, issues = md_phonon_output.check_md_health()
+    elements = list(dict.fromkeys(structure.get_chemical_symbols()))
+    q_mesh_tuple = tuple(int(x) for x in q_mesh)
+    return FreeEnergyOutput(
+        mode="anharmonic_dynaphopy",
+        reference_phase="solid",
+        free_energy=float(free_energy_per_atom),
+        free_energy_error=0.0,
+        temperature=float(temperature),
+        pressure=0.0,
+        n_atoms=len(structure),
+        elements=elements,
+        simfolder=simfolder,
+        report={
+            "method": "anharmonic_dynaphopy",
+            "n_md_steps": int(md_phonon_output.n_md_steps),
+            "time_step_fs": float(md_phonon_output.time_step_fs),
+            "md_temperature_mean": float(md_phonon_output.md_temperature_mean),
+            "md_temperature_std": float(md_phonon_output.md_temperature_std),
+            "md_health": {"healthy": bool(healthy), "issues": list(issues)},
+        },
+        entropy=float(entropy_per_atom),
+        heat_capacity=float(cv_per_atom),
+        harmonic_frequencies=np.asarray(md_phonon_output.harmonic_frequencies),
+        renormalised_frequencies=np.asarray(
+            md_phonon_output.renormalised_frequencies
+        ),
+        linewidths=np.asarray(md_phonon_output.linewidths),
+        q_mesh=q_mesh_tuple,
+        dynaphopy_handle=(
+            md_phonon_output.quasiparticle if keep_handles else None
+        ),
+        phonopy_handle=md_phonon_output.phonopy if keep_handles else None,
+    )
+
+
+@pwf.api.as_macro_node("free_energy_output")
+def anharmonic_free_energy_dynaphopy(
+    wf,
+    structure: Atoms,
+    engine: Engine,
+    fc2_supercell_matrix,
+    temperature: float,
+    equilibration_steps: int = 2000,
+    production_steps: int = 10000,
+    time_step: float = 1.0,
+    thermostat_time_constant: float = 100.0,
+    seed: int | None = None,
+    q_mesh=(11, 11, 11),
+    phono3py_output=None,
+    working_directory: str = ".",
+    subdir: str = "anharmonic_free_energy_dynaphopy",
+    keep_handles: bool = False,
+):
+    """Anharmonic free energy at one T via dynaphopy MD projection + harmonic-formula sum.
+
+    Engine must expose ``.calculator`` (inherited from
+    ``calculate_phonon_md_renormalisation``).
+
+    Notes
+    -----
+    The macro passes ``n_atoms_primitive=len(structure)`` to
+    ``_free_energy_from_spectrum`` so the returned F/S/Cv are per *unit-cell*
+    atom — i.e., per atom of the user-supplied ``structure``. This is correct
+    when ``structure`` is itself a primitive cell, but it is also the unit
+    that callers typically expect when ``structure`` is a conventional cell
+    (e.g. ``bulk("Al", "fcc", cubic=True)`` with 4 atoms): dynaphopy returns
+    ``renormalised_frequencies`` with shape ``(n_q, 3 * n_atoms_unitcell)``,
+    so summing over all bands and dividing by ``len(structure)`` gives a
+    per-atom F that matches the per-atom F produced upstream by
+    ``_compute_harmonic_observables``. For genuinely non-primitive non-cubic
+    inputs the result will still be per-unit-cell-atom, which is the consistent
+    convention across the free-energy module.
+    """
+    wf.paths = _resolve_simfolder(
+        engine=engine,
+        working_directory=working_directory,
+        subdir=subdir,
+    )
+    wf.q = _commensurate_q_points_node(structure=structure, q_mesh=q_mesh)
+    wf.n_atoms = _n_atoms_node(structure=structure)
+
+    wf.md_renorm = calculate_phonon_md_renormalisation(
+        structure=structure,
+        engine=wf.paths.outputs.sub_engine,
+        fc2_supercell_matrix=fc2_supercell_matrix,
+        temperature=temperature,
+        equilibration_steps=equilibration_steps,
+        production_steps=production_steps,
+        time_step=time_step,
+        thermostat_time_constant=thermostat_time_constant,
+        seed=seed,
+        q_points=wf.q.outputs.q_points,
+        phono3py_output=phono3py_output,
+        power_spectra=False,
+        keep_handles=True,  # we need .phonopy / .quasiparticle handles to extract data
+    )
+    wf.guarded = _guard_unphysical_frequencies(
+        renormalised_frequencies=(
+            wf.md_renorm.outputs.md_phonon_output.renormalised_frequencies
+        ),
+        harmonic_frequencies=(
+            wf.md_renorm.outputs.md_phonon_output.harmonic_frequencies
+        ),
+    )
+    wf.spectrum = _free_energy_from_spectrum(
+        frequencies=wf.guarded.outputs.guarded_frequencies,
+        q_weights=wf.q.outputs.q_weights,
+        temperature=temperature,
+        # Per-unit-cell-atom: primitive equals unitcell for fcc cubic; see docstring.
+        n_atoms_primitive=wf.n_atoms.outputs.n_atoms,
+    )
+    wf.synthesis = _pack_anharmonic_dynaphopy_output(
+        structure=structure,
+        md_phonon_output=wf.md_renorm.outputs.md_phonon_output,
+        q_weights=wf.q.outputs.q_weights,
+        free_energy_per_atom=wf.spectrum.outputs.free_energy_per_atom,
+        entropy_per_atom=wf.spectrum.outputs.entropy_per_atom,
+        cv_per_atom=wf.spectrum.outputs.cv_per_atom,
+        temperature=temperature,
+        q_mesh=q_mesh,
+        simfolder=wf.paths.outputs.simfolder,
+        keep_handles=keep_handles,
+    )
+    return wf.synthesis.outputs.free_energy_output

--- a/pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py
@@ -168,12 +168,12 @@ def _n_atoms_node(structure: Atoms) -> int:
     return len(structure)
 
 
-@pwf.as_function_node("guarded_frequencies")
+@pwf.as_function_node("guarded_frequencies", "n_guarded")
 def _guard_unphysical_frequencies(
     renormalised_frequencies: np.ndarray,
     harmonic_frequencies: np.ndarray,
     max_relative_shift: float = 0.5,
-) -> np.ndarray:
+):
     """Fall back to harmonic frequencies for clearly-unphysical renorm fits.
 
     dynaphopy fits each (q, band) Lorentzian independently. With short MD
@@ -185,6 +185,9 @@ def _guard_unphysical_frequencies(
     more than ``max_relative_shift`` (default 50%) is replaced by the
     harmonic value. NaN renormalised entries are also replaced. The check
     runs per-(q, band) so good fits are preserved.
+
+    Returns both the guarded array and the count of substituted entries so
+    callers can warn / record how much of the result fell back to harmonic.
     """
     renorm = np.asarray(renormalised_frequencies, dtype=float)
     harm = np.asarray(harmonic_frequencies, dtype=float)
@@ -208,9 +211,10 @@ def _guard_unphysical_frequencies(
         np.abs(renorm - harm) / np.where(abs_harm > 0, abs_harm, 1.0),
         0.0,
     )
-    bad = ~np.isfinite(renorm) | (relative_shift > max_relative_shift)
-    out = np.where(bad, harm, out)
-    return out
+    needs_guard = ~np.isfinite(renorm) | (relative_shift > max_relative_shift)
+    out = np.where(needs_guard, harm, out)
+    n_guarded = int(np.sum(needs_guard))
+    return out, n_guarded
 
 
 @pwf.as_function_node("free_energy_output")
@@ -223,6 +227,7 @@ def _pack_anharmonic_dynaphopy_output(
     cv_per_atom: float,
     temperature: float,
     q_mesh,
+    n_guarded: int,
     simfolder: str,
     keep_handles: bool,
 ) -> FreeEnergyOutput:
@@ -231,10 +236,28 @@ def _pack_anharmonic_dynaphopy_output(
     Units follow the ``FreeEnergyOutput`` spec: ``free_energy`` in eV/atom,
     ``entropy`` / ``heat_capacity`` in (eV/K)/atom. ``_free_energy_from_spectrum``
     already produces values in these units, so no conversion is needed here.
+
+    Records the count of (q, band) entries that fell back to harmonic via
+    ``_guard_unphysical_frequencies`` in ``report["n_guarded_modes"]`` and
+    emits a ``UserWarning`` when any guard fired — the renormalised spectrum
+    was not entirely trusted and the result is a partial harmonic fall-back.
     """
+    import warnings
+
     healthy, issues = md_phonon_output.check_md_health()
     elements = list(dict.fromkeys(structure.get_chemical_symbols()))
     q_mesh_tuple = tuple(int(x) for x in q_mesh)
+    if n_guarded > 0:
+        n_total = int(
+            np.prod(np.asarray(md_phonon_output.renormalised_frequencies).shape)
+        )
+        warnings.warn(
+            f"_guard_unphysical_frequencies replaced {n_guarded}/{n_total} (q, band) "
+            "entries with their harmonic values (renormalisation differed by >50% or was "
+            "NaN). The result reflects a partial fall-back to harmonic; bump "
+            "`production_steps` or `q_mesh` for more trustworthy anharmonic values.",
+            stacklevel=2,
+        )
     return FreeEnergyOutput(
         mode="anharmonic_dynaphopy",
         reference_phase="solid",
@@ -252,6 +275,7 @@ def _pack_anharmonic_dynaphopy_output(
             "md_temperature_mean": float(md_phonon_output.md_temperature_mean),
             "md_temperature_std": float(md_phonon_output.md_temperature_std),
             "md_health": {"healthy": bool(healthy), "issues": list(issues)},
+            "n_guarded_modes": int(n_guarded),
         },
         entropy=float(entropy_per_atom),
         heat_capacity=float(cv_per_atom),
@@ -287,6 +311,14 @@ def anharmonic_free_energy_dynaphopy(
     keep_handles: bool = False,
 ):
     """Anharmonic free energy at one T via dynaphopy MD projection + harmonic-formula sum.
+
+    This macro applies a defensive guard: any (q, band) whose renormalised
+    frequency deviates from its harmonic counterpart by more than 50% (or is
+    NaN) is replaced by the harmonic value, and the number of guarded entries
+    is recorded in ``report["n_guarded_modes"]`` with a warning when it fires.
+    The default 50% threshold catches under-converged Lorentzian fits from
+    short MD trajectories; bump ``production_steps`` and ``q_mesh`` for results
+    that lean less on the harmonic fall-back.
 
     Engine must expose ``.calculator`` (inherited from
     ``calculate_phonon_md_renormalisation``).
@@ -353,6 +385,7 @@ def anharmonic_free_energy_dynaphopy(
         cv_per_atom=wf.spectrum.outputs.cv_per_atom,
         temperature=temperature,
         q_mesh=q_mesh,
+        n_guarded=wf.guarded.outputs.n_guarded,
         simfolder=wf.paths.outputs.simfolder,
         keep_handles=keep_handles,
     )

--- a/pyiron_workflow_atomistics/physics/free_energy/harmonic.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/harmonic.py
@@ -110,14 +110,26 @@ def _pack_harmonic_output(
     simfolder: str,
     keep_handles: bool,
 ) -> FreeEnergyOutput:
-    """Compute thermal properties from the FC2 view and pack into FreeEnergyOutput."""
+    """Compute thermal properties from the FC2 view and pack into FreeEnergyOutput.
+
+    Note: phonopy's ``ThermalProperties`` reports ``free_energy`` in kJ/mol
+    and ``entropy``/``heat_capacity`` in J/K/mol per *primitive* unit cell.
+    The spec for ``FreeEnergyOutput`` documents eV/atom and (eV/K)/atom,
+    so we convert here. Downstream callers that expect phonopy's native
+    units (e.g. ``phonopy.qha.QHA`` in ``quasiharmonic._harmonic_grid_over_volumes``)
+    must multiply back by ``c.eV * c.Avogadro / 1000`` (= ``EvTokJmol``).
+    """
+    import scipy.constants as c
+
     T = np.asarray(temperatures, dtype=float)
     band_structure, dos, free_energy_dict = _compute_harmonic_observables(
         ph3=_Phono3pyShim(phonopy_view), temperatures=T
     )
-    F = np.asarray(free_energy_dict["F"])
-    S = np.asarray(free_energy_dict["S"])
-    Cv = np.asarray(free_energy_dict["Cv"])
+    # phonopy → eV / (eV/K) per primitive-cell atom.
+    ev_to_kj_mol = c.eV * c.Avogadro / 1000.0  # ≈ 96.485
+    F = np.asarray(free_energy_dict["F"]) / ev_to_kj_mol
+    S = np.asarray(free_energy_dict["S"]) / (ev_to_kj_mol * 1000.0)
+    Cv = np.asarray(free_energy_dict["Cv"]) / (ev_to_kj_mol * 1000.0)
 
     elements = list(dict.fromkeys(structure.get_chemical_symbols()))
     return FreeEnergyOutput(

--- a/pyiron_workflow_atomistics/physics/free_energy/harmonic.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/harmonic.py
@@ -1,0 +1,206 @@
+"""Harmonic free energy via phonopy FC2 — single user-facing entry point.
+
+Built on top of phonopy via thin wrappers around the FC2 helpers in
+`physics.phonons.harmonic`. The κ(T) workflow continues to own those
+helpers; we import them here without behavioural change.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pyiron_workflow as pwf
+from ase import Atoms
+
+from pyiron_workflow_atomistics.engine import Engine
+from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+from pyiron_workflow_atomistics.physics.phonons._compat import require_phonopy
+from pyiron_workflow_atomistics.physics.phonons.anharmonic import (
+    _check_all_converged,
+    _evaluate_supercells,
+    _stack_forces,
+)
+from pyiron_workflow_atomistics.physics.phonons.harmonic import (
+    _ase_to_phonopy,
+    _compute_harmonic_observables,
+    _generate_fc2_supercells,
+    _normalise_supercell_matrix,
+)
+
+
+@pwf.as_function_node("simfolder", "sub_engine")
+def _resolve_simfolder(
+    engine: Engine,
+    working_directory: str,
+    subdir: str,
+):
+    """Compute the absolute simfolder path and a working-directory-bound engine.
+
+    Lives in a function-node so the path-join executes at run time with real
+    string values, not the proxy UserInput objects a macro body sees during
+    graph construction.
+    """
+    simfolder = os.path.abspath(os.path.join(working_directory, subdir))
+    os.makedirs(simfolder, exist_ok=True)
+    sub_engine = engine.with_working_directory(simfolder)
+    return simfolder, sub_engine
+
+
+@pwf.as_function_node("phonopy_view")
+def _produce_fc2_view(
+    structure: Atoms,
+    fc2_supercell_matrix,
+    fc2_engine_outputs: list,
+    displacement_distance: float,
+    is_plusminus,
+):
+    """Build a phonopy.Phonopy with FC2 fitted from supercell forces."""
+    require_phonopy()
+    import phonopy
+
+    _check_all_converged(fc2_engine_outputs, label="FC2")
+    sc = _normalise_supercell_matrix(fc2_supercell_matrix)
+
+    unitcell = _ase_to_phonopy(structure)
+    phonon = phonopy.Phonopy(
+        unitcell=unitcell, supercell_matrix=sc, primitive_matrix="auto"
+    )
+    phonon.generate_displacements(
+        distance=displacement_distance, is_plusminus=is_plusminus
+    )
+    forces = _stack_forces(fc2_engine_outputs)
+    if forces.shape[0] != len(phonon.supercells_with_displacements):
+        raise RuntimeError(
+            f"FC2 force/supercell mismatch: {forces.shape[0]} forces vs "
+            f"{len(phonon.supercells_with_displacements)} expected supercells. "
+            "displacement kwargs likely drifted between generation and synthesis."
+        )
+    phonon.forces = forces
+    phonon.produce_force_constants()
+    return phonon
+
+
+@pwf.as_function_node("free_energy_output")
+def _pack_harmonic_output(
+    structure: Atoms,
+    phonopy_view,
+    temperatures,
+    fc2_supercell_matrix,
+    displacement_distance: float,
+    simfolder: str,
+    keep_handles: bool,
+) -> FreeEnergyOutput:
+    """Compute thermal properties from the FC2 view and pack into FreeEnergyOutput."""
+    T = np.asarray(temperatures, dtype=float)
+    band_structure, dos, free_energy_dict = _compute_harmonic_observables(
+        ph3=_Phono3pyShim(phonopy_view), temperatures=T
+    )
+    F = np.asarray(free_energy_dict["F"])
+    S = np.asarray(free_energy_dict["S"])
+    Cv = np.asarray(free_energy_dict["Cv"])
+
+    elements = list(dict.fromkeys(structure.get_chemical_symbols()))
+    return FreeEnergyOutput(
+        mode="harmonic",
+        reference_phase="solid",
+        free_energy=float(F[0]),
+        free_energy_error=0.0,
+        temperature=float(T[0]),
+        pressure=0.0,
+        n_atoms=len(structure),
+        elements=elements,
+        simfolder=simfolder,
+        report={
+            "method": "harmonic",
+            "fc2_supercell_matrix": _normalise_supercell_matrix(
+                fc2_supercell_matrix
+            ).tolist(),
+            "displacement_distance": float(displacement_distance),
+        },
+        temperature_array=T,
+        free_energy_array=F,
+        entropy=float(S[0]),
+        heat_capacity=float(Cv[0]),
+        entropy_array=S,
+        heat_capacity_array=Cv,
+        phonopy_handle=phonopy_view if keep_handles else None,
+        band_structure=band_structure if keep_handles else None,
+        phonon_dos=dos if keep_handles else None,
+    )
+
+
+class _Phono3pyShim:
+    """Minimal adapter exposing the four attributes _compute_harmonic_observables reads.
+
+    `_compute_harmonic_observables` was originally written against a Phono3py
+    object; for the harmonic-only path we hand it a Phonopy view with the
+    same four attributes. Keeps the helper signature unchanged.
+    """
+
+    def __init__(self, phonopy_view) -> None:
+        self.phonon_primitive = phonopy_view.primitive
+        self.phonon_supercell_matrix = phonopy_view.supercell_matrix
+        self.fc2 = phonopy_view.force_constants
+
+
+@pwf.api.as_macro_node("free_energy_output")
+def harmonic_free_energy(
+    wf,
+    structure: Atoms,
+    engine: Engine,
+    fc2_supercell_matrix,
+    temperatures=(0.0, 100.0, 200.0, 300.0, 400.0, 500.0),
+    displacement_distance: float = 0.03,
+    is_plusminus="auto",
+    working_directory: str = ".",
+    subdir: str = "harmonic_free_energy",
+    keep_handles: bool = False,
+):
+    """Helmholtz free energy F(T), entropy S(T), heat capacity Cv(T) at fixed volume.
+
+    Returns
+    -------
+    FreeEnergyOutput
+        ``mode="harmonic"``, ``reference_phase="solid"``. The scalar
+        ``free_energy`` is the value at the *lowest* T in ``temperatures``
+        (typically T=0, i.e. zero-point energy). Curves are in
+        ``temperature_array`` / ``free_energy_array`` / ``entropy_array`` /
+        ``heat_capacity_array``.
+
+    See spec: docs/design/specs/2026-05-15-free-energy-consolidation-design.md
+    """
+    wf.paths = _resolve_simfolder(
+        engine=engine,
+        working_directory=working_directory,
+        subdir=subdir,
+    )
+
+    wf.fc2_supercells = _generate_fc2_supercells(
+        structure=structure,
+        fc2_supercell_matrix=fc2_supercell_matrix,
+        displacement_distance=displacement_distance,
+        is_plusminus=is_plusminus,
+    )
+    wf.fc2_eval = _evaluate_supercells(
+        supercells=wf.fc2_supercells.outputs.fc2_supercells,
+        engine=wf.paths.outputs.sub_engine,
+        prefix="fc2_disp_",
+    )
+    wf.fc2_view = _produce_fc2_view(
+        structure=structure,
+        fc2_supercell_matrix=fc2_supercell_matrix,
+        fc2_engine_outputs=wf.fc2_eval.outputs.engine_outputs,
+        displacement_distance=displacement_distance,
+        is_plusminus=is_plusminus,
+    )
+    wf.synthesis = _pack_harmonic_output(
+        structure=structure,
+        phonopy_view=wf.fc2_view.outputs.phonopy_view,
+        temperatures=temperatures,
+        fc2_supercell_matrix=fc2_supercell_matrix,
+        displacement_distance=displacement_distance,
+        simfolder=wf.paths.outputs.simfolder,
+        keep_handles=keep_handles,
+    )
+    return wf.synthesis.outputs.free_energy_output

--- a/pyiron_workflow_atomistics/physics/free_energy/harmonic.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/harmonic.py
@@ -35,7 +35,12 @@ def _resolve_simfolder(
     working_directory: str,
     subdir: str,
 ):
-    """Compute the absolute simfolder path and a working-directory-bound engine.
+    """Resolve the absolute simfolder path AND create it on disk.
+
+    Joins ``working_directory`` and ``subdir``, absolute-paths the result,
+    mkdirs it (``exist_ok=True``), and wraps the engine into a child that
+    runs inside that directory. The mkdir side effect is intentional: by
+    the time downstream nodes execute, the simfolder is guaranteed to exist.
 
     Lives in a function-node so the path-join executes at run time with real
     string values, not the proxy UserInput objects a macro body sees during
@@ -79,6 +84,20 @@ def _produce_fc2_view(
     phonon.forces = forces
     phonon.produce_force_constants()
     return phonon
+
+
+class _Phono3pyShim:
+    """Minimal adapter exposing the four attributes _compute_harmonic_observables reads.
+
+    `_compute_harmonic_observables` was originally written against a Phono3py
+    object; for the harmonic-only path we hand it a Phonopy view with the
+    same four attributes. Keeps the helper signature unchanged.
+    """
+
+    def __init__(self, phonopy_view) -> None:
+        self.phonon_primitive = phonopy_view.primitive
+        self.phonon_supercell_matrix = phonopy_view.supercell_matrix
+        self.fc2 = phonopy_view.force_constants
 
 
 @pwf.as_function_node("free_energy_output")
@@ -128,20 +147,6 @@ def _pack_harmonic_output(
         band_structure=band_structure if keep_handles else None,
         phonon_dos=dos if keep_handles else None,
     )
-
-
-class _Phono3pyShim:
-    """Minimal adapter exposing the four attributes _compute_harmonic_observables reads.
-
-    `_compute_harmonic_observables` was originally written against a Phono3py
-    object; for the harmonic-only path we hand it a Phonopy view with the
-    same four attributes. Keeps the helper signature unchanged.
-    """
-
-    def __init__(self, phonopy_view) -> None:
-        self.phonon_primitive = phonopy_view.primitive
-        self.phonon_supercell_matrix = phonopy_view.supercell_matrix
-        self.fc2 = phonopy_view.force_constants
 
 
 @pwf.api.as_macro_node("free_energy_output")

--- a/pyiron_workflow_atomistics/physics/free_energy/harmonic.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/harmonic.py
@@ -113,11 +113,19 @@ def _pack_harmonic_output(
     """Compute thermal properties from the FC2 view and pack into FreeEnergyOutput.
 
     Note: phonopy's ``ThermalProperties`` reports ``free_energy`` in kJ/mol
-    and ``entropy``/``heat_capacity`` in J/K/mol per *primitive* unit cell.
-    The spec for ``FreeEnergyOutput`` documents eV/atom and (eV/K)/atom,
-    so we convert here. Downstream callers that expect phonopy's native
-    units (e.g. ``phonopy.qha.QHA`` in ``quasiharmonic._harmonic_grid_over_volumes``)
-    must multiply back by ``c.eV * c.Avogadro / 1000`` (= ``EvTokJmol``).
+    and ``entropy``/``heat_capacity`` in J/K/mol per *primitive cell* (not
+    per atom). The spec for ``FreeEnergyOutput`` documents eV / (eV/K) per
+    **primitive-cell atom**, so we divide by both ``ev_to_kj_mol`` and the
+    number of atoms in phonopy's primitive cell. For users who pass a
+    conventional (non-primitive) cell, phonopy's ``primitive_matrix="auto"``
+    decides the primitive cell — e.g. ``bulk("Al", "fcc", cubic=True)``
+    (4-atom conventional) reduces to a 1-atom fcc primitive.
+
+    Downstream callers that expect phonopy's native units per primitive
+    cell (e.g. ``phonopy.qha.QHA`` in
+    ``quasiharmonic._harmonic_grid_over_volumes``) must multiply back by
+    ``c.eV * c.Avogadro / 1000`` (= ``EvTokJmol``) AND by
+    ``n_atoms_primitive`` (stashed in ``report["n_atoms_primitive"]``).
     """
     import scipy.constants as c
 
@@ -126,10 +134,11 @@ def _pack_harmonic_output(
         ph3=_Phono3pyShim(phonopy_view), temperatures=T
     )
     # phonopy → eV / (eV/K) per primitive-cell atom.
+    n_atoms_primitive = len(phonopy_view.primitive)
     ev_to_kj_mol = c.eV * c.Avogadro / 1000.0  # ≈ 96.485
-    F = np.asarray(free_energy_dict["F"]) / ev_to_kj_mol
-    S = np.asarray(free_energy_dict["S"]) / (ev_to_kj_mol * 1000.0)
-    Cv = np.asarray(free_energy_dict["Cv"]) / (ev_to_kj_mol * 1000.0)
+    F = np.asarray(free_energy_dict["F"]) / (ev_to_kj_mol * n_atoms_primitive)
+    S = np.asarray(free_energy_dict["S"]) / (ev_to_kj_mol * 1000.0 * n_atoms_primitive)
+    Cv = np.asarray(free_energy_dict["Cv"]) / (ev_to_kj_mol * 1000.0 * n_atoms_primitive)
 
     elements = list(dict.fromkeys(structure.get_chemical_symbols()))
     return FreeEnergyOutput(
@@ -148,6 +157,7 @@ def _pack_harmonic_output(
                 fc2_supercell_matrix
             ).tolist(),
             "displacement_distance": float(displacement_distance),
+            "n_atoms_primitive": int(n_atoms_primitive),
         },
         temperature_array=T,
         free_energy_array=F,

--- a/pyiron_workflow_atomistics/physics/free_energy/harmonic.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/harmonic.py
@@ -138,7 +138,9 @@ def _pack_harmonic_output(
     ev_to_kj_mol = c.eV * c.Avogadro / 1000.0  # ≈ 96.485
     F = np.asarray(free_energy_dict["F"]) / (ev_to_kj_mol * n_atoms_primitive)
     S = np.asarray(free_energy_dict["S"]) / (ev_to_kj_mol * 1000.0 * n_atoms_primitive)
-    Cv = np.asarray(free_energy_dict["Cv"]) / (ev_to_kj_mol * 1000.0 * n_atoms_primitive)
+    Cv = np.asarray(free_energy_dict["Cv"]) / (
+        ev_to_kj_mol * 1000.0 * n_atoms_primitive
+    )
 
     elements = list(dict.fromkeys(structure.get_chemical_symbols()))
     return FreeEnergyOutput(

--- a/pyiron_workflow_atomistics/physics/free_energy/outputs.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/outputs.py
@@ -1,32 +1,38 @@
-"""Structured result of a calphy free-energy calculation.
+"""Structured result of a free-energy calculation.
 
-Same shape regardless of which mode produced it; per-mode arrays
-(temperature_array, free_energy_array, melting_temperature, ...) are
-None when not applicable. Pickleable — holds plain Python + numpy
-types only, no Phase references, no LAMMPS handles.
+Same shape across calphy + phonopy harmonic + phonopy QHA + dynaphopy modes;
+per-mode arrays are None when not applicable. Pickleable for plain-data
+fields; phonopy/dynaphopy handle fields (carried in memory when
+``keep_handles=True``) are excluded from ``to_dict()``.
+
+Unit conventions
+----------------
+``free_energy`` / ``free_energy_error`` / ``free_energy_array`` / ``gibbs_free_energy_array``
+/ ``einstein_free_energy``: eV/atom (calphy native).
+``temperature`` / ``temperature_array``: K.
+``pressure`` for calphy modes (fe, ts, tscale, pscale, melting_temperature,
+alchemy, composition_scaling): bar (calphy native).
+``pressure`` for ``qha``: GPa (phonopy.qha native).
+``bulk_modulus_array``: GPa.
+``thermal_expansion_array``: 1/K.
+``volumes`` / ``equilibrium_volume_array``: Å³/atom.
 """
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass, fields
 from typing import Any, Literal
 
 import numpy as np
 
+_HANDLE_FIELDS = frozenset(
+    {"phonopy_handle", "qha_handle", "dynaphopy_handle", "band_structure", "phonon_dos"}
+)
+
 
 @dataclass
 class FreeEnergyOutput:
-    """Result of one calphy free-energy calculation.
-
-    Units
-    -----
-    ``free_energy`` / ``free_energy_error`` / ``einstein_free_energy``:
-    eV/atom (calphy native).
-    ``temperature``: K.
-    ``pressure``: bar (calphy native — differs from
-    :class:`pyiron_workflow_atomistics.engine.CalcInputMD.pressure`
-    which is Pa; do not mix).
-    """
+    """Result of one free-energy calculation across calphy / phonopy / dynaphopy modes."""
 
     mode: Literal[
         "fe",
@@ -36,6 +42,10 @@ class FreeEnergyOutput:
         "melting_temperature",
         "alchemy",
         "composition_scaling",
+        "harmonic",
+        "qha",
+        "anharmonic_dynaphopy",
+        "anharmonic_dynaphopy_tdi",
     ]
     reference_phase: Literal["solid", "liquid", "both"]
     free_energy: float
@@ -47,7 +57,7 @@ class FreeEnergyOutput:
     simfolder: str
     report: dict[str, Any]
 
-    # mode-specific; None when not applicable
+    # existing optional fields
     temperature_array: np.ndarray | None = None
     free_energy_array: np.ndarray | None = None
     pressure_array: np.ndarray | None = None
@@ -56,6 +66,41 @@ class FreeEnergyOutput:
     composition_path: list[dict[str, int]] | None = None
     einstein_free_energy: float | None = None
 
+    # NEW — harmonic + dynaphopy (single T)
+    entropy: float | None = None
+    heat_capacity: float | None = None
+
+    # NEW — harmonic + qha + dynaphopy TDI (arrays over temperature_array)
+    entropy_array: np.ndarray | None = None
+    heat_capacity_array: np.ndarray | None = None
+
+    # NEW — qha specific
+    volumes: np.ndarray | None = None
+    free_energy_volume_array: np.ndarray | None = None
+    equilibrium_volume_array: np.ndarray | None = None
+    gibbs_free_energy_array: np.ndarray | None = None
+    bulk_modulus_array: np.ndarray | None = None
+    thermal_expansion_array: np.ndarray | None = None
+
+    # NEW — dynaphopy specific
+    harmonic_frequencies: np.ndarray | None = None
+    renormalised_frequencies: np.ndarray | None = None
+    linewidths: np.ndarray | None = None
+    renormalised_frequencies_per_T: np.ndarray | None = None
+    linewidths_per_T: np.ndarray | None = None
+    q_mesh: tuple[int, int, int] | None = None
+
+    # NEW — handles (always excluded from to_dict)
+    phonopy_handle: Any | None = None
+    qha_handle: Any | None = None
+    dynaphopy_handle: Any | None = None
+    band_structure: dict | None = None
+    phonon_dos: dict | None = None
+
     def to_dict(self) -> dict[str, Any]:
-        """Return a plain dict of the dataclass fields."""
-        return asdict(self)
+        """Return a plain dict of every non-handle field."""
+        return {
+            f.name: getattr(self, f.name)
+            for f in fields(self)
+            if f.name not in _HANDLE_FIELDS
+        }

--- a/pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py
@@ -7,7 +7,6 @@ gives G(T,P), V*(T,P), B(T,P), α(T,P). Reuses `harmonic_free_energy` per volume
 from __future__ import annotations
 
 import os
-from typing import Any
 
 import numpy as np
 import pyiron_workflow as pwf
@@ -171,7 +170,6 @@ def _harmonic_grid_over_volumes(
 def _pack_qha_output(
     structure: Atoms,
     qha_results: dict,
-    energies: np.ndarray,
     volumes: np.ndarray,
     free_energy_per_T_V: np.ndarray,
     entropy_per_T_V: np.ndarray,
@@ -184,6 +182,9 @@ def _pack_qha_output(
     """Pack phonopy.qha results plus the V/T grids into a FreeEnergyOutput."""
     T = np.asarray(temperatures, dtype=float)
     elements = list(dict.fromkeys(structure.get_chemical_symbols()))
+    # entropy_array/heat_capacity_array are a representative slice at the
+    # central reference volume; the full (n_T, n_V) grid lives in
+    # free_energy_volume_array (the unconstrained F(T,V) phonon grid).
     mid = entropy_per_T_V.shape[1] // 2
     return FreeEnergyOutput(
         mode="qha",
@@ -234,8 +235,14 @@ def quasiharmonic_free_energy(
     """Gibbs free energy G(T,P), V*(T,P), B(T,P), α(T,P) via phonopy.qha.QHA.
 
     Pressure is in **GPa** (phonopy.qha native). At ``pressure=0.0`` the
-    output is Helmholtz. See spec
-    ``docs/design/specs/2026-05-15-free-energy-consolidation-design.md``.
+    ``gibbs_free_energy_array`` field is the Helmholtz free energy F(T).
+
+    The returned ``FreeEnergyOutput`` populates ``free_energy_array`` directly
+    from ``gibbs_free_energy_array`` for compatibility with the calphy ``ts``
+    mode shape — at finite pressure this is Gibbs, at zero pressure it is
+    Helmholtz.
+
+    See spec ``docs/design/specs/2026-05-15-free-energy-consolidation-design.md``.
     """
     wf.paths = _resolve_simfolder(
         engine=engine,
@@ -274,7 +281,6 @@ def quasiharmonic_free_energy(
     wf.synthesis = _pack_qha_output(
         structure=structure,
         qha_results=wf.qha.outputs.qha_results,
-        energies=wf.static_E.outputs.energies_per_volume,
         volumes=wf.static_E.outputs.volumes,
         free_energy_per_T_V=wf.harmonic_grid.outputs.free_energy_per_T_V,
         entropy_per_T_V=wf.harmonic_grid.outputs.entropy_per_T_V,

--- a/pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py
@@ -52,7 +52,7 @@ def _fit_qha(
 ) -> dict:
     """Fit phonopy.qha.QHA on the (V, T) grid and return derived thermodynamics."""
     require_phonopy()
-    from phonopy.qha import QHA
+    from phonopy.qha.core import QHA
 
     E = np.asarray(energies, dtype=float)
     V = np.asarray(volumes, dtype=float)
@@ -61,24 +61,48 @@ def _fit_qha(
     S_TV = np.asarray(entropy_per_T_V, dtype=float)
     Cv_TV = np.asarray(cv_per_T_V, dtype=float)
 
+    # phonopy.qha truncates its outputs to length (len(T) - 1) because it needs
+    # one extra temperature point as a finite-difference buffer for thermal
+    # expansion. To return arrays aligned 1:1 with the input temperature grid,
+    # append one extrapolated buffer point above T[-1] and slice the buffer off
+    # the outputs (when phonopy retains it).
+    if T.size >= 2:
+        dT = T[-1] - T[-2]
+        T_ext = np.concatenate([T, [T[-1] + dT]])
+        F_ext = np.vstack([F_TV, 2.0 * F_TV[-1] - F_TV[-2]])
+        S_ext = np.vstack([S_TV, 2.0 * S_TV[-1] - S_TV[-2]])
+        Cv_ext = np.vstack([Cv_TV, 2.0 * Cv_TV[-1] - Cv_TV[-2]])
+    else:
+        T_ext, F_ext, S_ext, Cv_ext = T, F_TV, S_TV, Cv_TV
+
     qha = QHA(
         volumes=V,
         electronic_energies=E,
-        temperatures=T,
-        free_energy=F_TV,
-        cv=Cv_TV,
-        entropy=S_TV,
+        temperatures=T_ext,
+        fe_phonon=F_ext,
+        cv=Cv_ext,
+        entropy=S_ext,
         eos=eos_type,
         pressure=pressure_GPa,
     )
     qha.run()
-    V_T = np.asarray(qha.get_volume_temperature())
+
+    n_T = T.size
+    V_T_raw = np.asarray(qha.volume_temperature)
+    V_T = V_T_raw[:n_T] if V_T_raw.size >= n_T else V_T_raw
     _check_qha_volume_range(V_T, T, strain_range=(V.min(), V.max()), volumes=V)
+
+    gibbs_raw = np.asarray(qha.get_gibbs_temperature())
+    bulk_raw = np.asarray(qha.get_bulk_modulus_temperature())
+    alpha_raw = np.asarray(qha.thermal_expansion)
+    gibbs = gibbs_raw[:n_T] if gibbs_raw.size >= n_T else gibbs_raw
+    bulk = bulk_raw[:n_T] if bulk_raw.size >= n_T else bulk_raw
+    alpha = alpha_raw[:n_T] if alpha_raw.size >= n_T else alpha_raw
 
     return {
         "equilibrium_volume_array": V_T,
-        "gibbs_free_energy_array": np.asarray(qha.get_gibbs_temperature()),
-        "bulk_modulus_array": np.asarray(qha.get_bulk_modulus_temperature()),
-        "thermal_expansion_array": np.asarray(qha.get_thermal_expansion()),
+        "gibbs_free_energy_array": gibbs,
+        "bulk_modulus_array": bulk,
+        "thermal_expansion_array": alpha,
         "qha_handle": qha,
     }

--- a/pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py
@@ -16,6 +16,7 @@ from ase import Atoms
 from pyiron_workflow_atomistics.engine import Engine, calculate
 from pyiron_workflow_atomistics.physics.bulk import generate_structures
 from pyiron_workflow_atomistics.physics.free_energy.harmonic import (
+    _resolve_simfolder,
     harmonic_free_energy,
 )
 from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
@@ -106,3 +107,181 @@ def _fit_qha(
         "thermal_expansion_array": alpha,
         "qha_handle": qha,
     }
+
+
+@pwf.as_function_node("energies_per_volume", "volumes")
+def _static_energies_per_volume(strained_structures: list[Atoms], engine: Engine):
+    """One-shot static energy per strained cell. Returns (energies, volumes/atom)."""
+    energies: list[float] = []
+    volumes: list[float] = []
+    for i, s in enumerate(strained_structures):
+        sub_engine = engine.with_working_directory(f"vol_E_{i:03d}")
+        out = calculate.node_function(structure=s, engine=sub_engine)
+        if not out.converged:
+            raise RuntimeError(
+                f"Static-energy calc failed for strained cell {i} "
+                f"(volume {s.get_volume():.3f} Å³)."
+            )
+        energies.append(float(out.final_energy))
+        volumes.append(float(s.get_volume()) / len(s))
+    return np.asarray(energies), np.asarray(volumes)
+
+
+@pwf.as_function_node(
+    "free_energy_per_T_V", "entropy_per_T_V", "cv_per_T_V"
+)
+def _harmonic_grid_over_volumes(
+    strained_structures: list[Atoms],
+    engine: Engine,
+    fc2_supercell_matrix,
+    temperatures,
+    displacement_distance: float,
+    is_plusminus,
+    working_directory: str,
+):
+    """Run harmonic_free_energy at each strained cell, stack F/S/Cv along V axis."""
+    T_arr = np.asarray(temperatures)
+    n_T = int(T_arr.size)
+    n_V = len(strained_structures)
+    F_TV = np.zeros((n_T, n_V))
+    S_TV = np.zeros((n_T, n_V))
+    Cv_TV = np.zeros((n_T, n_V))
+    for j, s in enumerate(strained_structures):
+        vol_dir = os.path.join(working_directory, f"vol_{j:03d}")
+        sub_engine = engine.with_working_directory(vol_dir)
+        sub_wf = harmonic_free_energy(
+            structure=s,
+            engine=sub_engine,
+            fc2_supercell_matrix=fc2_supercell_matrix,
+            temperatures=temperatures,
+            displacement_distance=displacement_distance,
+            is_plusminus=is_plusminus,
+            working_directory=vol_dir,
+            subdir="harmonic",
+        )
+        out = sub_wf.run()
+        out = out["free_energy_output"] if isinstance(out, dict) else out
+        F_TV[:, j] = out.free_energy_array
+        S_TV[:, j] = out.entropy_array
+        Cv_TV[:, j] = out.heat_capacity_array
+    return F_TV, S_TV, Cv_TV
+
+
+@pwf.as_function_node("free_energy_output")
+def _pack_qha_output(
+    structure: Atoms,
+    qha_results: dict,
+    energies: np.ndarray,
+    volumes: np.ndarray,
+    free_energy_per_T_V: np.ndarray,
+    entropy_per_T_V: np.ndarray,
+    cv_per_T_V: np.ndarray,
+    temperatures,
+    pressure_GPa: float,
+    simfolder: str,
+    keep_handles: bool,
+) -> FreeEnergyOutput:
+    """Pack phonopy.qha results plus the V/T grids into a FreeEnergyOutput."""
+    T = np.asarray(temperatures, dtype=float)
+    elements = list(dict.fromkeys(structure.get_chemical_symbols()))
+    mid = entropy_per_T_V.shape[1] // 2
+    return FreeEnergyOutput(
+        mode="qha",
+        reference_phase="solid",
+        free_energy=float(qha_results["gibbs_free_energy_array"][0]),
+        free_energy_error=0.0,
+        temperature=float(T[0]),
+        pressure=float(pressure_GPa),
+        n_atoms=len(structure),
+        elements=elements,
+        simfolder=simfolder,
+        report={
+            "method": "qha",
+            "n_volumes": int(np.asarray(volumes).size),
+            "pressure_GPa": float(pressure_GPa),
+        },
+        temperature_array=T,
+        free_energy_array=qha_results["gibbs_free_energy_array"],
+        entropy_array=entropy_per_T_V[:, mid],
+        heat_capacity_array=cv_per_T_V[:, mid],
+        volumes=volumes,
+        free_energy_volume_array=free_energy_per_T_V,
+        equilibrium_volume_array=qha_results["equilibrium_volume_array"],
+        gibbs_free_energy_array=qha_results["gibbs_free_energy_array"],
+        bulk_modulus_array=qha_results["bulk_modulus_array"],
+        thermal_expansion_array=qha_results["thermal_expansion_array"],
+        qha_handle=qha_results["qha_handle"] if keep_handles else None,
+    )
+
+
+@pwf.api.as_macro_node("free_energy_output")
+def quasiharmonic_free_energy(
+    wf,
+    structure: Atoms,
+    engine: Engine,
+    fc2_supercell_matrix,
+    temperatures=(0.0, 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0),
+    pressure: float = 0.0,
+    strain_range: tuple[float, float] = (-0.03, 0.03),
+    num_volumes: int = 7,
+    displacement_distance: float = 0.03,
+    is_plusminus="auto",
+    eos_type: str = "vinet",
+    working_directory: str = ".",
+    subdir: str = "quasiharmonic_free_energy",
+    keep_handles: bool = False,
+):
+    """Gibbs free energy G(T,P), V*(T,P), B(T,P), α(T,P) via phonopy.qha.QHA.
+
+    Pressure is in **GPa** (phonopy.qha native). At ``pressure=0.0`` the
+    output is Helmholtz. See spec
+    ``docs/design/specs/2026-05-15-free-energy-consolidation-design.md``.
+    """
+    wf.paths = _resolve_simfolder(
+        engine=engine,
+        working_directory=working_directory,
+        subdir=subdir,
+    )
+    wf.strained_structures = generate_structures(
+        base_structure=structure,
+        axes=["iso"],
+        strain_range=strain_range,
+        num_points=num_volumes,
+    )
+    wf.static_E = _static_energies_per_volume(
+        strained_structures=wf.strained_structures.outputs.structure_list,
+        engine=wf.paths.outputs.sub_engine,
+    )
+    wf.harmonic_grid = _harmonic_grid_over_volumes(
+        strained_structures=wf.strained_structures.outputs.structure_list,
+        engine=engine,
+        fc2_supercell_matrix=fc2_supercell_matrix,
+        temperatures=temperatures,
+        displacement_distance=displacement_distance,
+        is_plusminus=is_plusminus,
+        working_directory=wf.paths.outputs.simfolder,
+    )
+    wf.qha = _fit_qha(
+        energies=wf.static_E.outputs.energies_per_volume,
+        volumes=wf.static_E.outputs.volumes,
+        free_energy_per_T_V=wf.harmonic_grid.outputs.free_energy_per_T_V,
+        entropy_per_T_V=wf.harmonic_grid.outputs.entropy_per_T_V,
+        cv_per_T_V=wf.harmonic_grid.outputs.cv_per_T_V,
+        temperatures=temperatures,
+        pressure_GPa=pressure,
+        eos_type=eos_type,
+    )
+    wf.synthesis = _pack_qha_output(
+        structure=structure,
+        qha_results=wf.qha.outputs.qha_results,
+        energies=wf.static_E.outputs.energies_per_volume,
+        volumes=wf.static_E.outputs.volumes,
+        free_energy_per_T_V=wf.harmonic_grid.outputs.free_energy_per_T_V,
+        entropy_per_T_V=wf.harmonic_grid.outputs.entropy_per_T_V,
+        cv_per_T_V=wf.harmonic_grid.outputs.cv_per_T_V,
+        temperatures=temperatures,
+        pressure_GPa=pressure,
+        simfolder=wf.paths.outputs.simfolder,
+        keep_handles=keep_handles,
+    )
+    return wf.synthesis.outputs.free_energy_output

--- a/pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py
@@ -142,9 +142,12 @@ def _harmonic_grid_over_volumes(
     import scipy.constants as c
 
     # phonopy.qha expects fe_phonon in kJ/mol and entropy/cv in J/K/mol per
-    # primitive unit cell. ``harmonic_free_energy`` reports those quantities
-    # in eV / (eV/K) / atom per the FreeEnergyOutput spec, so convert here
-    # at the boundary.
+    # *primitive cell* (not per primitive-cell atom). ``harmonic_free_energy``
+    # reports those quantities in eV / (eV/K) per primitive-cell ATOM per the
+    # FreeEnergyOutput spec, so the boundary conversion has to undo BOTH:
+    # (1) eV → kJ/mol via ``ev_to_kj_mol`` and (2) per-primitive-atom →
+    # per-primitive-cell via ``n_atoms_primitive`` (stashed in the harmonic
+    # output's report dict, per-volume).
     ev_to_kj_mol = c.eV * c.Avogadro / 1000.0  # ≈ 96.485
 
     T_arr = np.asarray(temperatures)
@@ -168,9 +171,19 @@ def _harmonic_grid_over_volumes(
         )
         out = sub_wf.run()
         out = out["free_energy_output"] if isinstance(out, dict) else out
-        F_TV[:, j] = np.asarray(out.free_energy_array) * ev_to_kj_mol
-        S_TV[:, j] = np.asarray(out.entropy_array) * ev_to_kj_mol * 1000.0
-        Cv_TV[:, j] = np.asarray(out.heat_capacity_array) * ev_to_kj_mol * 1000.0
+        n_atoms_primitive = int(out.report["n_atoms_primitive"])
+        F_TV[:, j] = (
+            np.asarray(out.free_energy_array) * ev_to_kj_mol * n_atoms_primitive
+        )
+        S_TV[:, j] = (
+            np.asarray(out.entropy_array) * ev_to_kj_mol * 1000.0 * n_atoms_primitive
+        )
+        Cv_TV[:, j] = (
+            np.asarray(out.heat_capacity_array)
+            * ev_to_kj_mol
+            * 1000.0
+            * n_atoms_primitive
+        )
     return F_TV, S_TV, Cv_TV
 
 

--- a/pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py
@@ -126,9 +126,7 @@ def _static_energies_per_volume(strained_structures: list[Atoms], engine: Engine
     return np.asarray(energies), np.asarray(volumes)
 
 
-@pwf.as_function_node(
-    "free_energy_per_T_V", "entropy_per_T_V", "cv_per_T_V"
-)
+@pwf.as_function_node("free_energy_per_T_V", "entropy_per_T_V", "cv_per_T_V")
 def _harmonic_grid_over_volumes(
     strained_structures: list[Atoms],
     engine: Engine,

--- a/pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py
@@ -1,0 +1,84 @@
+"""Quasiharmonic free energy via phonopy.qha — single user-facing entry point.
+
+QHA recipe: EOS volume sweep + per-volume harmonic free energy → phonopy.qha.QHA
+gives G(T,P), V*(T,P), B(T,P), α(T,P). Reuses `harmonic_free_energy` per volume.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import numpy as np
+import pyiron_workflow as pwf
+from ase import Atoms
+
+from pyiron_workflow_atomistics.engine import Engine, calculate
+from pyiron_workflow_atomistics.physics.bulk import generate_structures
+from pyiron_workflow_atomistics.physics.free_energy.harmonic import (
+    harmonic_free_energy,
+)
+from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+from pyiron_workflow_atomistics.physics.phonons._compat import require_phonopy
+
+
+def _check_qha_volume_range(
+    V_T: np.ndarray,
+    temperatures: np.ndarray,
+    strain_range: tuple[float, float],
+    volumes: np.ndarray,
+) -> None:
+    """Raise if `phonopy.qha` returned NaN V*(T) anywhere — indicates V grid too narrow."""
+    nan_mask = ~np.isfinite(V_T)
+    if nan_mask.any():
+        bad_T = np.asarray(temperatures)[nan_mask].tolist()
+        raise RuntimeError(
+            f"QHA equilibrium volume undefined at T={bad_T} K — widen "
+            f"`strain_range` or extend it to include positive strain "
+            f"(current range: {strain_range}, current V grid: {volumes.tolist()} Å³/atom)."
+        )
+
+
+@pwf.as_function_node("qha_results")
+def _fit_qha(
+    energies,
+    volumes,
+    free_energy_per_T_V,
+    entropy_per_T_V,
+    cv_per_T_V,
+    temperatures,
+    pressure_GPa: float,
+    eos_type: str,
+) -> dict:
+    """Fit phonopy.qha.QHA on the (V, T) grid and return derived thermodynamics."""
+    require_phonopy()
+    from phonopy.qha import QHA
+
+    E = np.asarray(energies, dtype=float)
+    V = np.asarray(volumes, dtype=float)
+    T = np.asarray(temperatures, dtype=float)
+    F_TV = np.asarray(free_energy_per_T_V, dtype=float)
+    S_TV = np.asarray(entropy_per_T_V, dtype=float)
+    Cv_TV = np.asarray(cv_per_T_V, dtype=float)
+
+    qha = QHA(
+        volumes=V,
+        electronic_energies=E,
+        temperatures=T,
+        free_energy=F_TV,
+        cv=Cv_TV,
+        entropy=S_TV,
+        eos=eos_type,
+        pressure=pressure_GPa,
+    )
+    qha.run()
+    V_T = np.asarray(qha.get_volume_temperature())
+    _check_qha_volume_range(V_T, T, strain_range=(V.min(), V.max()), volumes=V)
+
+    return {
+        "equilibrium_volume_array": V_T,
+        "gibbs_free_energy_array": np.asarray(qha.get_gibbs_temperature()),
+        "bulk_modulus_array": np.asarray(qha.get_bulk_modulus_temperature()),
+        "thermal_expansion_array": np.asarray(qha.get_thermal_expansion()),
+        "qha_handle": qha,
+    }

--- a/pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/quasiharmonic.py
@@ -139,6 +139,14 @@ def _harmonic_grid_over_volumes(
     working_directory: str,
 ):
     """Run harmonic_free_energy at each strained cell, stack F/S/Cv along V axis."""
+    import scipy.constants as c
+
+    # phonopy.qha expects fe_phonon in kJ/mol and entropy/cv in J/K/mol per
+    # primitive unit cell. ``harmonic_free_energy`` reports those quantities
+    # in eV / (eV/K) / atom per the FreeEnergyOutput spec, so convert here
+    # at the boundary.
+    ev_to_kj_mol = c.eV * c.Avogadro / 1000.0  # ≈ 96.485
+
     T_arr = np.asarray(temperatures)
     n_T = int(T_arr.size)
     n_V = len(strained_structures)
@@ -160,9 +168,9 @@ def _harmonic_grid_over_volumes(
         )
         out = sub_wf.run()
         out = out["free_energy_output"] if isinstance(out, dict) else out
-        F_TV[:, j] = out.free_energy_array
-        S_TV[:, j] = out.entropy_array
-        Cv_TV[:, j] = out.heat_capacity_array
+        F_TV[:, j] = np.asarray(out.free_energy_array) * ev_to_kj_mol
+        S_TV[:, j] = np.asarray(out.entropy_array) * ev_to_kj_mol * 1000.0
+        Cv_TV[:, j] = np.asarray(out.heat_capacity_array) * ev_to_kj_mol * 1000.0
     return F_TV, S_TV, Cv_TV
 
 

--- a/tests/unit/physics/test_free_energy.py
+++ b/tests/unit/physics/test_free_energy.py
@@ -1264,3 +1264,25 @@ def test_to_dict_excludes_handle_fields():
     assert "qha_handle" not in d
     assert "dynaphopy_handle" not in d
     assert d["mode"] == "harmonic"
+
+
+def test_public_free_energy_exports():
+    import pyiron_workflow_atomistics.physics.free_energy as fe
+
+    expected = {
+        "FreeEnergyOutput",
+        "LammpsPotential",
+        "alchemy",
+        "composition_scaling",
+        "free_energy",
+        "melting_temperature",
+        "reversible_scaling_pressure",
+        "reversible_scaling_temperature",
+        "harmonic_free_energy",
+        "quasiharmonic_free_energy",
+        "anharmonic_free_energy_dynaphopy",
+        "anharmonic_free_energy_dynaphopy_tdi",
+    }
+    assert expected.issubset(set(fe.__all__))
+    for name in expected:
+        assert hasattr(fe, name), f"missing public export: {name}"

--- a/tests/unit/physics/test_free_energy.py
+++ b/tests/unit/physics/test_free_energy.py
@@ -1150,6 +1150,7 @@ def test_composition_scaling_smoke(tmp_path):
 
 def test_free_energy_output_accepts_harmonic_mode():
     import numpy as np
+
     from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
 
     out = FreeEnergyOutput(
@@ -1176,6 +1177,7 @@ def test_free_energy_output_accepts_harmonic_mode():
 
 def test_free_energy_output_accepts_qha_mode():
     import numpy as np
+
     from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
 
     out = FreeEnergyOutput(
@@ -1201,6 +1203,7 @@ def test_free_energy_output_accepts_qha_mode():
 
 def test_free_energy_output_accepts_anharmonic_dynaphopy_modes():
     import numpy as np
+
     from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
 
     out_single = FreeEnergyOutput(

--- a/tests/unit/physics/test_free_energy.py
+++ b/tests/unit/physics/test_free_energy.py
@@ -1146,3 +1146,121 @@ def test_composition_scaling_smoke(tmp_path):
     # composition_path should be populated (verify the coercion bug is fixed)
     assert out.composition_path is not None
     assert all(isinstance(c, dict) for c in out.composition_path)
+
+
+def test_free_energy_output_accepts_harmonic_mode():
+    import numpy as np
+    from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+
+    out = FreeEnergyOutput(
+        mode="harmonic",
+        reference_phase="solid",
+        free_energy=-3.0,
+        free_energy_error=0.0,
+        temperature=0.0,
+        pressure=0.0,
+        n_atoms=4,
+        elements=["Al"],
+        simfolder="/tmp",
+        report={},
+        temperature_array=np.array([0.0, 300.0]),
+        free_energy_array=np.array([-3.0, -3.05]),
+        entropy_array=np.array([0.0, 1e-4]),
+        heat_capacity_array=np.array([0.0, 2e-4]),
+        entropy=0.0,
+        heat_capacity=0.0,
+    )
+    assert out.mode == "harmonic"
+    assert out.entropy_array.shape == (2,)
+
+
+def test_free_energy_output_accepts_qha_mode():
+    import numpy as np
+    from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+
+    out = FreeEnergyOutput(
+        mode="qha",
+        reference_phase="solid",
+        free_energy=-3.0,
+        free_energy_error=0.0,
+        temperature=0.0,
+        pressure=0.0,
+        n_atoms=4,
+        elements=["Al"],
+        simfolder="/tmp",
+        report={},
+        volumes=np.array([15.0, 16.0, 17.0]),
+        free_energy_volume_array=np.zeros((2, 3)),
+        equilibrium_volume_array=np.array([16.0, 16.1]),
+        gibbs_free_energy_array=np.array([-3.0, -3.1]),
+        bulk_modulus_array=np.array([70.0, 68.0]),
+        thermal_expansion_array=np.array([0.0, 2e-5]),
+    )
+    assert out.bulk_modulus_array[0] == 70.0
+
+
+def test_free_energy_output_accepts_anharmonic_dynaphopy_modes():
+    import numpy as np
+    from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+
+    out_single = FreeEnergyOutput(
+        mode="anharmonic_dynaphopy",
+        reference_phase="solid",
+        free_energy=-2.9,
+        free_energy_error=0.0,
+        temperature=300.0,
+        pressure=0.0,
+        n_atoms=4,
+        elements=["Al"],
+        simfolder="/tmp",
+        report={},
+        harmonic_frequencies=np.zeros((1, 12)),
+        renormalised_frequencies=np.zeros((1, 12)),
+        linewidths=np.zeros((1, 12)),
+        q_mesh=(7, 7, 7),
+    )
+    assert out_single.q_mesh == (7, 7, 7)
+
+    out_tdi = FreeEnergyOutput(
+        mode="anharmonic_dynaphopy_tdi",
+        reference_phase="solid",
+        free_energy=-2.9,
+        free_energy_error=0.0,
+        temperature=200.0,
+        pressure=0.0,
+        n_atoms=4,
+        elements=["Al"],
+        simfolder="/tmp",
+        report={},
+        temperature_array=np.array([200.0, 400.0]),
+        free_energy_array=np.array([-2.9, -3.0]),
+        renormalised_frequencies_per_T=np.zeros((2, 1, 12)),
+        linewidths_per_T=np.zeros((2, 1, 12)),
+    )
+    assert out_tdi.renormalised_frequencies_per_T.shape == (2, 1, 12)
+
+
+def test_to_dict_excludes_handle_fields():
+    from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+
+    sentinel = object()
+    out = FreeEnergyOutput(
+        mode="harmonic",
+        reference_phase="solid",
+        free_energy=-3.0,
+        free_energy_error=0.0,
+        temperature=0.0,
+        pressure=0.0,
+        n_atoms=4,
+        elements=["Al"],
+        simfolder="/tmp",
+        report={},
+        phonopy_handle=sentinel,
+        qha_handle=sentinel,
+        dynaphopy_handle=sentinel,
+    )
+    d = out.to_dict()
+    assert "phonopy_handle" not in d
+    assert "qha_handle" not in d
+    assert "dynaphopy_handle" not in d
+    assert d["mode"] == "harmonic"

--- a/tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py
+++ b/tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py
@@ -141,3 +141,81 @@ def test_anharmonic_free_energy_dynaphopy_emt_al(tmp_path):
     # Anharmonic and harmonic Al/EMT at 300 K should be within 50 meV/atom
     assert abs(out_a.free_energy - out_h.free_energy) < 0.05
     assert out_a.harmonic_frequencies.shape == out_a.renormalised_frequencies.shape
+
+
+def test_stack_tdi_outputs_central_differences():
+    from pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy import (
+        _stack_tdi_outputs,
+    )
+    from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
+
+    # Synthetic F(T) = a + b T + c T^2  → S = -∂F/∂T = -(b + 2cT)
+    a, b, c = -3.0, -1e-4, -1e-7
+    Ts = np.array([100.0, 200.0, 300.0, 400.0, 500.0])
+    Fs = a + b * Ts + c * Ts**2
+    per_T = [
+        FreeEnergyOutput(
+            mode="anharmonic_dynaphopy",
+            reference_phase="solid",
+            free_energy=float(F),
+            free_energy_error=0.0,
+            temperature=float(T),
+            pressure=0.0,
+            n_atoms=4,
+            elements=["Al"],
+            simfolder="/tmp",
+            report={},
+            harmonic_frequencies=np.zeros((1, 12)),
+            renormalised_frequencies=np.zeros((1, 12)),
+            linewidths=np.zeros((1, 12)),
+            q_mesh=(7, 7, 7),
+        )
+        for T, F in zip(Ts, Fs)
+    ]
+    structure = type("FakeAtoms", (), {"__len__": lambda self: 4})()
+    out = _stack_tdi_outputs.node_function(
+        per_T_outputs=per_T,
+        structure=structure,
+        temperatures=Ts,
+    )
+    # interior central-difference S at T=300:  -(b + 2 c * 300)
+    expected_S_300 = -(b + 2 * c * 300.0)
+    assert out.entropy_array[2] == pytest.approx(expected_S_300, rel=5e-2)
+    assert out.renormalised_frequencies_per_T.shape == (5, 1, 12)
+
+
+@pytest.mark.slow
+def test_anharmonic_free_energy_dynaphopy_tdi_emt_al(tmp_path):
+    pytest.importorskip("dynaphopy", reason="dynaphopy not installed")
+
+    from ase.build import bulk
+    from ase.calculators.emt import EMT
+
+    from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+    from pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy import (
+        anharmonic_free_energy_dynaphopy_tdi,
+    )
+
+    structure = bulk("Al", "fcc", a=4.05, cubic=True)
+    engine = ASEEngine(
+        EngineInput=CalcInputStatic(),
+        calculator=EMT(),
+        working_directory=str(tmp_path),
+    )
+
+    out = anharmonic_free_energy_dynaphopy_tdi(
+        structure=structure,
+        engine=engine,
+        fc2_supercell_matrix=2 * np.eye(3, dtype=int),
+        temperatures=(200.0, 400.0),
+        production_steps=2000,
+        q_mesh=(5, 5, 5),
+        working_directory=str(tmp_path),
+        subdir="anharmonic_tdi",
+    ).run()
+    out = out["free_energy_output"] if isinstance(out, dict) else out
+
+    assert out.mode == "anharmonic_dynaphopy_tdi"
+    assert out.temperature_array.shape == (2,)
+    assert out.free_energy_array.shape == (2,)
+    assert out.renormalised_frequencies_per_T.shape == (2, *out.renormalised_frequencies_per_T.shape[1:])

--- a/tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py
+++ b/tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py
@@ -89,3 +89,55 @@ def test_free_energy_from_spectrum_rejects_imaginary_modes():
             temperature=300.0,
             n_atoms_primitive=1,
         )
+
+
+@pytest.mark.slow
+def test_anharmonic_free_energy_dynaphopy_emt_al(tmp_path):
+    pytest.importorskip("dynaphopy", reason="dynaphopy not installed")
+    pytest.importorskip("phonopy", reason="phonopy not installed")
+
+    from ase.build import bulk
+    from ase.calculators.emt import EMT
+
+    from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+    from pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy import (
+        anharmonic_free_energy_dynaphopy,
+    )
+    from pyiron_workflow_atomistics.physics.free_energy.harmonic import (
+        harmonic_free_energy,
+    )
+
+    structure = bulk("Al", "fcc", a=4.05, cubic=True)
+    engine = ASEEngine(
+        EngineInput=CalcInputStatic(),
+        calculator=EMT(),
+        working_directory=str(tmp_path),
+    )
+
+    out_h = harmonic_free_energy(
+        structure=structure,
+        engine=engine,
+        fc2_supercell_matrix=2 * np.eye(3, dtype=int),
+        temperatures=(300.0,),
+        working_directory=str(tmp_path),
+        subdir="harmonic_ref",
+    ).run()
+    out_h = out_h["free_energy_output"] if isinstance(out_h, dict) else out_h
+
+    out_a = anharmonic_free_energy_dynaphopy(
+        structure=structure,
+        engine=engine,
+        fc2_supercell_matrix=2 * np.eye(3, dtype=int),
+        temperature=300.0,
+        production_steps=2000,
+        q_mesh=(5, 5, 5),
+        working_directory=str(tmp_path),
+        subdir="anharmonic_T300",
+    ).run()
+    out_a = out_a["free_energy_output"] if isinstance(out_a, dict) else out_a
+
+    assert out_a.mode == "anharmonic_dynaphopy"
+    assert out_a.temperature == 300.0
+    # Anharmonic and harmonic Al/EMT at 300 K should be within 50 meV/atom
+    assert abs(out_a.free_energy - out_h.free_energy) < 0.05
+    assert out_a.harmonic_frequencies.shape == out_a.renormalised_frequencies.shape

--- a/tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py
+++ b/tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py
@@ -70,8 +70,8 @@ def test_free_energy_from_spectrum_matches_einstein_closed_form():
     expected_F = 3 * _einstein_free_energy_per_mode(omega_THz, 300.0)
     expected_S = 3 * _einstein_entropy_per_mode(omega_THz, 300.0)
     expected_Cv = 3 * _einstein_cv_per_mode(omega_THz, 300.0)
-    assert F == pytest.approx(expected_F, rel=1e-8)
-    assert S == pytest.approx(expected_S, rel=1e-8)
+    assert pytest.approx(expected_F, rel=1e-8) == F
+    assert pytest.approx(expected_S, rel=1e-8) == S
     assert Cv == pytest.approx(expected_Cv, rel=1e-8)
 
 
@@ -218,4 +218,7 @@ def test_anharmonic_free_energy_dynaphopy_tdi_emt_al(tmp_path):
     assert out.mode == "anharmonic_dynaphopy_tdi"
     assert out.temperature_array.shape == (2,)
     assert out.free_energy_array.shape == (2,)
-    assert out.renormalised_frequencies_per_T.shape == (2, *out.renormalised_frequencies_per_T.shape[1:])
+    assert out.renormalised_frequencies_per_T.shape == (
+        2,
+        *out.renormalised_frequencies_per_T.shape[1:],
+    )

--- a/tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py
+++ b/tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py
@@ -1,0 +1,58 @@
+"""Tests for pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+def _einstein_free_energy_per_mode(omega_THz: float, T_K: float) -> float:
+    """Closed-form F per mode for an Einstein oscillator. eV.
+
+    F = ℏω/2 + k_B T ln(1 − exp(−ℏω / k_B T))
+    """
+    import scipy.constants as c
+
+    omega_rad_s = omega_THz * 1e12 * 2 * np.pi
+    hbar_omega_eV = c.hbar * omega_rad_s / c.eV
+    if T_K == 0:
+        return 0.5 * hbar_omega_eV
+    kT_eV = c.Boltzmann * T_K / c.eV
+    x = hbar_omega_eV / kT_eV
+    return 0.5 * hbar_omega_eV + kT_eV * np.log1p(-np.exp(-x))
+
+
+def test_free_energy_from_spectrum_matches_einstein_closed_form():
+    from pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy import (
+        _free_energy_from_spectrum,
+    )
+
+    omega_THz = 5.0
+    frequencies = np.full((1, 3), omega_THz)  # 1 q, 3 bands, all identical
+    q_weights = np.array([1.0])
+    F, S, Cv = _free_energy_from_spectrum.node_function(
+        frequencies=frequencies,
+        q_weights=q_weights,
+        temperature=300.0,
+        n_atoms_primitive=1,
+    )
+
+    expected_per_atom = 3 * _einstein_free_energy_per_mode(omega_THz, 300.0)
+    assert F == pytest.approx(expected_per_atom, rel=1e-8)
+    assert Cv > 0
+
+
+def test_free_energy_from_spectrum_rejects_imaginary_modes():
+    from pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy import (
+        _free_energy_from_spectrum,
+    )
+
+    frequencies = np.array([[5.0, -1.0, 3.0]])  # one imaginary
+    q_weights = np.array([1.0])
+    with pytest.raises(ValueError, match="imaginary modes"):
+        _free_energy_from_spectrum.node_function(
+            frequencies=frequencies,
+            q_weights=q_weights,
+            temperature=300.0,
+            n_atoms_primitive=1,
+        )

--- a/tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py
+++ b/tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py
@@ -22,6 +22,36 @@ def _einstein_free_energy_per_mode(omega_THz: float, T_K: float) -> float:
     return 0.5 * hbar_omega_eV + kT_eV * np.log1p(-np.exp(-x))
 
 
+def _einstein_entropy_per_mode(omega_THz: float, T_K: float) -> float:
+    """Closed-form S per mode for an Einstein oscillator. eV/K.
+
+    S = k_B [ x/(exp(x)−1) − ln(1 − exp(−x)) ]
+    """
+    import scipy.constants as c
+
+    omega_rad_s = omega_THz * 1e12 * 2 * np.pi
+    hbar_omega_eV = c.hbar * omega_rad_s / c.eV
+    kT_eV = c.Boltzmann * T_K / c.eV
+    x = hbar_omega_eV / kT_eV
+    kB_eV_per_K = c.Boltzmann / c.eV
+    return kB_eV_per_K * (x / np.expm1(x) - np.log1p(-np.exp(-x)))
+
+
+def _einstein_cv_per_mode(omega_THz: float, T_K: float) -> float:
+    """Closed-form C_v per mode for an Einstein oscillator. eV/K.
+
+    C_v = k_B [ x^2 exp(x) / (exp(x)−1)^2 ]
+    """
+    import scipy.constants as c
+
+    omega_rad_s = omega_THz * 1e12 * 2 * np.pi
+    hbar_omega_eV = c.hbar * omega_rad_s / c.eV
+    kT_eV = c.Boltzmann * T_K / c.eV
+    x = hbar_omega_eV / kT_eV
+    kB_eV_per_K = c.Boltzmann / c.eV
+    return kB_eV_per_K * (x**2) * np.exp(x) / np.expm1(x) ** 2
+
+
 def test_free_energy_from_spectrum_matches_einstein_closed_form():
     from pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy import (
         _free_energy_from_spectrum,
@@ -37,9 +67,12 @@ def test_free_energy_from_spectrum_matches_einstein_closed_form():
         n_atoms_primitive=1,
     )
 
-    expected_per_atom = 3 * _einstein_free_energy_per_mode(omega_THz, 300.0)
-    assert F == pytest.approx(expected_per_atom, rel=1e-8)
-    assert Cv > 0
+    expected_F = 3 * _einstein_free_energy_per_mode(omega_THz, 300.0)
+    expected_S = 3 * _einstein_entropy_per_mode(omega_THz, 300.0)
+    expected_Cv = 3 * _einstein_cv_per_mode(omega_THz, 300.0)
+    assert F == pytest.approx(expected_F, rel=1e-8)
+    assert S == pytest.approx(expected_S, rel=1e-8)
+    assert Cv == pytest.approx(expected_Cv, rel=1e-8)
 
 
 def test_free_energy_from_spectrum_rejects_imaginary_modes():

--- a/tests/unit/physics/test_free_energy_harmonic.py
+++ b/tests/unit/physics/test_free_energy_harmonic.py
@@ -1,0 +1,46 @@
+"""Tests for pyiron_workflow_atomistics.physics.free_energy.harmonic."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+@pytest.mark.slow
+def test_harmonic_free_energy_emt_al_2x2x2(tmp_path):
+    pytest.importorskip("phonopy", reason="phonopy not installed")
+
+    from ase.build import bulk
+    from ase.calculators.emt import EMT
+
+    from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+    from pyiron_workflow_atomistics.physics.free_energy.harmonic import (
+        harmonic_free_energy,
+    )
+
+    structure = bulk("Al", "fcc", a=4.05, cubic=True)
+    engine = ASEEngine(
+        EngineInput=CalcInputStatic(),
+        calculator=EMT(),
+        working_directory=str(tmp_path),
+    )
+
+    wf = harmonic_free_energy(
+        structure=structure,
+        engine=engine,
+        fc2_supercell_matrix=2 * np.eye(3, dtype=int),
+        temperatures=(0.0, 300.0),
+        working_directory=str(tmp_path),
+        subdir="harmonic",
+    )
+    out = wf.run()
+    out = out["free_energy_output"] if isinstance(out, dict) else out
+
+    assert out.mode == "harmonic"
+    assert out.reference_phase == "solid"
+    # ZPE > 0 at T=0
+    assert out.free_energy_array[0] > 0.0
+    # F decreases with T (entropy dominates)
+    assert out.free_energy_array[1] < out.free_energy_array[0]
+    # Entropy at T=0 is zero
+    assert out.entropy_array[0] == pytest.approx(0.0, abs=1e-6)

--- a/tests/unit/physics/test_free_energy_qha.py
+++ b/tests/unit/physics/test_free_energy_qha.py
@@ -13,11 +13,9 @@ def _synthetic_qha_inputs(n_T=5, n_V=7):
     Bp = 4.0
     volumes = V0 * np.linspace(0.95, 1.05, n_V)
     # Murnaghan-like E(V) parametrisation in eV/atom
-    energies = (
-        -3.5
-        + 9 * V0 * B0 / 1602.176 / Bp / (Bp - 1)
-        * (volumes / V0) ** (1 - Bp) * ((volumes / V0) ** Bp - 1)
-    )
+    energies = -3.5 + 9 * V0 * B0 / 1602.176 / Bp / (Bp - 1) * (volumes / V0) ** (
+        1 - Bp
+    ) * ((volumes / V0) ** Bp - 1)
     # Per-volume Einstein-like F(T): F(T,V) = -3 k_B T ln(...) — keep simple.
     temperatures = np.linspace(0, 400, n_T)
     F_TV = np.zeros((n_T, n_V))

--- a/tests/unit/physics/test_free_energy_qha.py
+++ b/tests/unit/physics/test_free_energy_qha.py
@@ -109,6 +109,7 @@ def test_quasiharmonic_free_energy_emt_al(tmp_path):
         subdir="qha",
     )
     out = wf.run()
+    out = out["free_energy_output"] if isinstance(out, dict) else out
 
     assert out.mode == "qha"
     # Thermal expansion is positive on warming for Al/EMT

--- a/tests/unit/physics/test_free_energy_qha.py
+++ b/tests/unit/physics/test_free_energy_qha.py
@@ -1,0 +1,118 @@
+"""Tests for pyiron_workflow_atomistics.physics.free_energy.quasiharmonic."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+
+def _synthetic_qha_inputs(n_T=5, n_V=7):
+    """Build a synthetic well-behaved QHA input grid (Vinet-like E(V), Einstein phonons)."""
+    V0 = 16.0  # Å³/atom
+    B0 = 70.0  # GPa, converted later
+    Bp = 4.0
+    volumes = V0 * np.linspace(0.95, 1.05, n_V)
+    # Murnaghan-like E(V) parametrisation in eV/atom
+    energies = (
+        -3.5
+        + 9 * V0 * B0 / 1602.176 / Bp / (Bp - 1)
+        * (volumes / V0) ** (1 - Bp) * ((volumes / V0) ** Bp - 1)
+    )
+    # Per-volume Einstein-like F(T): F(T,V) = -3 k_B T ln(...) — keep simple.
+    temperatures = np.linspace(0, 400, n_T)
+    F_TV = np.zeros((n_T, n_V))
+    S_TV = np.zeros((n_T, n_V))
+    Cv_TV = np.zeros((n_T, n_V))
+    for j, V in enumerate(volumes):
+        omega_THz = 5.0 * (V0 / V) ** 1.5
+        from pyiron_workflow_atomistics.physics.free_energy.anharmonic_dynaphopy import (
+            _free_energy_from_spectrum,
+        )
+
+        for i, T in enumerate(temperatures):
+            F_TV[i, j], S_TV[i, j], Cv_TV[i, j] = (
+                _free_energy_from_spectrum.node_function(
+                    frequencies=np.full((1, 3), omega_THz),
+                    q_weights=np.array([1.0]),
+                    temperature=T,
+                    n_atoms_primitive=1,
+                )
+            )
+    return energies, volumes, temperatures, F_TV, S_TV, Cv_TV
+
+
+def test_fit_qha_produces_finite_arrays():
+    pytest.importorskip("phonopy.qha", reason="phonopy.qha not installed")
+    from pyiron_workflow_atomistics.physics.free_energy.quasiharmonic import _fit_qha
+
+    energies, volumes, T, F_TV, S_TV, Cv_TV = _synthetic_qha_inputs()
+    result = _fit_qha.node_function(
+        energies=energies,
+        volumes=volumes,
+        free_energy_per_T_V=F_TV,
+        entropy_per_T_V=S_TV,
+        cv_per_T_V=Cv_TV,
+        temperatures=T,
+        pressure_GPa=0.0,
+        eos_type="vinet",
+    )
+    for key in (
+        "equilibrium_volume_array",
+        "gibbs_free_energy_array",
+        "bulk_modulus_array",
+        "thermal_expansion_array",
+    ):
+        arr = result[key]
+        assert arr.shape == T.shape, f"{key} shape {arr.shape} != {T.shape}"
+        assert np.all(np.isfinite(arr[1:])), f"{key} has NaNs at finite T"
+
+
+def test_check_qha_volume_range_raises_on_nan_volume():
+    from pyiron_workflow_atomistics.physics.free_energy.quasiharmonic import (
+        _check_qha_volume_range,
+    )
+
+    V_T = np.array([16.0, 16.1, np.nan, np.nan])
+    T = np.array([0.0, 100.0, 200.0, 300.0])
+    volumes = np.array([15.5, 16.0, 16.5])
+    with pytest.raises(RuntimeError, match="QHA equilibrium volume undefined"):
+        _check_qha_volume_range(V_T, T, strain_range=(-0.03, 0.03), volumes=volumes)
+
+
+@pytest.mark.slow
+def test_quasiharmonic_free_energy_emt_al(tmp_path):
+    pytest.importorskip("phonopy.qha", reason="phonopy.qha not installed")
+
+    from ase.build import bulk
+    from ase.calculators.emt import EMT
+
+    from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+    from pyiron_workflow_atomistics.physics.free_energy.quasiharmonic import (
+        quasiharmonic_free_energy,
+    )
+
+    structure = bulk("Al", "fcc", a=4.05, cubic=True)
+    engine = ASEEngine(
+        EngineInput=CalcInputStatic(),
+        calculator=EMT(),
+        working_directory=str(tmp_path),
+    )
+
+    wf = quasiharmonic_free_energy(
+        structure=structure,
+        engine=engine,
+        fc2_supercell_matrix=2 * np.eye(3, dtype=int),
+        temperatures=(0.0, 300.0),
+        strain_range=(-0.03, 0.03),
+        num_volumes=5,
+        working_directory=str(tmp_path),
+        subdir="qha",
+    )
+    out = wf.run()
+
+    assert out.mode == "qha"
+    # Thermal expansion is positive on warming for Al/EMT
+    assert out.equilibrium_volume_array[1] > out.equilibrium_volume_array[0]
+    # Thermal expansion coefficient is finite and positive at 300 K
+    assert np.isfinite(out.thermal_expansion_array[1])
+    assert out.thermal_expansion_array[1] > 0


### PR DESCRIPTION
## Summary

Adds four new free-energy macros under `physics.free_energy`, wrapping `phonopy` (harmonic + QHA), `dynaphopy` (anharmonic at one T + over a T grid), alongside the existing `calphy` nodes. Brings all three levels (harmonic / quasiharmonic / anharmonic) into one discoverable subpackage.

- `harmonic_free_energy` — phonopy FC2 at a fixed reference volume.
- `quasiharmonic_free_energy` — `phonopy.qha.QHA` on top of harmonic per volume; G(T,P), V*(T,P), B(T,P), α(T,P).
- `anharmonic_free_energy_dynaphopy` — dynaphopy MD projection + harmonic-formula F on the renormalised spectrum at one T.
- `anharmonic_free_energy_dynaphopy_tdi` — same recipe swept over a T grid.

`FreeEnergyOutput` extended with method-specific fields (entropy/Cv arrays, V*(T), G(T), B(T), α(T), renormalised frequencies, q_mesh). Handle fields are excluded from `to_dict()`.

## Implementation

Import-and-wrap consolidation; `physics.phonons.{harmonic, anharmonic, md_renormalised}` are untouched and continue to own the FC2/FC3 plumbing for the κ(T) workflow.

Notable surfaced fixes during implementation:
- `phonopy.qha.QHA` lives in `phonopy.qha.core` with kwarg `fe_phonon` (not what the spec assumed); patched.
- `phonopy.qha` truncates outputs to `n_T-1` (uses last T as a finite-difference buffer); worked around with linear extrapolation to preserve the `(n_T,)` shape contract.
- Original harmonic packer was storing phonopy's native kJ/mol-per-primitive-cell instead of eV/atom; fixed with explicit `n_atoms_primitive` divisor.
- Dynaphopy "guard" against unphysical Lorentzian fits is now observable (warns + records `report["n_guarded_modes"]`).

## Documents

- Spec: `docs/design/specs/2026-05-15-free-energy-consolidation-design.md`
- Plan: `docs/design/plans/2026-05-15-free-energy-consolidation.md`
- Notebook: `notebooks/free_energy_solid.ipynb` (fcc Al / EMT, ~7 min to execute end-to-end)

## Test plan

- [x] `pytest tests/unit/physics/test_free_energy*.py` — 52 passed, 19 skipped (calphy-extras-gated)
- [x] `pytest tests/unit/physics/test_phonons*.py tests/unit/physics/test_bulk_workflows.py` — 93 passed, no regressions
- [x] `pytest tests/integration/` — 18 passed; the 1 failure is the pre-existing `dynaphopy_grace_example.ipynb` needing `tensorpotential` (unrelated)
- [x] `black` + `ruff check` clean
- [x] Numerical regression: Al/EMT 2×2×2 harmonic F(0K) = 33.4 meV/atom (correct order of magnitude for Al ZPE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)