### PR TITLE
fix(free_energy): adapt calphy adapter to real calphy 1.5.6 API

### DIFF
--- a/pyiron_workflow_atomistics/physics/free_energy/_calphy_adapter.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/_calphy_adapter.py
@@ -424,15 +424,93 @@ def __import_calphy():
 
 
 def _setup_calculation(calc):
-    """Indirection seam so tests can monkeypatch without importing calphy."""
+    """Build the calphy phase-job from a Calculation.
+
+    calphy 1.5.6 exposes one job class per reference phase / mode:
+    ``Solid``, ``Liquid``, ``Alchemy``, ``MeltingTemp``,
+    ``CompositionTransformation``. The mode/reference-phase fields on
+    ``calc`` pick the constructor; the simfolder is materialised via
+    ``calc.create_folders()`` before the job is built (the constructors
+    immediately write ``input_file.yaml`` into ``simfolder``, so it must
+    exist on disk).
+    """
     calphy = __import_calphy()
-    return calphy.kernel.setup_calculation(calc)
+    simfolder = calc.create_folders()
+    mode = getattr(calc, "mode", None)
+    ref = getattr(calc, "reference_phase", None)
+    if mode == "alchemy":
+        return calphy.Alchemy(calculation=calc, simfolder=simfolder)
+    if mode == "composition_scaling":
+        from calphy.routines import CompositionTransformation
+
+        return CompositionTransformation(calculation=calc, simfolder=simfolder)
+    if mode == "melting_temperature":
+        return calphy.MeltingTemp(calculation=calc, simfolder=simfolder)
+    # fe / ts / tscale / pscale fork on reference_phase
+    if ref == "liquid":
+        return calphy.Liquid(calculation=calc, simfolder=simfolder)
+    return calphy.Solid(calculation=calc, simfolder=simfolder)
 
 
 def _run_calculation(job):
-    """Same indirection seam for ``calphy.kernel.run_calculation``."""
-    calphy = __import_calphy()
-    return calphy.kernel.run_calculation(job)
+    """Run a calphy phase-job to completion.
+
+    For ``fe``/``ts``/``tscale``/``pscale`` we inline the routine flow:
+    ``run_averaging`` → ``process_averaging_results`` (populates
+    ``self.lx/ly/lz`` from ``avg.dat`` — the step that calphy 1.5.6's
+    ``routine_fe`` omits, expected to be supplied externally by the
+    CLI orchestrator) → ``run_integration`` → integrate. ``alchemy``,
+    ``composition_scaling``, ``melting_temperature`` delegate to the
+    upstream routines unchanged.
+    """
+    from calphy import MeltingTemp
+    from calphy.routines import (
+        routine_alchemy,
+        routine_composition_scaling,
+    )
+
+    if isinstance(job, MeltingTemp):
+        job.run_jobs()
+        return job
+
+    mode = getattr(getattr(job, "calc", None), "mode", None)
+
+    if mode in ("fe", "ts", "tscale", "pscale"):
+        # ── averaging ─────────────────────────────────────────────────
+        job.run_averaging()
+        # bridge missing from upstream routine_fe; populates lx/ly/lz
+        # and the spring constants used by run_integration.
+        job.process_averaging_results()
+        # ── free-energy integration (always; ts/tscale/pscale piggyback) ─
+        for i in range(job.calc.n_iterations):
+            job.run_integration(iteration=i + 1)
+        job.thermodynamic_integration()
+        job.submit_report()
+        if mode == "ts":
+            for i in range(job.calc.n_iterations):
+                job.reversible_scaling(iteration=i + 1)
+            job.integrate_reversible_scaling(scale_energy=True)
+        elif mode == "tscale":
+            for i in range(job.calc.n_iterations):
+                job.reversible_scaling(iteration=i + 1)
+            job.integrate_reversible_scaling(scale_energy=False)
+        elif mode == "pscale":
+            for i in range(job.calc.n_iterations):
+                job.pressure_scaling(iteration=i + 1)
+            job.integrate_pressure_scaling()
+        job.clean_up()
+        return job
+
+    if mode == "alchemy":
+        return routine_alchemy(job)
+    if mode == "composition_scaling":
+        return routine_composition_scaling(job)
+
+    raise ValueError(
+        f"No calphy routine for mode={mode!r}. Supported: "
+        "'fe', 'ts', 'tscale', 'pscale', 'alchemy', 'composition_scaling', "
+        "'melting_temperature'."
+    )
 
 
 def _run_calphy_job(calc):

