### PR TITLE
fix(grand_canonical_gb): correct gb_energy formula for ASE engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and the package follows [PEP 440](https://peps.python.org/pep-0440/) versioning
 via `versioneer`.
 
+## [0.0.11] — 2026-05-16
+
+### Fixed
+
+- **`physics.grand_canonical_gb` GB-energy formula.** The ported
+  ``gb_energy()`` followed GRIP's ``(E_total − n_mask·E_coh) / area``
+  formulation, which only works when the calculator provides per-atom
+  energy decomposition (LAMMPS-native). Under any ASE engine the full
+  slab energy was summed against a partial atom mask, producing
+  non-physical negative excess that clamped to 100 J/m² every iteration.
+  Now matches ``physics.grain_boundary.get_GB_energy``:
+
+      Egb = (E_total − N·E_coh) / (2·area) · 16.021766    [J/m²]
+
+  where ``N`` is the **total** atom count in the slab and the factor of 2
+  accounts for the two equivalent GB planes in a periodic bicrystal.
+  The private ``_count_atoms_in_gb_region`` helper is removed.
+- The ``n_gb_atoms`` parameter of ``gb_energy()`` is renamed to
+  ``n_atoms`` to reflect the new semantics. The signature change is
+  internal to ``_grand_canonical_gb_code`` (not part of the public
+  ``physics.grand_canonical_gb`` API), so consumers of ``gco_search``
+  see no breakage.
+
 ## [0.0.10] — 2026-05-16
 
 ### Added

--- a/pyiron_workflow_atomistics/physics/_grand_canonical_gb_code/energies.py
+++ b/pyiron_workflow_atomistics/physics/_grand_canonical_gb_code/energies.py
@@ -1,7 +1,23 @@
 """Grain-boundary energy formula.
 
-Port of GRIP's ``Calculator.get_gb_energy`` (``core/calculator.py``), as a
-pure function — no calculator state, no atoms, just numbers.
+Adapted from GRIP's ``Calculator.get_gb_energy`` (``core/calculator.py``).
+
+Differences from the GRIP formula
+---------------------------------
+GRIP divides by a single ``area`` and uses the count of atoms inside a
+z-mask around the GB plane. That formulation only works when the
+calculator provides per-atom energy decomposition (LAMMPS-native) so the
+energy is summed against the same masked atom set. Under a generic ASE
+engine the full slab energy is summed against a partial atom count,
+producing non-physical negative excess.
+
+Instead we use the standard pyiron_workflow_atomistics convention
+(matches ``physics.grain_boundary.get_GB_energy``):
+
+    Egb = (E_total − N × E_coh) / (2 × area) × 16.021766    [J/m²]
+
+where ``N`` is the **total** atom count in the slab and the factor of 2
+accounts for the two equivalent GB planes in a periodic bicrystal.
 """
 
 from __future__ import annotations
@@ -13,26 +29,31 @@ logger = logging.getLogger(__name__)
 # eV / Å² → J / m²
 _EV_PER_A2_TO_J_PER_M2 = 16.021766
 
-# Clamp value for unphysical negative GB energies (matches GRIP).
+# Clamp value for unphysical negative GB energies (preserves GRIP's behaviour
+# of producing a single, easily-spotted sentinel value rather than a NaN).
 _NEGATIVE_CLAMP_J_PER_M2 = 100.0
 
 
 def gb_energy(
     final_energy_ev: float,
-    n_gb_atoms: int,
+    n_atoms: int,
     gb_area_a2: float,
     e_cohesive_ev: float,
 ) -> float:
-    """Grain-boundary energy in J/m².
+    """Grain-boundary energy in J/m² for a periodic bicrystal.
 
-        Egb = (E_total - n_gb_atoms × E_coh) / area × 16.021766
+        Egb = (E_total − N × E_coh) / (2 × area) × 16.021766
+
+    The factor of 2 in the denominator accounts for the two equivalent
+    GB planes produced when the bicrystal is stitched with periodic
+    boundaries (one at the stitch line, one across the z-boundary).
 
     Negative results indicate an unphysical configuration; clamped to
-    100 J/m² with a warning (preserves upstream GRIP behaviour).
+    100 J/m² with a warning.
     """
-    e_bulk = n_gb_atoms * e_cohesive_ev
+    e_bulk = n_atoms * e_cohesive_ev
     e_excess = final_energy_ev - e_bulk
-    e_gb = e_excess / gb_area_a2 * _EV_PER_A2_TO_J_PER_M2
+    e_gb = e_excess / (2.0 * gb_area_a2) * _EV_PER_A2_TO_J_PER_M2
 
     if e_gb < 0:
         logger.warning(

--- a/pyiron_workflow_atomistics/physics/grand_canonical_gb.py
+++ b/pyiron_workflow_atomistics/physics/grand_canonical_gb.py
@@ -109,21 +109,6 @@ def build_bicrystal_slabs(
 # ---------------------------------------------------------------------------
 
 
-def _count_atoms_in_gb_region(structure: Atoms, bounds: np.ndarray) -> int:
-    """Atom count inside the (pad-extended) GB region.
-
-    Port of GRIP ``Simulation.get_gb_energy``'s z-mask, used to populate
-    ``n_gb_atoms`` for the energy formula.
-    """
-    lowerb, upperb, pad = bounds
-    z = structure.positions[:, 2]
-    z_min, z_max = z.min(), z.max()
-    lower_cutoff = z_min + lowerb - pad
-    upper_cutoff = z_max - upperb + pad
-    mask = (z >= lower_cutoff) & (z <= upper_cutoff)
-    return int(mask.sum())
-
-
 def _make_iter_md_engine(
     md_engine: Engine,
     temperature: int,
@@ -289,7 +274,6 @@ def gco_search(
                 voronoi_warned = True
 
         atoms = bc.gb
-        bounds = bc.bounds
         n_frac = bc.n if bc.n is not None else 0.0
 
         # ---- optional MD -----------------------------------------------
@@ -319,13 +303,12 @@ def gco_search(
             continue
 
         # ---- score + keep ----------------------------------------------
-        n_gb = _count_atoms_in_gb_region(out.final_structure, bounds)
         area = float(out.final_structure.cell[0, 0]) * float(
             out.final_structure.cell[1, 1]
         )
         egb = gb_energy(
             final_energy_ev=out.final_energy,
-            n_gb_atoms=n_gb,
+            n_atoms=len(out.final_structure),
             gb_area_a2=area,
             e_cohesive_ev=e_cohesive,
         )

--- a/tests/unit/physics/test_gco_energy.py
+++ b/tests/unit/physics/test_gco_energy.py
@@ -12,24 +12,24 @@ from pyiron_workflow_atomistics.physics._grand_canonical_gb_code.energies import
 
 
 def test_zero_excess_gives_zero_egb():
-    # E_total exactly == n * E_coh ⇒ Egb = 0
+    # E_total exactly == N * E_coh ⇒ Egb = 0
     assert gb_energy(
         final_energy_ev=-48.312,
-        n_gb_atoms=10,
+        n_atoms=10,
         gb_area_a2=100.0,
         e_cohesive_ev=-4.8312,
     ) == pytest.approx(0.0, abs=1e-9)
 
 
-def test_positive_excess_converts_to_jpm2():
-    # 1 eV excess over 1 Å² ⇒ Egb = 16.021766 J/m²
+def test_positive_excess_converts_to_jpm2_with_two_gb_factor():
+    # 1 eV excess over 1 Å² with two-GB factor ⇒ Egb = 16.021766 / 2 J/m²
     e = gb_energy(
         final_energy_ev=-47.312,  # 1 eV above 10*(-4.8312)
-        n_gb_atoms=10,
+        n_atoms=10,
         gb_area_a2=1.0,
         e_cohesive_ev=-4.8312,
     )
-    assert e == pytest.approx(16.021766, rel=1e-6)
+    assert e == pytest.approx(16.021766 / 2.0, rel=1e-6)
 
 
 def test_negative_egb_clamped_to_hundred(caplog):
@@ -39,7 +39,7 @@ def test_negative_egb_clamped_to_hundred(caplog):
     ):
         e = gb_energy(
             final_energy_ev=-49.0,  # below the bulk reference
-            n_gb_atoms=10,
+            n_atoms=10,
             gb_area_a2=100.0,
             e_cohesive_ev=-4.8312,
         )
@@ -48,13 +48,31 @@ def test_negative_egb_clamped_to_hundred(caplog):
 
 
 def test_realistic_scale():
-    # Cu GB target: 0.5 J/m² over 100 Å² with 50 atoms in GB region at E_coh=-3.59 eV/atom.
-    # E_excess = 0.5 / 16.021766 * 100 ≈ 3.121 eV
-    # E_total  = 50 * (-3.59) + 3.121 ≈ -176.38 eV
+    # Al GB target: 0.5 J/m² over 100 Å² with 50 atoms at E_coh=-3.59 eV/atom.
+    # Egb = (E_total − N·E_coh) / (2·A) · 16.021766
+    # ⇒ E_total − N·E_coh = 0.5 · 2 · 100 / 16.021766 ≈ 6.242 eV
+    # ⇒ E_total = 50·(-3.59) + 6.242 = -173.258 eV
     e = gb_energy(
-        final_energy_ev=-176.38,
-        n_gb_atoms=50,
+        final_energy_ev=-173.258,
+        n_atoms=50,
         gb_area_a2=100.0,
         e_cohesive_ev=-3.59,
     )
     assert e == pytest.approx(0.5, rel=0.01)
+
+
+def test_matches_get_GB_energy_convention():
+    """gb_energy() must match physics.grain_boundary.get_GB_energy semantics.
+
+    Both use the periodic-bicrystal convention: full atom count divided by
+    twice the cross-sectional area.
+    """
+    e_pwa = gb_energy(
+        final_energy_ev=-100.0,
+        n_atoms=30,
+        gb_area_a2=50.0,
+        e_cohesive_ev=-3.5,
+    )
+    # Same formula, computed inline:
+    expected = (-100.0 - 30 * (-3.5)) / (2.0 * 50.0) * 16.021766
+    assert e_pwa == pytest.approx(expected, rel=1e-9)


### PR DESCRIPTION
## Summary

The merged `gb_energy()` carried GRIP's atom-mask + single-area formula, which only works when the calculator provides per-atom energy decomposition (LAMMPS-native). Under any ASE engine, the full slab energy is summed against a partial atom mask — producing non-physical *negative* excess that the function then clamps to 100 J/m² every iteration. The negative-clamp warnings flooded the logs in any non-LAMMPS GCO run.

Switch to the standard pwa convention (matches `physics.grain_boundary.get_GB_energy`):

```
Egb = (E_total - N·E_coh) / (2·area) · 16.021766    [J/m²]
```

where `N` is the **total** atom count in the slab, and the factor of 2 accounts for the two equivalent GB planes produced when the bicrystal is stitched with periodic boundaries.

## Changes

- `_grand_canonical_gb_code/energies.py`: rewrite `gb_energy()` to use `len(atoms) / (2·area)`. Rename parameter `n_gb_atoms` → `n_atoms` to reflect the new semantics.
- `grand_canonical_gb.py`: in `gco_search`, pass `n_atoms=len(out.final_structure)` instead of the masked count. Drop the now-unused `_count_atoms_in_gb_region` helper.
- `tests/unit/physics/test_gco_energy.py`: update expected values for the new formula; add `test_matches_get_GB_energy_convention` pinning the convention against the inline formula.
- `CHANGELOG.md`: 0.0.11 entry.

## Verification

- Reproduced the bug end-to-end with an Al + EAM(`Al-Fe.eam.fs`) Σ3⟨110⟩ tilt boundary: before the fix, every iteration printed `Computed negative GB energy (~-8.7 J/m²); clamping to 100.0 J/m²`. After the fix, Egb values are physical (0.18–0.95 J/m², lowest ≈ 0.18 J/m² at iter 0).
- Cross-check with `physics.grain_boundary.get_GB_energy` on the same kept structures gives identical Egb to four decimal places.
- 72/72 GCO unit + integration tests pass (71 + 1 new convention-match test).

## Test Plan

- [x] `pytest tests/unit/physics/test_gco_*.py tests/integration/test_gco_emt.py` — 72/72 pass
- [x] Lint (`ruff check`, `black --check`) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)