--- a/tests/unit/physics/test_free_energy.py
+++ b/tests/unit/physics/test_free_energy.py
@@ -1289,3 +1289,137 @@ def test_public_free_energy_exports():
     assert expected.issubset(set(fe.__all__))
     for name in expected:
         assert hasattr(fe, name), f"missing public export: {name}"
+
+
+# -- Adapter dispatch regression tests (calphy 1.5.6 API) ---------------------
+
+
+class _FakeCalc:
+    """Stand-in for calphy.input.Calculation used by adapter dispatch tests."""
+
+    def __init__(self, mode: str, reference_phase: str = "solid") -> None:
+        self.mode = mode
+        self.reference_phase = reference_phase
+        self.n_iterations = 1
+        self._folder_created = False
+
+    def create_folders(self) -> str:
+        self._folder_created = True
+        return "/tmp/_fake_simfolder"
+
+
+class _RecordingJob:
+    """Captures method invocations in order for adapter-flow assertions."""
+
+    def __init__(self, calc: _FakeCalc) -> None:
+        self.calc = calc
+        self.calls: list[str] = []
+
+    def __getattr__(self, name):
+        if name.startswith("_") or name in ("calc", "calls"):
+            raise AttributeError(name)
+
+        def _record(*args, **kwargs):
+            self.calls.append(name)
+
+        return _record
+
+
+def _patch_calphy_module(monkeypatch):
+    """Install a stand-in calphy module so _setup_calculation can dispatch."""
+    import sys
+    import types
+
+    fake = types.SimpleNamespace()
+    fake.Solid = lambda calculation=None, simfolder=None: _RecordingJob(calculation)
+    fake.Liquid = lambda calculation=None, simfolder=None: _RecordingJob(calculation)
+    fake.Alchemy = lambda calculation=None, simfolder=None: _RecordingJob(calculation)
+    fake.MeltingTemp = type("MeltingTemp", (_RecordingJob,), {})
+
+    fake_routines = types.SimpleNamespace()
+    fake_routines.CompositionTransformation = (
+        lambda calculation=None, simfolder=None: _RecordingJob(calculation)
+    )
+    fake_routines.routine_alchemy = lambda job: (
+        job.calls.append("routine_alchemy") or job
+    )
+    fake_routines.routine_composition_scaling = lambda job: (
+        job.calls.append("routine_composition_scaling") or job
+    )
+    monkeypatch.setitem(sys.modules, "calphy", fake)
+    monkeypatch.setitem(sys.modules, "calphy.routines", fake_routines)
+    fake.routines = fake_routines
+
+
+def test_run_calculation_inlines_process_averaging_for_fe(monkeypatch):
+    """fe-mode dispatch must call process_averaging_results between averaging and integration."""
+    _patch_calphy_module(monkeypatch)
+    from pyiron_workflow_atomistics.physics.free_energy._calphy_adapter import (
+        _run_calculation,
+    )
+
+    job = _RecordingJob(_FakeCalc("fe"))
+    _run_calculation(job)
+    expected_prefix = [
+        "run_averaging",
+        "process_averaging_results",
+        "run_integration",
+        "thermodynamic_integration",
+        "submit_report",
+        "clean_up",
+    ]
+    assert job.calls == expected_prefix, job.calls
+
+
+def test_run_calculation_ts_appends_reversible_scaling(monkeypatch):
+    """ts mode adds reversible_scaling + integrate_reversible_scaling at the end."""
+    _patch_calphy_module(monkeypatch)
+    from pyiron_workflow_atomistics.physics.free_energy._calphy_adapter import (
+        _run_calculation,
+    )
+
+    job = _RecordingJob(_FakeCalc("ts"))
+    _run_calculation(job)
+    assert "reversible_scaling" in job.calls
+    assert "integrate_reversible_scaling" in job.calls
+    assert job.calls.index("reversible_scaling") > job.calls.index("run_integration")
+
+
+def test_run_calculation_pscale_branches_to_pressure_scaling(monkeypatch):
+    """pscale mode uses pressure_scaling / integrate_pressure_scaling, not the ts variants."""
+    _patch_calphy_module(monkeypatch)
+    from pyiron_workflow_atomistics.physics.free_energy._calphy_adapter import (
+        _run_calculation,
+    )
+
+    job = _RecordingJob(_FakeCalc("pscale"))
+    _run_calculation(job)
+    assert "pressure_scaling" in job.calls
+    assert "integrate_pressure_scaling" in job.calls
+    assert "reversible_scaling" not in job.calls
+
+
+def test_run_calculation_rejects_unknown_mode(monkeypatch):
+    _patch_calphy_module(monkeypatch)
+    import pytest as _pytest
+
+    from pyiron_workflow_atomistics.physics.free_energy._calphy_adapter import (
+        _run_calculation,
+    )
+
+    job = _RecordingJob(_FakeCalc("totally-fake"))
+    with _pytest.raises(ValueError, match="No calphy routine for mode"):
+        _run_calculation(job)
+
+
+def test_setup_calculation_creates_simfolder_first(monkeypatch):
+    """_setup_calculation must materialise the simfolder before constructing the job."""
+    _patch_calphy_module(monkeypatch)
+    from pyiron_workflow_atomistics.physics.free_energy._calphy_adapter import (
+        _setup_calculation,
+    )
+
+    calc = _FakeCalc("fe", reference_phase="solid")
+    job = _setup_calculation(calc)
+    assert calc._folder_created, "create_folders() must run before the job is built"
+    assert isinstance(job, _RecordingJob)


### PR DESCRIPTION
## Problem

PR #46's calphy adapter calls a namespace that does not exist in calphy 1.5.6:

```python
return calphy.kernel.setup_calculation(calc)  # AttributeError
```

The calphy path was gated behind `pytest.importorskip(\"calphy\")`, so CI never ran it. End-to-end exercise — wiring it through a real LAMMPS build and a GRACE potential — surfaced three concrete gaps.

## Fixes

1. **Dispatch on real calphy classes.** `_setup_calculation` now picks `Solid` / `Liquid` / `Alchemy` / `MeltingTemp` / `routines.CompositionTransformation` based on `mode` and `reference_phase`, instead of calling a non-existent `calphy.kernel.setup_calculation`.

2. **Materialise the simfolder.** `Solid()` (and friends) immediately writes `input_file.yaml` into `simfolder` in its constructor and raises on the `None` default. The adapter now calls `calc.create_folders()` first and threads the path through.

3. **Inject the `process_averaging_results` bridge.** calphy 1.5.6's `routine_fe` calls `run_averaging()` → `run_integration()` directly, leaving `self.lx/ly/lz` as `None`. Those box-dimension fields are only populated by `process_averaging_results()`, which the upstream `routine_fe` skips (the CLI orchestrator calls it externally). `_run_calculation` now inlines the full sequence with the bridge step injected, then forks on `mode` to add reversible-scaling (`ts`/`tscale`) or pressure-scaling (`pscale`). `alchemy`, `composition_scaling`, and `melting_temperature` continue to delegate to their upstream routines unchanged.

## Tests

Five new dispatch regression tests in `tests/unit/physics/test_free_energy.py` use a `monkeypatch`-installed fake `calphy` module so the dispatch logic is exercised in CI without needing a real calphy + LAMMPS install:

- `test_run_calculation_inlines_process_averaging_for_fe` — confirms the call sequence is `run_averaging → process_averaging_results → run_integration → thermodynamic_integration → submit_report → clean_up`.
- `test_run_calculation_ts_appends_reversible_scaling` — `ts` mode appends `reversible_scaling` + `integrate_reversible_scaling` AFTER the `fe` sequence.
- `test_run_calculation_pscale_branches_to_pressure_scaling` — `pscale` uses `pressure_scaling` / `integrate_pressure_scaling`, not the `ts` variants.
- `test_run_calculation_rejects_unknown_mode` — unknown modes raise `ValueError`.
- `test_setup_calculation_creates_simfolder_first` — `create_folders()` runs before the job is constructed.

## Test plan

- [x] `pytest tests/unit/physics/test_free_energy.py` — 48 passed, 19 skipped (calphy-extras-gated, unchanged from prior state).
- [x] `ruff check .` and `black --check` clean.
- [x] Smoke-tested end-to-end via local calphy + GRACE on FCC Cu (`reversible_scaling_temperature`, T=[200, 1200] K). Reaches `run_integration` cleanly after the bridge fix; the integration step itself surfaces a separate LAMMPS-side issue (`EXTRA-FIX` package missing from the local lmp build) that is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)