### PR TITLE
docs(notebooks): add grand_canonical_gb_example.ipynb (MD + relax)

### DIFF
--- a/notebooks/grand_canonical_gb_example.ipynb
+++ b/notebooks/grand_canonical_gb_example.ipynb
@@ -1,0 +1,483 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e023fe9c",
+   "metadata": {},
+   "source": [
+    "# Grand-canonical grain-boundary optimization (Al, EAM, MD + relax)\n",
+    "\n",
+    "Sample the lowest-energy grain-boundary microstructures by varying\n",
+    "the vacancy fraction on the GB plane, the in-plane translation\n",
+    "between the two crystallites, and the supercell replication. Each\n",
+    "candidate is **thermalised by a short MD run** and then relaxed under\n",
+    "BFGS — the MD step helps the candidate escape shallow local minima\n",
+    "before the final relaxation.\n",
+    "\n",
+    "This notebook demonstrates the [`gco_search`](../pyiron_workflow_atomistics/physics/grand_canonical_gb.py)\n",
+    "workflow on an FCC-Al tilt boundary using the EAM `Al-Fe.eam.fs`\n",
+    "potential shipped with this repo. The algorithm is a port of\n",
+    "Chen & Frolov's GRIP ([Nat. Commun. **15**, 7049 (2024)](https://doi.org/10.1038/s41467-024-51330-9);\n",
+    "upstream: https://github.com/enze-chen/grip).\n",
+    "\n",
+    "> **Cell convention:** with the default `vacuum=1.0` Å, the bicrystal\n",
+    "> cell has **two equivalent GB planes** — one at the stitch line and\n",
+    "> one across the z-periodic boundary. The 1 Å is intentionally too\n",
+    "> thin to be a real vacuum layer, making the cell a bulk-periodic\n",
+    "> stack of bicrystals. The GB-energy formula in\n",
+    "> `_grand_canonical_gb_code.gb_energy` therefore divides by\n",
+    "> `2 × area`. If you ever increase `vacuum` to make a true slab\n",
+    "> (`>15` Å), that formula will mix surface energy into `Egb`.\n",
+    ">\n",
+    "> **Caveat on absolute numbers:** `Al-Fe.eam.fs` is fit for the\n",
+    "> Al–Fe interaction; its pure-Al GB energies are an order-of-magnitude\n",
+    "> demonstration only. The notebook structure transfers directly to\n",
+    "> any other ASE-compatible calculator (MACE, CHGNet, MTP, …)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0fda633d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-16T15:21:05.295116Z",
+     "iopub.status.busy": "2026-05-16T15:21:05.294449Z",
+     "iopub.status.idle": "2026-05-16T15:21:09.812466Z",
+     "shell.execute_reply": "2026-05-16T15:21:09.809571Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pathlib\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from ase.calculators.eam import EAM\n",
+    "from ase.optimize import BFGS\n",
+    "\n",
+    "from pyiron_workflow_atomistics.engine import (\n",
+    "    ASEEngine,\n",
+    "    CalcInputMD,\n",
+    "    CalcInputMinimize,\n",
+    ")\n",
+    "from pyiron_workflow_atomistics.physics.bulk import optimise_cubic_lattice_parameter\n",
+    "from pyiron_workflow_atomistics.physics.grand_canonical_gb import (\n",
+    "    GCOConfig,\n",
+    "    build_bicrystal_slabs,\n",
+    "    gco_search,\n",
+    ")\n",
+    "from pyiron_workflow_atomistics.structure import get_bulk"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f8f2527",
+   "metadata": {},
+   "source": [
+    "## 1. Build the engines\n",
+    "\n",
+    "`gco_search` always runs a relaxation per iteration, and (when\n",
+    "supplied) an MD run before it. We therefore build **two** engines\n",
+    "under the same EAM potential — they share the calculator but carry\n",
+    "different `EngineInput` types:\n",
+    "\n",
+    "- **minimize_engine** — `CalcInputMinimize(force_convergence_tolerance=0.001)`.\n",
+    "  Runs every iteration. `optimizer_kwargs={\"logfile\": None}` suppresses\n",
+    "  BFGS's per-step printouts to keep the notebook readable.\n",
+    "- **md_engine** — `CalcInputMD(mode=\"NVT\", thermostat=\"langevin\")`.\n",
+    "  `gco_search` overrides `temperature` and `n_ionic_steps` per iteration\n",
+    "  via `dataclasses.replace`, so the values below are just placeholders\n",
+    "  for the engine constructor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7889fb31",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-16T15:21:09.817385Z",
+     "iopub.status.busy": "2026-05-16T15:21:09.816680Z",
+     "iopub.status.idle": "2026-05-16T15:21:09.912263Z",
+     "shell.execute_reply": "2026-05-16T15:21:09.908640Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pot_path = next(\n",
+    "    p\n",
+    "    for p in (pathlib.Path(\"Al-Fe.eam.fs\"), pathlib.Path(\"notebooks/Al-Fe.eam.fs\"))\n",
+    "    if p.exists()\n",
+    ")\n",
+    "calculator = EAM(potential=str(pot_path))\n",
+    "\n",
+    "minimize_engine = ASEEngine(\n",
+    "    EngineInput=CalcInputMinimize(\n",
+    "        force_convergence_tolerance=0.001, max_iterations=500\n",
+    "    ),\n",
+    "    calculator=calculator,\n",
+    "    optimizer_class=BFGS,\n",
+    "    optimizer_kwargs={\"logfile\": None},\n",
+    "    working_directory=\"./_gco_aleam_runs\",\n",
+    "    write_to_disk=False,\n",
+    ")\n",
+    "\n",
+    "md_engine = ASEEngine(\n",
+    "    EngineInput=CalcInputMD(\n",
+    "        mode=\"NVT\",\n",
+    "        thermostat=\"langevin\",\n",
+    "        temperature=400.0,     # overridden per iter by gco_search\n",
+    "        n_ionic_steps=50,       # overridden per iter by gco_search\n",
+    "        time_step=1.0,          # fs\n",
+    "        thermostat_time_constant=100.0,  # fs\n",
+    "        seed=0,\n",
+    "    ),\n",
+    "    calculator=calculator,\n",
+    "    working_directory=\"./_gco_aleam_runs\",\n",
+    "    write_to_disk=False,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64b452cc",
+   "metadata": {},
+   "source": [
+    "## 2. Optimize the bulk reference under the same calculator\n",
+    "\n",
+    "The GB-energy formula\n",
+    "$E_\\mathrm{gb} = (E_\\mathrm{total} - N\\,E_\\mathrm{coh})/(2 A)\\, \\times 16.0218 \\; \\mathrm{J/m^2}$\n",
+    "requires the bulk per-atom cohesive energy *under the same potential*\n",
+    "as the GB relaxation. We get it by running\n",
+    "[`optimise_cubic_lattice_parameter`](../pyiron_workflow_atomistics/physics/bulk.py) —\n",
+    "an EOS volume-scan macro that fits a Birch–Murnaghan EOS to a small\n",
+    "strain sweep and returns the equilibrium lattice parameter, bulk\n",
+    "modulus, per-atom energy, and per-atom volume."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5a59eae9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-16T15:21:09.918671Z",
+     "iopub.status.busy": "2026-05-16T15:21:09.918224Z",
+     "iopub.status.idle": "2026-05-16T15:21:10.577498Z",
+     "shell.execute_reply": "2026-05-16T15:21:10.574073Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a0           = 4.0336 Å\n",
+      "e_cohesive   = -3.3697 eV/atom\n",
+      "B            = 80.4 GPa\n",
+      "v0           = 16.407 Å³/atom\n"
+     ]
+    }
+   ],
+   "source": [
+    "al_guess = get_bulk.node_function(\"Al\", crystalstructure=\"fcc\", a=4.05, cubic=True)\n",
+    "\n",
+    "bulk_wf = optimise_cubic_lattice_parameter(\n",
+    "    structure=al_guess,\n",
+    "    name=\"Al\",\n",
+    "    crystalstructure=\"fcc\",\n",
+    "    engine=minimize_engine.with_working_directory(\"bulk_opt\"),\n",
+    "    rattle_amount=0.0,\n",
+    "    strain_range=(-0.02, 0.02),\n",
+    "    num_points=5,\n",
+    ")\n",
+    "bulk_wf.run()\n",
+    "\n",
+    "a0 = bulk_wf.outputs.a0.value\n",
+    "e0_per_atom = bulk_wf.outputs.equil_energy_per_atom.value\n",
+    "B_GPa = bulk_wf.outputs.B.value\n",
+    "v0_per_atom = bulk_wf.outputs.equil_volume_per_atom.value\n",
+    "\n",
+    "print(f\"a0           = {a0:.4f} Å\")\n",
+    "print(f\"e_cohesive   = {e0_per_atom:.4f} eV/atom\")\n",
+    "print(f\"B            = {B_GPa:.1f} GPa\")\n",
+    "print(f\"v0           = {v0_per_atom:.3f} Å³/atom\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "979d807d",
+   "metadata": {},
+   "source": [
+    "## 3. Build matched upper / lower slabs\n",
+    "\n",
+    "`build_bicrystal_slabs` constructs the two crystallites from a tilt\n",
+    "axis specified per slab. The two slabs here describe a Σ3 ⟨110⟩ tilt\n",
+    "boundary in FCC Al, using the optimized `a0` from step 2."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4a7a23db",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-16T15:21:10.581794Z",
+     "iopub.status.busy": "2026-05-16T15:21:10.581376Z",
+     "iopub.status.idle": "2026-05-16T15:21:10.636678Z",
+     "shell.execute_reply": "2026-05-16T15:21:10.626989Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lower: 16 atoms\n",
+      "upper: 16 atoms\n",
+      "dlat  = 1.426 Å\n"
+     ]
+    }
+   ],
+   "source": [
+    "lower_slab, upper_slab, dlat = build_bicrystal_slabs.node_function(\n",
+    "    crystal=\"fcc\",\n",
+    "    symbol=\"Al\",\n",
+    "    a=a0,\n",
+    "    upper_dirs=[[1, 1, 0], [0, 0, 1], [1, -1, 0]],\n",
+    "    lower_dirs=[[1, -1, 0], [0, 0, 1], [-1, -1, 0]],\n",
+    "    cutoff=20.0,\n",
+    ")\n",
+    "print(f\"lower: {len(lower_slab)} atoms\")\n",
+    "print(f\"upper: {len(upper_slab)} atoms\")\n",
+    "print(f\"dlat  = {dlat:.3f} Å\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7a42219f",
+   "metadata": {},
+   "source": [
+    "## 4. Configure the GCO search\n",
+    "\n",
+    "Per-iteration MD parameters:\n",
+    "\n",
+    "- `md_run_probability=1.0` — every iteration runs MD before the\n",
+    "  relaxation. Set < 1.0 for stochastic gating.\n",
+    "- `t_min`, `t_max` — random temperature in this range (multiples of\n",
+    "  100 K). Here both equal 400 K, so every MD runs at 400 K.\n",
+    "- `md_step_sampling=\"exact\"` — every MD runs exactly `md_min_steps`\n",
+    "  steps (no random sweep). For demo speed.\n",
+    "- `md_min_steps=md_max_steps=50` — 50 × 1 fs = 50 fs of MD per iter.\n",
+    "  A real run would use 1–500 ps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ddced284",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-16T15:21:10.652627Z",
+     "iopub.status.busy": "2026-05-16T15:21:10.652179Z",
+     "iopub.status.idle": "2026-05-16T15:21:10.660733Z",
+     "shell.execute_reply": "2026-05-16T15:21:10.658112Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "config = GCOConfig(\n",
+    "    # vacancy fraction on the GB plane: scan 0.5 .. 1.0\n",
+    "    frac_min=0.5,\n",
+    "    frac_max=1.0,\n",
+    "    # small supercells to keep the demo fast\n",
+    "    size0=(1, 1, 1),\n",
+    "    size=(1, 2, 5),\n",
+    "    reps_mode=2,  # uniform\n",
+    "    ngrid=10,\n",
+    "    # MD before every iteration\n",
+    "    md_run_probability=1.0,\n",
+    "    t_min=400,\n",
+    "    t_max=400,\n",
+    "    md_min_steps=50,\n",
+    "    md_max_steps=50,\n",
+    "    md_step_sampling=\"exact\",\n",
+    "    # disable periodic dedup for clarity; n=3 is too short for it to matter\n",
+    "    dedup_every=0,\n",
+    "    # generous Egb gate so most converged iterations get kept\n",
+    "    e_mult=5.0,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f522d5d1",
+   "metadata": {},
+   "source": [
+    "## 5. Run the search\n",
+    "\n",
+    "Each iteration now does:\n",
+    "\n",
+    "1. Sample translation, replication, vacancy fraction\n",
+    "2. Stitch the bicrystal\n",
+    "3. **MD at 400 K for 50 fs** (`md_engine`)\n",
+    "4. Relax under BFGS to `fmax = 0.001 eV/Å` (`minimize_engine`)\n",
+    "5. Compute `Egb` and conditionally store\n",
+    "\n",
+    "Returns `(DataFrame, list[ase.Atoms])`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0c3a0cc3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-16T15:21:10.664071Z",
+     "iopub.status.busy": "2026-05-16T15:21:10.663766Z",
+     "iopub.status.idle": "2026-05-16T15:28:05.310195Z",
+     "shell.execute_reply": "2026-05-16T15:28:05.307340Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/liger/miniforge3/envs/test_pyiron_workflow_atomistics/lib/python3.11/site-packages/ase/md/langevin.py:110: FutureWarning: The implementation of `fixcm=True` in `Langevin` does not strictly sample the correct NVT distributions. The deviations are typically small for large systems but can be more pronounced for small systems. Use `fixcm=False` together with `ase.constraints.FixCom`. `fixcm` is deprecated since ASE 3.28.0 and will be removed in a future release.\n",
+      "  warnings.warn(msg, FutureWarning)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Kept 3 structures across 3 iterations:\n",
+      "\n",
+      " iter      Egb   n  rx  ry   T  n_md_steps\n",
+      "    0 0.101962 0.0   1   1 400          50\n",
+      "    1 0.283826 0.5   1   2 400          50\n",
+      "    2 0.199803 0.0   1   1 400          50\n"
+     ]
+    }
+   ],
+   "source": [
+    "df, atoms_list = gco_search.node_function(\n",
+    "    minimize_engine=minimize_engine,\n",
+    "    md_engine=md_engine,\n",
+    "    lower_slab=lower_slab,\n",
+    "    upper_slab=upper_slab,\n",
+    "    dlat=dlat,\n",
+    "    e_cohesive=e0_per_atom,\n",
+    "    config=config,\n",
+    "    n_iters=3,\n",
+    "    seed=0,\n",
+    ")\n",
+    "print(f\"Kept {len(df)} structures across 3 iterations:\\n\")\n",
+    "print(df[[\"iter\", \"Egb\", \"n\", \"rx\", \"ry\", \"T\", \"n_md_steps\"]].to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d8ecd6c",
+   "metadata": {},
+   "source": [
+    "## 6. Plot $E_\\mathrm{gb}$ versus vacancy fraction\n",
+    "\n",
+    "The classic GRIP output. With only 3 iterations the plot is sparse;\n",
+    "scaling to hundreds of iterations across multiple seeds (via\n",
+    "`for_node`) populates the n-vs-Egb curve properly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d3697ddc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-16T15:28:05.314311Z",
+     "iopub.status.busy": "2026-05-16T15:28:05.313847Z",
+     "iopub.status.idle": "2026-05-16T15:28:05.815309Z",
+     "shell.execute_reply": "2026-05-16T15:28:05.811763Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk4AAAGGCAYAAACNCg6xAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAZhRJREFUeJzt3XlYlFX/P/D3DMiwb8qqKCLuiigqEYqaJJZrYrmL5oPlVsHjWgluCamJ9bgV5VJhmmupT2aSmAtqD0jmmpjmxmYq4MI65/eHP+brOAPMMAuDvV/XNdfFnPvc55z7M9uHc5+5RyKEECAiIiKiaklrewBEREREdQUTJyIiIiINMXEiIiIi0hATJyIiIiINMXEiIiIi0hATJyIiIiINMXEiIiIi0hATJyIiIiINMXEiIiIi0hATJ6KnXL16FRKJBBs2bDB632VlZZg5cya8vLwglUoxePBgvbS7YcMGSCQSXL16VS/tmYqUlBRIJBKkpKQoysaNGwdvb+9aG5Mu5HI52rVrhw8++KC2h0Ja6NmzJ3r27Fnbw9ALU3z9DB8+HK+99lptD0OBiVMdduXKFUydOhUtWrSAtbU1rK2t0aZNG0yZMgWnT59Wu09GRgZGjx4NLy8vyGQyODs7IzQ0FOvXr0d5eblS3QcPHmDhwoXw8/ODtbU1HBwc0L17d3z55ZfgL/UYxrp167B06VIMHToUGzduRFRUlEb7de3aFRKJBGvWrNGp/3nz5kEikai9rV27VqluUVEREhISEBgYCAcHB1haWqJFixaYOnUq/vjjD5W2tXnuPW316tU1TmQfPnyIefPmKSVXmsjNzcXs2bPRvn172NrawtLSEr6+vhg/fjyOHDmiVLciMX3y5urqil69euGHH37QuM9vvvkG169fx9SpU6ts+8nb8ePHVdq5d+8eLC0tIZFIcP78ebV9jRs3DhKJBPb29nj06JHK9kuXLin6WLZsmcbHoI8+KhLiiptMJoObmxt69uyJxYsXIy8vr0bj+Sf45ZdfMHDgQHh5ecHS0hLu7u7o27cvjh49WqP2avr60adZs2Zh+/bt+O2332ptDE8yr+0BUM3s2bMHw4YNg7m5OUaNGoUOHTpAKpXiwoUL2LFjB9asWYMrV66gSZMmin0+//xzvPnmm3Bzc8OYMWPQvHlzFBYWIjk5GRMmTEBWVhbeffddAEBOTg569+6N8+fPY/jw4Zg6dSqKioqwfft2RERE4L///S+SkpJgZmZWWyF4Jv38889o2LAhEhISNN7n0qVL+PXXX+Ht7Y2kpCRMmjRJ53GsWbMGtra2SmWBgYGKv2/fvo2+ffsiLS0N/fv3x8iRI2Fra4uLFy9i8+bN+Oyzz1BSUqKor81zT53Vq1ejQYMGGDdunFJ5SEgIHj16BAsLi0r3ffjwIebPnw8AGs8KnDx5Ev369UNhYSGGDx+ON998EzKZDFeuXMGuXbuwYcMGHDp0CCEhIUr7LViwAE2bNoUQAjk5OdiwYQNefvll7N69G/3796+236VLl2L48OFwcHBQ2VbR9tN8fX1VyrZu3QqJRAJ3d3ckJSVh0aJFavszNzfHw4cPsXv3bpX/6JOSkmBpaYmioqJqx10VXfp466230KVLF5SXlyMvLw/Hjh1DbGwsli9fjm+//RYvvPCCTmN7Fv3xxx+QSqV488034e7ujrt37+Lrr79GSEgI9u7di759+1a5f2JiIuRyueJ+TV4/+taxY0d07twZH330Eb788staGYMSQXVOZmamsLGxEa1btxa3bt1S2V5aWio+/vhjce3aNUVZamqqMDMzE926dRMFBQUq+/z6669i/fr1ivthYWFCKpWK7777TqXu9OnTBQARHx+vnwMyMVeuXBEAlOJhLL169RJt27bVap+YmBjh6uoqtm/fLiQSibhy5YpKnfXr1wsAarc9KTY2VgAQeXl5Vdbr16+fkEqlYtu2bSrbioqKxL///W/FfW2fe+q0bdtW9OjRo8o6FSIiIkSTJk0U9/Py8gQAERsbq9H+d+7cER4eHsLd3V2cP39eZbtcLhebNm0SJ0+eVJRVxPfXX39VaatevXpi5MiR1fabnp4uAIgDBw4olVfWdlVCQkLEkCFDRFRUlGjatKnaOhEREcLGxkb06dNHDB48WGV78+bNRXh4uAAgli5dqnHf+ujj4MGDAoDYunWryj4ZGRnC1dVVODo6qn3/e1KPHj1ERESE1uO+f/++VvV79Oih8fOzNjx48EC4ubmJsLAwrffV9vWjKW1jvGzZMmFjYyMKCwv1Oo6aYOJUB02cOFEAEMePH9d4n759+wpzc3Px119/VVs3NTVVABCvv/662u2lpaWiefPmwsnJSTx8+LDKtn799VfRp08fUb9+fWFpaSm8vb3F+PHjleosXbpUBAUFCWdnZ2FpaSk6deqk9g0TgJgyZYr49ttvRevWrYWlpaV47rnnxOnTp4UQQqxdu1Y0a9ZMyGQy0aNHD5UkoUePHqJt27bif//7nwgKClKMZ82aNUr1Kkuczp8/L8LDw4WTk5OQyWQiICBAbWKpzv3790V0dLRo1KiRsLCwEC1atBBLly4Vcrlcqc+nbwcPHqy2bV9fXzF58mRRXFwsHB0dxQcffKBSR5+J0/HjxwUAERkZWe3YhNDuuadOkyZNVOJS8SFV8QH7ZJyeTJwqi2tVHwKLFy8WAMTmzZs1HmNlyY1cLhf29vZi7Nix1bYRExMjLCwsRElJiUZtV+avv/4SEolEfPvtt+LEiRMCgDh69KhKvYqkZsOGDUImk4m7d+8qtp08eVIAENu3b9dL4qRtH1UlTkIIsWnTJgFAvPvuu1X2r0niVDHGzMxM8dJLLwlbW1sxaNAgIYQQ5eXlIiEhQbRp00bIZDLh6uoqJk6cKO7cuaPSz5OJU3FxsZg7d67o1KmTsLe3F9bW1qJbt27i559/VtovJiZGSCQSlWQ5MjJS1KtXT2RkZFQ5dm20a9dOBAYGVltP29ePJu+LFc/hlJQUMWnSJOHi4iIcHR2FEEIUFBSIt99+WzRp0kRYWFgIFxcXERoaKtLS0pTa+O233wQAsWPHDt0CoQdc41QH7dmzB76+vkqnTqry8OFDJCcnIyQkBI0bN662/u7duwEAY8eOVbvd3NwcI0eOxN27d6s8b56bm4s+ffrg6tWrmD17Nv7zn/9g1KhRKmsyPv74Y3Ts2BELFizA4sWLYW5ujldffRV79+5VafPw4cP497//jYiICMybNw/nz59H//79sWrVKnzyySeYPHkyZsyYgdTUVLz++usq+9+9excvv/wyAgICsGTJEjRq1AiTJk3CunXrqozJ2bNn8dxzz+H8+fOYPXs2PvroI9jY2GDw4MHYuXNnlfsKITBw4EAkJCSgb9++WL58OVq2bIkZM2YgOjoaAODi4oKvvvoKrVq1QqNGjfDVV1/hq6++QuvWrats+8SJE8jMzMSIESNgYWGBIUOGICkpqcp9NHHnzh3cvn1bcbt7965i2/fffw8AGDNmTLXtaPvcU2fFihVo1KgRWrVqpYjLe++9p9G+Li4uinVfr7zyimL/IUOGVLrP7t27YWVlVWWdyuTn5+P27dvIy8vD2bNnMWnSJNy/fx+jR4+udt9jx46hXbt2qFevXpVtP3n7+++/Vep98803sLGxQf/+/dG1a1c0a9asyufEkCFDIJFIsGPHDkXZpk2b0KpVK3Tq1EmDo66evvsYOnQorKyssH//fr2Mr6ysDGFhYXB1dcWyZcsQHh4OAHjjjTcwY8YMBAcH4+OPP8b48eORlJSEsLAwlJaWVtpeQUEBPv/8c/Ts2RMffvgh5s2bh7y8PISFhSEjI0NR7/3334e/vz8mTJiAwsJCAMCPP/6IxMRExMTEoEOHDjU+poKCAty+fRsXLlzAu+++izNnzqB3795atVHd60fb98XJkyfj3LlziImJwezZswEAb775JtasWYPw8HCsXr0a06dPh5WVlcravDZt2sDKyqrGa7X0qrYzN9JOfn6+AKB22vvu3bsiLy9PcauYDarI1N9++22N+hg8eLAAoPTf4dN27NghAIhPPvmk0jo7d+7U6D/lp2etSkpKRLt27cQLL7ygVA5AyGQypVmTTz/9VAAQ7u7uSqeB5syZozLD0qNHDwFAfPTRR4qy4uJi4e/vL1xdXRX/6aubcerdu7do3769KCoqUpTJ5XLx/PPPi+bNm1d5fLt27RIAxKJFi5TKhw4dKiQSicjMzFQaozan6qZOnSq8vLwUM1f79+8XAMSpU6eU6mk74/T07clTX6+88kq1z48K2j73KlPZqbrqZpyE0P5Ug5OTk/D391cpLygoUHp9PXmqoSK+T99kMpnYsGGDRv02atRIhIeHq5RX1nZF+09r3769GDVqlOL+u+++Kxo0aCBKS0uV6lXMtAjx+LnYu3dvIcTjWRZ3d3cxf/58xWtB1xknbfuobsZJCCE6dOggnJycquxf0xknAGL27NlK5YcPHxYARFJSklL5vn37VMqfnnEqKysTxcXFSvvdvXtXuLm5qczk//7778LCwkL861//Enfv3hUNGzYUnTt3Vnm8tBUWFqZ4nlhYWIg33nhDPHr0qNr9tHn9aPq+WPEc7tatmygrK1Nqw8HBQUyZMkWjY2rRooV46aWXNKprSJxxqmMKCgoAQGXhLvB44Z6Li4vitmrVKqV97OzsNOqj4j+fqupXbKtoWx1HR0cAj2fIqvrvzMrKSvH33bt3kZ+fj+7duyM9PV2lbu/evZW+Klsx6xYeHq403oryP//8U2l/c3NzvPHGG4r7FhYWeOONN5Cbm4u0tDS147tz5w5+/vlnvPbaaygsLFT6bz8sLAyXLl3CzZs3Kz2+//73vzAzM8Nbb72lVP7vf/8bQgitvnX1pLKyMmzZsgXDhg2DRCIBALzwwgtwdXXVedZp+/bt+OmnnxS3J9vT5vmk7XPPFBQUFKh9fY0ZM0bp9TVr1iyVOqtWrVLE7Ouvv0avXr3wr3/9S2mmpTJ///03nJycKt3+ZNsVt6efO6dPn8bvv/+OESNGKMpGjBiB27dv48cff6y07ZEjRyIlJQXZ2dn4+eefkZ2djZEjR1Y7Zm3ouw9bW1vFexUAlJaWqszIlZaWori4WKX8ycXPFZ7+UsXWrVvh4OCAF198UWnfgIAA2Nra4uDBg5WOzczMTPGFBblcjjt37qCsrAydO3dWeV9r164d5s+fj88//xxhYWG4ffs2Nm7cCHNz3b67FR8fj/379+OLL77Ac889h5KSEpSVlenU5pNq8r4YGRmp8oUiR0dHnDhxArdu3aq2TycnJ9y+fVtvx1BT/FZdHVPxAXT//n2VbZ9++ikKCwuRk5OjdGrA3t4eAJTeZDTpo7CwUJH8PE2T5KpHjx4IDw/H/PnzkZCQgJ49e2Lw4MEYOXIkZDKZot6ePXuwaNEiZGRkoLi4WFFekQw86enTPRXfPvLy8lJb/uQpJgDw9PSEjY2NUlmLFi0APL5+03PPPafSZ2ZmJoQQmDt3LubOnav2WHNzc9GwYUO12/766y94enqqxKriNNxff/2ldr/q7N+/H3l5eejatSsyMzMV5b169cI333yDDz/8EFJpzf43CgkJQYMGDdRue/L5VNnzQ13dusLOzk7t62vBggWKywS8+OKLavft2rUrOnfurLg/YsQIdOzYEVOnTkX//v2r/PYfgCov8/F02+p8/fXXsLGxgY+Pj+I5YWlpqfjGZb9+/dTu9/LLL8POzg5btmxBRkYGunTpAl9fX71e90vffdy/f1/pNXX06FH06tVLpd6xY8ewefNmpbIrV64o/QNmbm6ORo0aKdW5dOkS8vPz4erqqrb/3NzcKse3ceNGfPTRR7hw4YLSP47qvhk5Y8YMbN68GSdPnsTixYvRpk2bKtvWhL+/v+Lv0aNHo1OnThg3bhy2bdumc9tAzd4X1R37kiVLEBERAS8vLwQEBODll1/G2LFj4ePjo1JXCKH2c8HYmDjVMQ4ODvDw8MCZM2dUtlXMsjz9RuTr6wtzc3P8/vvvGvXRunVr7Nq1C6dPn1b5unWFiutEVfUCl0gk2LZtG44fP47du3fjxx9/xOuvv46PPvoIx48fh62tLQ4fPoyBAwciJCQEq1evhoeHB+rVq4f169dj06ZNKm1WdvmDysqr+iDSVMV/p9OnT0dYWJjaOuq+Em5oFbNAlV0Y7tChQ2o/SHTVqlUrAMDvv/+O7t27V1lX2+eeKWjVqhV+++03lJaWKq038vPz07otqVSKXr164eOPP8alS5fQtm3bSuvWr19fJdHXhhAC33zzDR48eKD2dZmbm4v79++rnU2TyWQYMmQINm7ciD///BPz5s2r8Tgqo88+SktL8ccff6Bdu3aKsg4dOuCnn35Sqvfvf/8b7u7umDFjhlK5u7u7ytie/idDLpdXOXvr4uJS6fi+/vprjBs3DoMHD8aMGTPg6uoKMzMzxMXF4fLlyyr1//zzT1y6dAkADPJasbCwwMCBAxEfH49Hjx4pzfLXVE3eF9X1+9prr6F79+7YuXMn9u/fj6VLl+LDDz/Ejh078NJLLynVvXv3Lpo3b67z2HXFxKkO6tevHz7//HOcPHkSXbt2rba+tbU1XnjhBfz888+4fv26yuzM0/r374+4uDh8+eWXahOn8vJybNq0CU5OTggODq62/+eeew7PPfccPvjgA2zatAmjRo3C5s2b8a9//Qvbt2+HpaUlfvzxR6VZqPXr11fbbk3cunULDx48UJp1qrhYY2VXy634z6devXoIDQ3Vus8mTZrgwIEDKCwsVPoP+cKFC4rt2nrw4AG+++47DBs2DEOHDlXZ/tZbbyEpKckgidOAAQMQFxeHr7/+utrESdvnXmV0+S9T23379++P48ePY+fOnXq5WnHF6RF1s1hPatWqFa5cuVLjfg4dOoQbN25gwYIFKl8quHv3LiZOnIhdu3ZVulB95MiRWLduHaRSKYYPH17jcVRFX31s27YNjx49UvrAdnJyUnl9Ojk5wcPDo0av22bNmuHAgQMIDg7WOtHYtm0bfHx8sGPHDqXnX2xsrEpduVyOcePGwd7eHu+88w4WL16MoUOH1ujLCVV59OgRhBAoLCzU6ngqe/3o+r74JA8PD0yePBmTJ09Gbm4uOnXqhA8++EApcSorK8P169cxcOBAnfrSB65xqoNmzpwJa2trvP7668jJyVHZrm6WJTY2FkIIjBkzRu0beFpaGjZu3AgAeP755xVXdN6zZ49K3ffeew9//PEHZs6cWeUL8O7duypjqZg+rjglZ2ZmBolEonTl6KtXr2LXrl2VtquLsrIyfPrpp4r7JSUl+PTTT+Hi4oKAgAC1+7i6uqJnz5749NNPkZWVpbK9uqsYv/zyyygvL8fKlSuVyhMSEiCRSFT+q9LEzp078eDBA0yZMgVDhw5VufXv3x/bt29XOvWpL0FBQejbty8+//xztY9TSUkJpk+frrivzXOvMjY2Nrh3716NxmttbQ0AGu8/adIkuLm5ISoqSu0V0LWZxSwtLcX+/fthYWFR7Tckg4KCcObMmRo/ZhWn6WbMmKHyfIiMjETz5s2rXPvWq1cvLFy4ECtXrlSZkdEXffTx22+/4Z133oGTkxOmTJmi5xH+n9deew3l5eVYuHChyraysrIqn08VM+BPPldOnDiB1NRUlbrLly/HsWPH8Nlnn2HhwoV4/vnnMWnSpBqv5VF3CvHevXvYvn07vLy8Kj31WJnKXj+6vi8Cj/8Jz8/PV2nX09NT5XVw7tw5FBUV4fnnn9dq/IbAGac6qHnz5ti0aRNGjBiBli1bKq4cLoTAlStXsGnTJkilUqVz9s8//zxWrVqFyZMno1WrVkpXb05JScH333+vdHXhL7/8Er1798agQYMwcuRIdO/eHcXFxdixYwdSUlIwbNgwlenvp23cuBGrV6/GK6+8gmbNmqGwsBCJiYmwt7fHyy+/DODx7Nny5cvRt29fjBw5Erm5uVi1ahV8fX0r/dkYXXh6euLDDz/E1atX0aJFC8V6i88++6zSr4EDjxfmduvWDe3bt0dkZCR8fHyQk5OD1NRU3Lhxo8qfAhgwYAB69eqF9957D1evXkWHDh2wf/9+fPfdd3jnnXfQrFkzrY8jKSkJ9evXr/RNZODAgUhMTMTevXv1/p8r8Pj50adPHwwZMgQDBgxA7969YWNjg0uXLmHz5s3IyspS/ISGts89dQICArBmzRosWrQIvr6+cHV11fiq0VZWVmjTpg22bNmCFi1awNnZGe3atVM6zfMkZ2dn7Ny5EwMGDECHDh0wfPhwdOnSBfXq1cP169exdetWAKrr7QDghx9+UMwk5ubmYtOmTbh06RJmz56tWO9VmUGDBmHhwoU4dOgQ+vTpU2XbT3r++efRsGFDbN++HS+++CIsLS3Vtj9w4EB8/PHHyM3NVfvhKZVK8f7771c5xgoVs7Park/Spg/g8eVHioqKUF5ejr///htHjx7F999/DwcHB+zcudNgCR7weI3mG2+8gbi4OGRkZKBPnz6oV68eLl26hK1bt+Ljjz9WO9sLPJ613LFjB1555RX069cPV65cwdq1a9GmTRulfx7Onz+PuXPnYty4cRgwYACAxz+x4+/vj8mTJ+Pbb79V1O3ZsycOHTpUbeL+0ksvoVGjRggMDISrqyuuXbuG9evX49atW9iyZYvWcajq9aPL+yLweO1jo0aNMHToUHTo0AG2trY4cOAAfv31V3z00UdKdX/66SdYW1tXur7QqIz/RT7Sl8zMTDFp0iTh6+srLC0thZWVlWjVqpV48803K71wWlpamhg5cqTw9PQU9erVE05OTqJ3795i48aNory8XKluYWGhmDdvnmjbtq2wsrISdnZ2Ijg4WGzYsEHx9feqpKenixEjRojGjRsrLh7Xv39/8b///U+p3hdffCGaN28uZDKZaNWqlVi/fr3ia/FPwv+/AOaTKvu6tLqvM6u7AGaTJk3EypUr1bb59AUwL1++LMaOHSvc3d1FvXr1RMOGDUX//v3VXj37aYWFhSIqKkoR9+bNmytdAPPpMVYlJydHmJubizFjxlRa5+HDh8La2lq88sorQgj9Xzm8oo9ly5aJLl26CFtbW2FhYSGaN28upk2bpnSJhQraPPeelp2dLfr16yfs7Oy0ugBmhWPHjomAgABhYWGh8aUJsrKyxIwZM0SbNm2ElZWVkMlkwsfHR4wdO1b88ssvSnXVXTLA0tJS+Pv7izVr1mj0ehFCCD8/PzFhwoRq237ytn79esVFJL/44otK205JSREAxMcff6yIU8WlAipT2eurQYMG4rnnnqv2eGraR8XjWnGrV6+ecHFxESEhIeKDDz4Qubm51fYthHYXwKzMZ599JgICAhTvge3btxczZ85Uumr505cjkMvlYvHixaJJkyZCJpOJjh07ij179ig9N8vKykSXLl1Eo0aNxL1795T6/PjjjwUAsWXLFkVZQECAcHd3r/aYV65cKbp16yYaNGggzM3NhYuLixgwYIDKc7aqeGjz+tHkfbGyi7gWFxeLGTNmiA4dOgg7OzthY2MjOnToIFavXq0yrsDAQDF69GiNjsHQJELw11rpn6Fnz564ffu22oX1RKbgq6++wpQpU3Dt2rVqv7FYW86dO4e2bdtiz549lX5Lj/SrsLAQzs7OWLFihUFPT5qqjIwMdOrUCenp6UrfFqwtXONERGQiRo0ahcaNGyuuwWaKDh48iKCgICZNRvTLL7+gYcOGiIyMrO2h1Ir4+HgMHTrUJJImAOCME/1jcMaJiIh0xRknIiIiIg1xxomIiIhIQ5xxIiIiItIQEyciIiIiDfECmAYkl8tx69Yt2NnZmcQPExIREZEq8f9/jsbT07PaH0dn4mRAt27dqvFvcxEREZFxXb9+XelXN9Rh4mRAFT/oev369Wp/bkEbcrkceXl5cHFxqTYzpppjnA2PMTYOxtnwGGPjMFScCwoK4OXlpfRD7JVh4mRAFafn7O3t9Z44FRUVwd7eni9QA2KcDY8xNg7G2fAYY+MwdJw1WVbDR5eIiIhIQ0yciIiIiDTExImIiIhIQ0yciIiIiDTExImIiIhIQ0yciIiIqE549OgR8vLy8OjRo1obAxMnIiIiMmlHjhzBkPBw2Ds4wM/PD/YODhgSHo6jR48afSxMnIiIiMhkrVmzBiEhIfjhSBocerwOl/C5cOjxOn44kobu3btj7dq1Rh0PL4BJREREJunIkSOYMmUKbDv1h1PvSEgk/zffY9d5AO4mJ2Ly5Mlo3749goODjTImzjgRERGRSVqekACZS2OVpAkAJBIpnHpHQubSGAkJCUYbExMnIiIiMjmPHj3Cd999B6t2fVSSpgoSiRRW7fpg565dRlswzsSJiIiITE5BQQHk5eUwd3Kvsp65ozvk5eUoKCgwyriYOBEREZHJsbe3h9TMDGV3s6usV3YvG1IzM9jb2xtlXEyciIiIyORYWVlh0KBBeHRmP4SQq60jhByPzuzHK4MHw8rKyijjYuJEREREJik6KgrFeddwNzlRJXkSQo67yYkozruGqKgoo42JlyMgIiIik9StWzesXr0akydPRun107Bq1wfmju4ou5eNR2f2ozjvGlavXm20SxEATJyIiIjIhL355pto3749EhISsHPXOsjLyyE1M8MrgwcjKirJqEkTwMSJiIiITFxwcDCCg4Px4MED/Pnnn/Dx8YGNjU2tjIVrnIiIiKhOsLKygouLi9EWgqvDxImIiIhIQ3UicVq1ahW8vb1haWmJwMBAnDx5stK6iYmJ6N69O5ycnODk5ITQ0FCV+hKJRO1t6dKlijre3t4q2+Pj4w12jERERGT6TD5x2rJlC6KjoxEbG4v09HR06NABYWFhyM3NVVs/JSUFI0aMwMGDB5GamgovLy/06dMHN2/eVNTJyspSuq1btw4SiQTh4eFKbS1YsECp3rRp0wx6rERERGTaTH5x+PLlyxEZGYnx48cDANauXYu9e/di3bp1mD17tkr9pKQkpfuff/45tm/fjuTkZIwdOxYA4O6ufPn27777Dr169YKPj49SuZ2dnUpdIiIi+ucy6cSppKQEaWlpmDNnjqJMKpUiNDQUqampGrXx8OFDlJaWwtnZWe32nJwc7N27Fxs3blTZFh8fj4ULF6Jx48YYOXIkoqKiYG5eeciKi4tRXFysuF/xuzlyuRxyufqrntaEXC6HEEKvbZIqxtnwGGPjYJwNjzE2DkPFWZv2TDpxun37NsrLy+Hm5qZU7ubmhgsXLmjUxqxZs+Dp6YnQ0FC12zdu3Ag7OzsMGTJEqfytt95Cp06d4OzsjGPHjmHOnDnIysrC8uXLK+0rLi4O8+fPVynPy8tDUVGRRuPVhFwuR35+PoQQkEpN/mxrncU4Gx5jbByMs+ExxsZhqDgXFhZqXNekEyddxcfHY/PmzUhJSYGlpaXaOuvWrcOoUaNUtkdHRyv+9vPzg4WFBd544w3ExcVBJpOpbWvOnDlK+xUUFMDLywsuLi56/fFBuVwOiUQCFxcXvkANiHE2PMbYOBhnw2OMjcNQca4sR1DHpBOnBg0awMzMDDk5OUrlOTk51a49WrZsGeLj43HgwAH4+fmprXP48GFcvHgRW7ZsqXYsgYGBKCsrw9WrV9GyZUu1dWQymdqkSiqV6v2FJJFIDNIuKWOcDY8xNg7G2fAYY+MwRJy1acukH10LCwsEBAQgOTlZUSaXy5GcnIygoKBK91uyZAkWLlyIffv2oXPnzpXW++KLLxAQEIAOHTpUO5aMjAxIpVK4urpqdxBERET0zDDpGSfg8SmziIgIdO7cGV27dsWKFSvw4MEDxbfsxo4di4YNGyIuLg4A8OGHHyImJgabNm2Ct7c3srOzAQC2trawtbVVtFtQUICtW7fio48+UukzNTUVJ06cQK9evWBnZ4fU1FRERUVh9OjRcHJyMsJRExERkSky+cRp2LBhyMvLQ0xMDLKzs+Hv7499+/YpFoxfu3ZNaYptzZo1KCkpwdChQ5XaiY2Nxbx58xT3N2/eDCEERowYodKnTCbD5s2bMW/ePBQXF6Np06aIiopSWr9ERERE/zwSIYSo7UE8qwoKCuDg4ID8/Hy9Lw7Pzc2Fq6srz6UbEONseIyxcTDOhscYG4eh4qzN5zUfXSIiIiINMXEiIiIi0hATJyIiIiINMXEiIiIi0hATJyIiIiINMXEiIiIi0hATJyIiIiINMXEiIiIi0hATJyIiIiINMXEiIiIi0hATJyIiIiINMXEiIiIi0hATJyIiIiINMXEiIiIi0hATJyIiIiINMXEiIiIi0hATJyIiIiINMXEiIiIi0hATJyIiIiINMXEiIiIi0hATJyIiIiINMXEiIiIi0hATJyIiIiINMXEiIiIi0hATJyIiIiINMXEiIiIi0lCdSJxWrVoFb29vWFpaIjAwECdPnqy0bmJiIrp37w4nJyc4OTkhNDRUpf64ceMgkUiUbn379lWqc+fOHYwaNQr29vZwdHTEhAkTcP/+fYMcHxEREdUNJp84bdmyBdHR0YiNjUV6ejo6dOiAsLAw5Obmqq2fkpKCESNG4ODBg0hNTYWXlxf69OmDmzdvKtXr27cvsrKyFLdvvvlGafuoUaNw9uxZ/PTTT9izZw9++eUXTJw40WDHSURERKbP5BOn5cuXIzIyEuPHj0ebNm2wdu1aWFtbY926dWrrJyUlYfLkyfD390erVq3w+eefQy6XIzk5WameTCaDu7u74ubk5KTYdv78eezbtw+ff/45AgMD0a1bN/znP//B5s2bcevWLYMeLxEREZkuk06cSkpKkJaWhtDQUEWZVCpFaGgoUlNTNWrj4cOHKC0thbOzs1J5SkoKXF1d0bJlS0yaNAl///23YltqaiocHR3RuXNnRVloaCikUilOnDih41ERERFRXWVe2wOoyu3bt1FeXg43Nzelcjc3N1y4cEGjNmbNmgVPT0+l5Ktv374YMmQImjZtisuXL+Pdd9/FSy+9hNTUVJiZmSE7Oxuurq5K7Zibm8PZ2RnZ2dmV9lVcXIzi4mLF/YKCAgCAXC6HXC7XaLyakMvlEELotU1SxTgbHmNsHIyz4THGxmGoOGvTnkknTrqKj4/H5s2bkZKSAktLS0X58OHDFX+3b98efn5+aNasGVJSUtC7d+8a9xcXF4f58+erlOfl5aGoqKjG7T5NLpcjPz8fQghIpSY9aVinMc6GxxgbB+NseIyxcRgqzoWFhRrXNenEqUGDBjAzM0NOTo5SeU5ODtzd3avcd9myZYiPj8eBAwfg5+dXZV0fHx80aNAAmZmZ6N27N9zd3VUWn5eVleHOnTtV9jtnzhxER0cr7hcUFMDLywsuLi6wt7evcgzakMvlkEgkcHFx4QvUgBhnw2OMjYNxNjzG2DgMFecnJ1eqY9KJk4WFBQICApCcnIzBgwcDgGKh99SpUyvdb8mSJfjggw/w448/Kq1TqsyNGzfw999/w8PDAwAQFBSEe/fuIS0tDQEBAQCAn3/+GXK5HIGBgZW2I5PJIJPJVMqlUqneX0gSicQg7ZIyxtnwGGPjYJwNjzE2DkPEWZu2TP7RjY6ORmJiIjZu3Ijz589j0qRJePDgAcaPHw8AGDt2LObMmaOo/+GHH2Lu3LlYt24dvL29kZ2djezsbMU1mO7fv48ZM2bg+PHjuHr1KpKTkzFo0CD4+voiLCwMANC6dWv07dsXkZGROHnyJI4ePYqpU6di+PDh8PT0NH4QiIiIyCSY9IwTAAwbNgx5eXmIiYlBdnY2/P39sW/fPsWC8WvXrillimvWrEFJSQmGDh2q1E5sbCzmzZsHMzMznD59Ghs3bsS9e/fg6emJPn36YOHChUqzRUlJSZg6dSp69+4NqVSK8PBwfPLJJ8Y5aCIiIjJJEiGEqO1BPKsKCgrg4OCA/Px8va9xys3NhaurK6eEDYhxNjzG2DgYZ8NjjI3DUHHW5vOajy4RERGRhpg4EREREWmoRmucvv/+e633efHFF2FlZVWT7oiIiIhMQo0Sp4pLA2hKIpHg0qVL8PHxqUl3RERERCahxqfqsrOzFT8lUt3N2tpan2MmIiIiqhU1SpwiIiK0Ou02evRovX6rjIiIiKg21OhU3fr167Wqv2bNmpp0Q0RERGRS+K06IiIiIg1pnTg9evQIN2/eVCk/e/asXgZEREREZKq0Spy2bduG5s2bo1+/fvDz88OJEycU28aMGaP3wRERERGZEq0Sp0WLFiEtLQ0ZGRlYv349JkyYgE2bNgEA+MstRERE9KzTanF4aWmp4sd1AwIC8Msvv+CVV15BZmYmJBKJQQZIREREZCq0mnFydXXF6dOnFfednZ3x008/4fz580rlRERERM8irRKnr776Cq6urkplFhYW+Oabb3Do0CG9DoyIiIjI1Gh1qq5Ro0aVbgsODtZ5MERERESmrEYXwHxaUVERTp8+jdzcXMjlcqVtAwcO1EcXRERERLVO58Rp3759GDt2LG7fvq2yTSKRoLy8XNcuiIiIiEyCzlcOnzZtGl599VVkZWWp/LgvkyYiIiJ6luicOOXk5CA6OlpxmQIiIiKiZ5XOidPQoUORkpKih6EQERERmTad1zitXLkSr776Kg4fPoz27dujXr16StvfeustXbsgIiIiMgk6J07ffPMN9u/fD0tLS6SkpChdQVwikTBxIiIiomeGzonTe++9h/nz52P27NmQSnU+80dERERksnTOdEpKSjBs2DAmTURERPTM0znbiYiIwJYtW/QxFiIiIiKTpvOpuvLycixZsgQ//vgj/Pz8VBaHL1++XNcuiIiIiEyCzonT77//jo4dOwIAzpw5o7TtyYXiRERERHVdjU/VxcTEIC0tDQcPHqz09vPPP+tlkKtWrYK3tzcsLS0RGBiIkydPVlo3MTER3bt3h5OTE5ycnBAaGqpUv7S0FLNmzUL79u1hY2MDT09PjB07Frdu3VJqx9vbGxKJROkWHx+vl+MhIiKiuqnGidONGzfw0ksvoVGjRpg0aRL27duHkpISfY4NALBlyxZER0cjNjYW6enp6NChA8LCwpCbm6u2fkpKCkaMGIGDBw8iNTUVXl5e6NOnD27evAkAePjwIdLT0zF37lykp6djx44duHjxotofI16wYAGysrIUt2nTpun9+IiIiKjukAghRE13lsvlOHr0KHbv3o3vvvsOWVlZePHFFzFo0CD0798fzs7OOg8wMDAQXbp0wcqVKxV9enl5Ydq0aZg9e3a1+5eXl8PJyQkrV67E2LFj1db59ddf0bVrV/z1119o3LgxgMczTu+88w7eeeedGo+9oKAADg4OyM/Ph729fY3beZpcLkdubi5cXV35bUYDYpwNjzE2DsbZ8Bhj4zBUnLX5vNZpjZNUKkX37t3RvXt3LFmyBOfPn8fu3bvx6aefYuLEiejatSsGDhyIESNGoGHDhlq3X1JSgrS0NMyZM0epz9DQUKSmpmrUxsOHD1FaWlplEpefnw+JRAJHR0el8vj4eCxcuBCNGzfGyJEjERUVBXPzykNWXFyM4uJixf2CggIAUPzosb7I5XIIIfTaJqlinA2PMTYOxtnwGGPjMFSctWlP58XhT2rdujVat26NmTNnIjc3F7t378b3338PAJg+fbrW7d2+fRvl5eUqPyDs5uaGCxcuaNTGrFmz4OnpidDQULXbi4qKMGvWLIwYMUIpy3zrrbfQqVMnODs749ixY5gzZw6ysrKq/JZgXFwc5s+fr1Kel5eHoqIijcarCblcjvz8fAgh+J+NATHOhscYGwfjbHiMsXEYKs6FhYUa19Vr4vQkV1dXTJgwARMmTDBUF9WKj4/H5s2bkZKSAktLS5XtpaWleO211yCEwJo1a5S2RUdHK/728/ODhYUF3njjDcTFxUEmk6ntb86cOUr7FRQUwMvLCy4uLno/VSeRSODi4sIXqAExzobHGBsH42x4jLFxGCrO6nKEytQ4cRoyZEj1jZubw93dHS+++CIGDBigdR8NGjSAmZkZcnJylMpzcnLg7u5e5b7Lli1DfHw8Dhw4AD8/P5XtFUnTX3/9hZ9//rnaxCYwMBBlZWW4evUqWrZsqbaOTCZTm1RJpVK9v5AkEolB2iVljLPhMcbGwTgbHmNsHIaIszZt1bhXBweHam9WVla4dOkShg0bhpiYGK37sLCwQEBAAJKTkxVlcrkcycnJCAoKqnS/JUuWYOHChdi3bx86d+6ssr0iabp06RIOHDiA+vXrVzuWjIwMSKVSuLq6an0cRERE9Gyo8YzT+vXrNa67Z88eTJ48GQsWLNC6n+joaERERKBz587o2rUrVqxYgQcPHmD8+PEAgLFjx6Jhw4aIi4sDAHz44YeIiYnBpk2b4O3tjezsbACAra0tbG1tUVpaiqFDhyI9PR179uxBeXm5oo6zszMsLCyQmpqKEydOoFevXrCzs0NqaiqioqIwevRoODk5aX0MRERE9Gww2BqnJ3Xr1k3tzI8mhg0bhry8PMTExCA7Oxv+/v7Yt2+fYsH4tWvXlKbY1qxZg5KSEgwdOlSpndjYWMybNw83b95ULFj39/dXqnPw4EH07NkTMpkMmzdvxrx581BcXIymTZsiKipKaf0SERER/fPU6DpOp0+fRrt27TQ+J3j27Fm0aNFC5XfsnnW8jlPdxjgbHmNsHIyz4THGxmEK13GqUa8dO3bE33//rXH9oKAgXL9+vSZdEREREZmMGp2qE0Jg7ty5sLa21qi+IX6KhYiIiMjYapQ4hYSE4OLFixrXDwoKgpWVVU26IiIiIjIZNUqcUlJS9DwMIiIiItPHFWxEREREGmLiRERERKQhJk5EREREGmLiRERERKQhJk5EREREGmLiRERERKQhJk5EREREGmLiRERERKQhJk5EREREGqrRlcOrI5fL8fXXX+PIkSOQSCTo1q0bRo4cCTMzM0N0R0RERGQUBkmcJkyYgJKSEgwfPhwSiQRbtmxBcnIyNmzYYIjuiIiIiIzCIInTiRMncO7cOcX9/v37o02bNoboioiIiMhoDLLGqX379jh16pTifkZGBjp06GCIroiIiIiMRq8zTl26dIFEIkFxcTE6d+6M5s2bAwAuXbqE9u3b67MrIiIiIqPTa+K0bds2fTZHREREZFL0mjg1adIEAPDf//5XZZu9vT3s7Ozg7Oyszy6JiIiIjMYgi8NXrlyJEydO4IUXXoAQAikpKfD398f169fx3nvvYezYsYboloiIiMigDJI4lZSU4MKFC3BxcQEA5OXlYeTIkThx4gS6devGxImIiIjqJIN8q+7GjRtKp+ScnJxw/fp1ODo6ol69eobokoiIiMjgDDLj9OqrryI4OBivvPIKAOC7777Dq6++igcPHqBly5aG6JKIiIjI4AySOC1cuBADBw7EsWPHIITAihUr0LVrVwDA5s2bDdElERERkcHVOHEaN24cVq9eDWtra7Xbu3Tpgi5dutR4YFS5R48eIS8vD3Z2drCxsant4RAREf1j1HiN01dffYX79+8r7k+aNAn37t1TqlNWVlbjgT1p1apV8Pb2hqWlJQIDA3Hy5MlK6yYmJqJ79+5wcnKCk5MTQkNDVeoLIRATEwMPDw9YWVkhNDQUly5dUqpz584djBo1Cvb29nB0dMSECROUjrc2HDlyBEPCw2Hv4AA/Pz/YOzhgSHg4jh49WqvjIiIi+qeoceIkhFC6n5SUhDt37iju5+TkwN7evuYj+/+2bNmC6OhoxMbGIj09HR06dEBYWBhyc3PV1k9JScGIESNw8OBBpKamwsvLC3369MHNmzcVdZYsWYJPPvkEa9euxYkTJ2BjY4OwsDAUFRUp6owaNQpnz57FTz/9hD179uCXX37BxIkTdT6emlqzZg1CQkLww5E0OPR4HS7hc+HQ43X8cCQN3bt3x9q1a2ttbERERP8YooYkEonIyclR3Le1tRWXL19W3M/OzhYSiaSmzSt07dpVTJkyRXG/vLxceHp6iri4OI32LysrE3Z2dmLjxo1CCCHkcrlwd3cXS5cuVdS5d++ekMlk4ptvvhFCCHHu3DkBQPz666+KOj/88IOQSCTi5s2bGo89Pz9fABD5+fka76PO4cOHhUQiEXYBA0Tjmd+LJrP2KG6NZ34v7AIGCIlEIo4cOaJTP6SsvLxcZGVlifLy8toeyjOLMTYOxtnwGGPjMFSctfm8NsjlCCpIJBKd9i8pKUFaWhpCQ0MVZVKpFKGhoUhNTdWojYcPH6K0tFRxeYQrV64gOztbqU0HBwcEBgYq2kxNTYWjoyM6d+6sqBMaGgqpVIoTJ07odEw1sTwhATKXxnDqHQmJRPkhk0ikcOodCZlLYyQkJBh9bERERP8kOn2rbtOmTQgJCTHYD/jevn0b5eXlcHNzUyp3c3PDhQsXNGpj1qxZ8PT0VCRK2dnZijaebrNiW3Z2NlxdXZW2m5ubw9nZWVFHneLiYhQXFyvuFxQUAADkcjnkcrlG433ao0eP8N1338Ghx+sqSVMFiUQKq3Z9sHPXOjx48ABWVlY16ouUyeVyCCFq/NhR9Rhj42CcDY8xNg5DxVmb9mqcOHXv3h2xsbEoLCxEvXr1UFZWhtjYWAQHB8Pf319x1fDaFB8fj82bNyMlJQWWlpYG7y8uLg7z589XKc/Ly1NaP6WNvLw8yMvLYe7kXmU9c0d3yMvL8eeff5pE7J8Fcrkc+fn5EEJAKjXo5Ow/FmNsHIyz4THGxmGoOBcWFmpct8aJ06FDhwAAly5dQlpaGtLT05Geno53330X9+7d0/k0HQA0aNAAZmZmyMnJUSrPycmBu3vVicSyZcsQHx+PAwcOwM/PT1FesV9OTg48PDyU2vT391fUeXrxeVlZGe7cuVNlv3PmzEF0dLTifkFBAby8vODi4lLjhfJ2dnaQmpmh7G7lM10AUHYvG1IzM/j4+HDGSU/kcjkkEglcXFz4RmggjLFxMM6Gxxgbh6HirM3kis4XwGzevDmaN2+O4cOHK8quXLmC//3vfzh16pRObVtYWCAgIADJyckYPHgwgMdBS05OxtSpUyvdb8mSJfjggw/w448/Kq1TAoCmTZvC3d0dycnJikSpoKAAJ06cwKRJkwAAQUFBuHfvHtLS0hAQEAAA+PnnnyGXyxEYGFhpvzKZDDKZTKVcKpXW+AG2sbHBoEGD8MOR/bDrPEDt6Toh5Hh0Zj9eGTyY13XSM4lEotPjR9VjjI2DcTY8xtg4DBFnbdoyyJXDmzZtiqZNm+LVV1/Vua3o6GhERESgc+fO6Nq1K1asWIEHDx5g/PjxAICxY8eiYcOGiIuLAwB8+OGHiImJwaZNm+Dt7a1Yk2RrawtbW1tIJBK88847WLRoEZo3b46mTZti7ty58PT0VCRnrVu3Rt++fREZGYm1a9eitLQUU6dOxfDhw+Hp6anzMWkdg6go7NoZgrvJiSoLxIWQ425yIorzriEqKsnoYyMiIvonMUjipE/Dhg1DXl4eYmJikJ2dDX9/f+zbt0+xuPvatWtKmeKaNWtQUlKCoUOHKrUTGxuLefPmAQBmzpyJBw8eYOLEibh37x66deuGffv2KU3VJSUlYerUqejduzekUinCw8PxySefGP6A1ejWrRtWr16NyZMno/T6aVi16wNzR3eU3cvGozP7UZx3DatXr0ZwcHCtjI+IiOifQiLEU1eyJL0pKCiAg4MD8vPz9XIx0KNHjyIhIQE7d+2CvLwcUjMzvDJ4MKKiopg0GYBcLkdubi5cXV059W4gjLFxMM6Gxxgbh6HirM3ntcnPONH/CQ4ORnBwMB48eIA///wTPj4+XNNERERkREyL6yArKyu4uLjw23NERERGxsSJiIiISENMnIiIiIg0xMSJiIiISENMnIiIiIg0xMSJiIiISEMGTZykUileeOEFpKWlGbIbIiIiIqMwaOK0bt06hISEYMqUKYbshoiIiMgoDHoBzHHjxgGA4qdOiIiIiOoynWecIiIi8Msvv+hjLEREREQmTefEKT8/H6GhoWjevDkWL16Mmzdv6mNcRERERCZH58Rp165duHnzJiZNmoQtW7bA29sbL730ErZt24bS0lJ9jJGIiIjIJOhlcbiLiwuio6Px22+/4cSJE/D19cWYMWPg6emJqKgoXLp0SR/dEBEREdUqvX6rLisrCz/99BN++uknmJmZ4eWXX8bvv/+ONm3aICEhQZ9dERERERmdzolTaWkptm/fjv79+6NJkybYunUr3nnnHdy6dQsbN27EgQMH8O2332LBggX6GC8RERFRrdH5cgQeHh6Qy+UYMWIETp48CX9/f5U6vXr1gqOjo65dEREREdUqnROnhIQEvPrqq7C0tKy0jqOjI65cuaJrV0RERES1SufEacyYMfoYBxEREZHJ0zlxio6OVlsukUhgaWkJX19fDBo0CM7Ozrp2RURERFSrdE6cTp06hfT0dJSXl6Nly5YAgD/++ANmZmZo1aoVVq9ejX//+984cuQI2rRpo/OAiYiIiGqLzt+qGzRoEEJDQ3Hr1i2kpaUhLS0NN27cwIsvvogRI0bg5s2bCAkJQVRUlD7GS0RERFRrdE6cli5dioULF8Le3l5R5uDggHnz5mHJkiWwtrZGTEwM0tLSdO2KiIiIqFbp5bfqcnNzVcrz8vJQUFAA4PG36kpKSnTtioiIiKhW6eVU3euvv46dO3fixo0buHHjBnbu3IkJEyZg8ODBAICTJ0+iRYsWunZFREREVKt0Xhz+6aefIioqCsOHD0dZWdnjRs3NERERofiZlVatWuHzzz/XtSsiIiKiWqVz4mRra4vExEQkJCTgzz//BAD4+PjA1tZWUUfd1cSJiIiI6hqdTtWVlpaid+/euHTpEmxtbeHn5wc/Pz+lpEkfVq1aBW9vb1haWiIwMBAnT56stO7Zs2cRHh4Ob29vSCQSrFixQqVOxbanb1OmTFHU6dmzp8r2N998U6/HRURERHWLTolTvXr1cPr0aX2NRa0tW7YgOjoasbGxSE9PR4cOHRAWFqZ2QToAPHz4ED4+PoiPj4e7u7vaOr/++iuysrIUt59++gkA8OqrryrVi4yMVKq3ZMkS/R4cERER1Sk6Lw4fPXo0vvjiC32MRa3ly5cjMjIS48ePR5s2bbB27VpYW1tj3bp1aut36dIFS5cuxfDhwyGTydTWcXFxgbu7u+K2Z88eNGvWDD169FCqZ21trVTvyUsuEBER0T+PzmucysrKsG7dOhw4cAABAQGwsbFR2r58+fIat11SUoK0tDTMmTNHUSaVShEaGorU1NQat/t0H19//TWio6MhkUiUtiUlJeHrr7+Gu7s7BgwYgLlz58La2rrStoqLi1FcXKy4X3E5BrlcDrlcrpfxVrQnhNBrm6SKcTY8xtg4GGfDY4yNw1Bx1qY9nROnM2fOoFOnTgAe/9TKk55ORLR1+/ZtlJeXw83NTanczc0NFy5c0KntCrt27cK9e/cwbtw4pfKRI0eiSZMm8PT0xOnTpzFr1ixcvHgRO3bsqLStuLg4zJ8/X6U8Ly8PRUVFehkv8PgBzs/PhxACUqnOk4ZUCcbZ8Bhj42CcDY8xNg5DxbmwsFDjujonTgcPHtS1iVr1xRdf4KWXXoKnp6dS+cSJExV/t2/fHh4eHujduzcuX76MZs2aqW1rzpw5Sj96XFBQAC8vL7i4uOj1NJ9cLodEIoGLiwtfoAbEOBseY2wcjLPhMcbGYag4W1paalxX58QJAA4fPoxPP/0Uf/75J7Zu3YqGDRviq6++QtOmTdGtW7cat9ugQQOYmZkhJydHqTwnJ6fShd/a+Ouvv3DgwIEqZ5EqBAYGAgAyMzMrTZxkMpnadVVSqVTvLySJRGKQdkkZ42x4jLFxMM6GxxgbhyHirE1bOve6fft2hIWFwcrKCunp6Yo1Pvn5+Vi8eLFObVtYWCAgIADJycmKMrlcjuTkZAQFBenUNgCsX78erq6u6NevX7V1MzIyAAAeHh4690tERER1k86J06JFi7B27VokJiaiXr16ivLg4GCkp6fr2jyio6ORmJiIjRs34vz585g0aRIePHiA8ePHAwDGjh2rtHi8pKQEGRkZyMjIQElJCW7evImMjAxkZmYqtSuXy7F+/XpERETA3Fx54u3y5ctYuHAh0tLScPXqVXz//fcYO3YsQkJC4Ofnp/MxERERUd2k86m6ixcvIiQkRKXcwcEB9+7d07V5DBs2DHl5eYiJiUF2djb8/f2xb98+xYLxa9euKU2x3bp1Cx07dlTcX7ZsGZYtW4YePXogJSVFUX7gwAFcu3YNr7/+ukqfFhYWOHDgAFasWIEHDx7Ay8sL4eHheP/993U+HiIiIqq7dE6c3N3dkZmZCW9vb6XyI0eOwMfHR9fmAQBTp07F1KlT1W57MhkCHl8VXAhRbZt9+vSptJ6XlxcOHTqk9TiJiIjo2abzqbrIyEi8/fbbOHHiBCQSCW7duoWkpCRMnz4dkyZN0scYiYiIiEyCzjNOs2fPhlwuR+/evfHw4UOEhIRAJpNh+vTpmDZtmj7GSERERGQSdE6cJBIJ3nvvPcyYMQOZmZm4f/8+2rRpo/cf+iUiIiKqbXq5jhPweEF1mzZt9NUcERERkcnRS+KUnJyM5ORk5ObmqvzeS2U/xktERERU1+icOM2fPx8LFixA586d4eHhofPv0xERERGZKp0Tp7Vr12LDhg0YM2aMPsZDREREZLJ0vhxBSUkJnn/+eX2MhYiIiMik6Zw4/etf/8KmTZv0MRYiIiIik6bzqbqioiJ89tlnOHDgAPz8/JR+rw4Ali9frmsXRERERCZB58Tp9OnT8Pf3BwCcOXNGaRsXihMREdGzROfE6eDBg/oYBxEREZHJ03mNExEREdE/hV4Sp8OHD2P06NEICgrCzZs3AQBfffUVjhw5oo/miYiIiEyCzonT9u3bERYWBisrK5w6dQrFxcUAgPz8fCxevFjnARIRERGZCp0Tp0WLFmHt2rVITExU+kZdcHAw0tPTdW2eiIiIyGTonDhdvHgRISEhKuUODg64d++ers0TERERmQydEyd3d3dkZmaqlB85cgQ+Pj66Nk9ERERkMnROnCIjI/H222/jxIkTkEgkuHXrFpKSkjB9+nRMmjRJH2MkIiIiMgk6X8dp9uzZkMvl6N27Nx4+fIiQkBDIZDJMnz4d06ZN08cYiYiIiEyCzomTRCLBe++9hxkzZiAzMxP3799HmzZtYGtrq4/xEREREZkMnROnChYWFmjTpo2+miMiIiIyObxyOBEREZGGmDgRERERaYiJExEREZGGmDgRERERaUjnxOnvv/9W/H39+nXExMRgxowZOHz4sK5NK6xatQre3t6wtLREYGAgTp48WWnds2fPIjw8HN7e3pBIJFixYoVKnXnz5kEikSjdWrVqpVSnqKgIU6ZMQf369WFra4vw8HDk5OTo7ZiIiIio7qlx4vT777/D29sbrq6uaNWqFTIyMtClSxckJCTgs88+Q69evbBr1y6dB7hlyxZER0cjNjYW6enp6NChA8LCwpCbm6u2/sOHD+Hj44P4+Hi4u7tX2m7btm2RlZWluB05ckRpe1RUFHbv3o2tW7fi0KFDuHXrFoYMGaLz8RAREVHdVePEaebMmWjfvj1++eUX9OzZE/3790e/fv2Qn5+Pu3fv4o033kB8fLzOA1y+fDkiIyMxfvx4tGnTBmvXroW1tTXWrVuntn6XLl2wdOlSDB8+HDKZrNJ2zc3N4e7urrg1aNBAsS0/Px9ffPEFli9fjhdeeAEBAQFYv349jh07huPHj+t8TERERFQ31Thx+vXXX/HBBx8gODgYy5Ytw61btzB58mRIpVJIpVJMmzYNFy5c0GlwJSUlSEtLQ2ho6P8NWCpFaGgoUlNTdWr70qVL8PT0hI+PD0aNGoVr164ptqWlpaG0tFSp31atWqFx48Y690tERER1V40vgHnnzh3FqTBbW1vY2NjAyclJsd3JyQmFhYU6De727dsoLy+Hm5ubUrmbm5tOSVlgYCA2bNiAli1bIisrC/Pnz0f37t1x5swZ2NnZITs7GxYWFnB0dFTpNzs7u9J2i4uLUVxcrLhfUFAAAJDL5ZDL5TUe79PkcjmEEHptk1QxzobHGBsH42x4jLFxGCrO2rSn05XDJRJJlfdN1UsvvaT428/PD4GBgWjSpAm+/fZbTJgwocbtxsXFYf78+SrleXl5KCoqqnG7T5PL5cjPz4cQAlIpvxhpKIyz4THGxsE4Gx5jbByGirM2Ez06JU7jxo1TrCMqKirCm2++CRsbGwBQmnmpqQYNGsDMzEzl22w5OTlVLvzWlqOjI1q0aIHMzEwAgLu7O0pKSnDv3j2lWafq+p0zZw6io6MV9wsKCuDl5QUXFxfY29vrbbxyuRwSiQQuLi58gRoQ42x4jLFxMM6Gxxgbh6HibGlpqXHdGidOY8eOVZphGj16tNo6urCwsEBAQACSk5MxePBgAI+DlpycjKlTp+rU9pPu37+Py5cvY8yYMQCAgIAA1KtXD8nJyQgPDwcAXLx4EdeuXUNQUFCl7chkMrUL0ivWfemTRCIxSLukjHE2PMbYOBhnw2OMjcMQcdamrRonThs2bKjprlqJjo5GREQEOnfujK5du2LFihV48OABxo8fD+BxctawYUPExcUBeLyg/Ny5c4q/b968iYyMDNja2sLX1xcAMH36dAwYMABNmjTBrVu3EBsbCzMzM4wYMQIA4ODggAkTJiA6OhrOzs6wt7fHtGnTEBQUhOeee84ox01ERESmp8aJU1FREQ4cOID+/fsDeHya6snTc+bm5liwYIFW01/qDBs2DHl5eYiJiUF2djb8/f2xb98+xYLxa9euKWWKt27dQseOHRX3ly1bhmXLlqFHjx5ISUkBANy4cQMjRozA33//DRcXF3Tr1g3Hjx+Hi4uLYr+EhARIpVKEh4ejuLgYYWFhWL16tU7HQkRERHWbRAgharLj2rVrsXfvXuzevRsAYGdnh7Zt28LKygoAcOHCBcycORNRUVH6G20dU1BQAAcHB+Tn5+t9jVNubi5cXV05JWxAjLPhMcbGwTgbHmNsHIaKszaf1zXuNSkpCRMnTlQq27RpEw4ePIiDBw9i6dKl+Pbbb2vaPBEREZHJqXHilJmZifbt2yvuW1paKmV/Xbt2Vaw1IiIiInoW1HiN071795TWNOXl5Sltl8vlerkkAREREZGpqPGMU6NGjXDmzJlKt58+fRqNGjWqafNEREREJqfGidPLL7+MmJgYtVfEfvToEebPn49+/frpNDgiIiIiU1LjU3Xvvvsuvv32W7Rs2RJTp05FixYtADy+UOTKlStRVlaGd999V28DJSIiIqptNU6c3NzccOzYMUyaNAmzZ89GxVUNJBIJXnzxRaxevVrlx3mJiIiI6jKdfquuadOm2LdvH+7cuaP4nTdfX184OzvrZXBEREREpkSnxKmCs7Mzunbtqo+miIiIiEwWL29KREREpCEmTkREREQaYuJEREREpCEmTkREREQaYuJEREREpCEmTkREREQaYuJEREREpCEmTkREREQaYuJEREREpCEmTkREREQaYuJEREREpCEmTkREREQaYuJEREREpCEmTkREREQaYuJEREREpCEmTkREREQaYuJEREREpCEmTkREREQaqhOJ06pVq+Dt7Q1LS0sEBgbi5MmTldY9e/YswsPD4e3tDYlEghUrVqjUiYuLQ5cuXWBnZwdXV1cMHjwYFy9eVKrTs2dPSCQSpdubb76p70MjIiKiOsTkE6ctW7YgOjoasbGxSE9PR4cOHRAWFobc3Fy19R8+fAgfHx/Ex8fD3d1dbZ1Dhw5hypQpOH78OH766SeUlpaiT58+ePDggVK9yMhIZGVlKW5LlizR+/ERERFR3WFe2wOozvLlyxEZGYnx48cDANauXYu9e/di3bp1mD17tkr9Ll26oEuXLgCgdjsA7Nu3T+n+hg0b4OrqirS0NISEhCjKra2tK02+iIiI6J/HpBOnkpISpKWlYc6cOYoyqVSK0NBQpKam6q2f/Px8AICzs7NSeVJSEr7++mu4u7tjwIABmDt3LqytrSttp7i4GMXFxYr7BQUFAAC5XA65XK638crlcggh9NomqWKcDY8xNg7G2fAYY+MwVJy1ac+kE6fbt2+jvLwcbm5uSuVubm64cOGCXvqQy+V45513EBwcjHbt2inKR44ciSZNmsDT0xOnT5/GrFmzcPHiRezYsaPStuLi4jB//nyV8ry8PBQVFellvBVjzs/PhxACUqnJn22tsxhnw2OMjYNxNjzG2DgMFefCwkKN65p04mQMU6ZMwZkzZ3DkyBGl8okTJyr+bt++PTw8PNC7d29cvnwZzZo1U9vWnDlzEB0drbhfUFAALy8vuLi4wN7eXm9jlsvlkEgkcHFx4QvUgBhnw2OMjYNxNjzG2DgMFWdLS0uN65p04tSgQQOYmZkhJydHqTwnJ0cva4+mTp2KPXv24JdffkGjRo2qrBsYGAgAyMzMrDRxkslkkMlkKuVSqVTvLySJRGKQdkkZ42x4jLFxMM6GxxgbhyHirE1bJv3oWlhYICAgAMnJyYoyuVyO5ORkBAUF1bhdIQSmTp2KnTt34ueff0bTpk2r3ScjIwMA4OHhUeN+iYiIqG4z6RknAIiOjkZERAQ6d+6Mrl27YsWKFXjw4IHiW3Zjx45Fw4YNERcXB+DxgvJz584p/r558yYyMjJga2sLX19fAI9Pz23atAnfffcd7OzskJ2dDQBwcHCAlZUVLl++jE2bNuHll19G/fr1cfr0aURFRSEkJAR+fn61EAUiIiIyBSafOA0bNgx5eXmIiYlBdnY2/P39sW/fPsWC8WvXrilNsd26dQsdO3ZU3F+2bBmWLVuGHj16ICUlBQCwZs0aAI8vcvmk9evXY9y4cbCwsMCBAwcUSZqXlxfCw8Px/vvvG/ZgiYiIyKRJhBCitgfxrCooKICDgwPy8/P1vjg8NzcXrq6uPJduQIyz4THGxsE4Gx5jbByGirM2n9d8dImIiIg0xMSJiIiISENMnIiIiIg0xMSJiIiISENMnIiIiIg0xMSJiIiISENMnIiIiIg0xMSJiIiISENMnIiIiIg0xMSJiIiISENMnIiIiIg0xMSJiIiISENMnIiIiIg0xMSJiIiISENMnIiIiIg0xMSJiIiISENMnIiIiIg0xMSJiIiISENMnIiIiIg0xMSJiIiISENMnIiIiIg0xMSJiIiISENMnOqgR48eIS8vD48ePartoRAREf2jMHGqQ44cOYIh4eGwd3CAn58f7B0cMCQ8HEePHq3toREREf0jMHGqI9asWYOQkBD8cCQNDj1eh0v4XDj0eB0/HElD9+7dsXbt2toeIhER0TPPvLYHQNU7cuQIpkyZAttO/eHUOxISyf/lu3adB+BuciImT56M9u3bIzg4uBZHSkRE9GzjjFMdsDwhATKXxipJEwBIJFI49Y6EzKUxEhISammERERE/wx1InFatWoVvL29YWlpicDAQJw8ebLSumfPnkV4eDi8vb0hkUiwYsWKGrVZVFSEKVOmoH79+rC1tUV4eDhycnL0eVgaefToEb777jtYteujkjRVkEiksGrXBzt37eKCcSIiIgMy+cRpy5YtiI6ORmxsLNLT09GhQweEhYUhNzdXbf2HDx/Cx8cH8fHxcHd3r3GbUVFR2L17N7Zu3YpDhw7h1q1bGDJkiEGOsSoFBQWQl5fD3En9sVQwd3SHvLwcBQUFRhoZERHRP4/JJ07Lly9HZGQkxo8fjzZt2mDt2rWwtrbGunXr1Nbv0qULli5diuHDh0Mmk9Wozfz8fHzxxRdYvnw5XnjhBQQEBGD9+vU4duwYjh8/brBjVcfe3h5SMzOU3c2usl7ZvWxIzcxgb29vpJERERH985j04vCSkhKkpaVhzpw5ijKpVIrQ0FCkpqYarM20tDSUlpYiNDRUUadVq1Zo3LgxUlNT8dxzz6ltu7i4GMXFxYr7FbM/crkccrm8RuOVyWQYNHAQfji6H3adB6g9XSeEHI/O7MfgQYMhk8lq3Bcpk8vlEEIwngbEGBsH42x4jLFxGCrO2rRn0onT7du3UV5eDjc3N6VyNzc3XLhwwWBtZmdnw8LCAo6Ojip1srMrn/mJi4vD/PnzVcrz8vJQVFRUo/ECQETEWOzatRN3kxNVFogLIcfd5EQU511DRMQnlZ7CJO3J5XLk5+dDCAGp1OQnZ+skxtg4GGfDY4yNw1BxLiws1LiuSSdOdc2cOXMQHR2tuF9QUAAvLy+4uLjodAptwIABWLlyJaZOnYrS66dh1a4PzB3dUXYvG4/O7Edx3jWsXLkS/fv318dh0P8nl8shkUjg4uLCN0IDYYyNg3E2PMbYOAwVZ0tLS43rmnTi1KBBA5iZmal8my0nJ6fShd/6aNPd3R0lJSW4d++e0qxTdf3KZDK166qkUqnOD/DkyZPRoUMHJCQkYOeudZCXl0NqZoZXBg9GVFQSr99kIBKJRC+PH1WOMTYOxtnwGGPjMESctWnLpB9dCwsLBAQEIDk5WVEml8uRnJyMoKAgg7UZEBCAevXqKdW5ePEirl27VuN+9SE4OBjbtm1DQX4+Tp8+jYL8fGzbto1JExERkZGY9IwTAERHRyMiIgKdO3dG165dsWLFCjx48ADjx48HAIwdOxYNGzZEXFwcgMeLv8+dO6f4++bNm8jIyICtrS18fX01atPBwQETJkxAdHQ0nJ2dYW9vj2nTpiEoKKjSheHGZGVlBRcXF1hZWdX2UIiIiP5RTD5xGjZsGPLy8hATE4Ps7Gz4+/tj3759isXd165dU5piu3XrFjp27Ki4v2zZMixbtgw9evRASkqKRm0CQEJCAqRSKcLDw1FcXIywsDCsXr3aOAdNREREJkkihBC1PYhnVUFBARwcHJCfn6/X6yvJ5XLk5ubC1dWV59INiHE2PMbYOBhnw2OMjcNQcdbm85qPLhEREZGGmDgRERERaYiJExEREZGGTH5xeF1WsXxM3z+8K5fLUVhYCEtLS55LNyDG2fAYY+NgnA2PMTYOQ8W54nNak2XfTJwMqOIS7l5eXrU8EiIiIqpOYWEhHBwcqqzDb9UZkFwux61bt2BnZweJRKK3dit+yuX69et6/bYeKWOcDY8xNg7G2fAYY+MwVJyFECgsLISnp2e1M1mccTIgqVSKRo0aGax9e3t7vkCNgHE2PMbYOBhnw2OMjcMQca5upqkCT8QSERERaYiJExEREZGGmDjVQTKZDLGxsZDJZLU9lGca42x4jLFxMM6GxxgbhynEmYvDiYiIiDTEGSciIiIiDTFxIiIiItIQEyciIiIiDTFxMlGrVq2Ct7c3LC0tERgYiJMnT1ZZf+vWrWjVqhUsLS3Rvn17/Pe//zXSSOsubWJ89uxZhIeHw9vbGxKJBCtWrDDeQOs4beKcmJiI7t27w8nJCU5OTggNDa32uU+PaRPnHTt2oHPnznB0dISNjQ38/f3x1VdfGXG0dZO278sVNm/eDIlEgsGDBxt2gM8IbeK8YcMGSCQSpZulpaVhByjI5GzevFlYWFiIdevWibNnz4rIyEjh6OgocnJy1NY/evSoMDMzE0uWLBHnzp0T77//vqhXr574/fffjTzyukPbGJ88eVJMnz5dfPPNN8Ld3V0kJCQYd8B1lLZxHjlypFi1apU4deqUOH/+vBg3bpxwcHAQN27cMPLI6xZt43zw4EGxY8cOce7cOZGZmSlWrFghzMzMxL59+4w88rpD2xhXuHLlimjYsKHo3r27GDRokHEGW4dpG+f169cLe3t7kZWVpbhlZ2cbdIxMnExQ165dxZQpUxT3y8vLhaenp4iLi1Nb/7XXXhP9+vVTKgsMDBRvvPGGQcdZl2kb4yc1adKEiZOGdImzEEKUlZUJOzs7sXHjRkMN8Zmga5yFEKJjx47i/fffN8Twngk1iXFZWZl4/vnnxeeffy4iIiKYOGlA2zivX79eODg4GGl0j/FUnYkpKSlBWloaQkNDFWVSqRShoaFITU1Vu09qaqpSfQAICwurtP4/XU1iTNrTR5wfPnyI0tJSODs7G2qYdZ6ucRZCIDk5GRcvXkRISIghh1pn1TTGCxYsgKurKyZMmGCMYdZ5NY3z/fv30aRJE3h5eWHQoEE4e/asQcfJxMnE3L59G+Xl5XBzc1Mqd3NzQ3Z2ttp9srOztar/T1eTGJP29BHnWbNmwdPTU+UfA/o/NY1zfn4+bG1tYWFhgX79+uE///kPXnzxRUMPt06qSYyPHDmCL774AomJicYY4jOhJnFu2bIl1q1bh++++w5ff/015HI5nn/+edy4ccNg4+SP/BKRSYqPj8fmzZuRkpJi+MWe/0B2dnbIyMjA/fv3kZycjOjoaPj4+KBnz561PbQ6r7CwEGPGjEFiYiIaNGhQ28N5pgUFBSEoKEhx//nnn0fr1q3x6aefYuHChQbpk4mTiWnQoAHMzMyQk5OjVJ6TkwN3d3e1+7i7u2tV/5+uJjEm7ekS52XLliE+Ph4HDhyAn5+fIYdZ59U0zlKpFL6+vgAAf39/nD9/HnFxcUyc1NA2xpcvX8bVq1cxYMAARZlcLgcAmJub4+LFi2jWrJlhB10H6eO9uV69eujYsSMyMzMNMUQAPFVnciwsLBAQEIDk5GRFmVwuR3JyslJW/aSgoCCl+gDw008/VVr/n64mMSbt1TTOS5YswcKFC7Fv3z507tzZGEOt0/T1fJbL5SguLjbEEOs8bWPcqlUr/P7778jIyFDcBg4ciF69eiEjIwNeXl7GHH6doY/ncnl5OX7//Xd4eHgYapi8HIEp2rx5s5DJZGLDhg3i3LlzYuLEicLR0VHxFcsxY8aI2bNnK+ofPXpUmJubi2XLlonz58+L2NhYXo6gGtrGuLi4WJw6dUqcOnVKeHh4iOnTp4tTp06JS5cu1dYh1Anaxjk+Pl5YWFiIbdu2KX29uLCwsLYOoU7QNs6LFy8W+/fvF5cvXxbnzp0Ty5YtE+bm5iIxMbG2DsHkaRvjp/FbdZrRNs7z588XP/74o7h8+bJIS0sTw4cPF5aWluLs2bMGGyMTJxP1n//8RzRu3FhYWFiIrl27iuPHjyu29ejRQ0RERCjV//bbb0WLFi2EhYWFaNu2rdi7d6+RR1z3aBPjK1euCAAqtx49ehh/4HWMNnFu0qSJ2jjHxsYaf+B1jDZxfu+994Svr6+wtLQUTk5OIigoSGzevLkWRl23aPu+/CQmTprTJs7vvPOOoq6bm5t4+eWXRXp6ukHHJxFCCMPNZxERERE9O7jGiYiIiEhDTJyIiIiINMTEiYiIiEhDTJyIiIiINMTEiYiIiEhDTJyIiIiINMTEiYiIiEhDTJyIiIiINMTEiYiIiEhDTJyIiIiINMTEiYiMQgiBiRMnwtnZGRKJBBkZGUYfQ8+ePfHOO+8Yvd9nBeNHxMSJiIxk37592LBhA/bs2YOsrCy0a9fOYH1V9gG/Y8cOLFy40GD9Glp2djbefvtt+Pr6wtLSEm5ubggODsaaNWvw8OFDRb1x48ZBIpEobvXr10ffvn1x+vTpWhw90bOBiRMRGcXly5fh4eGB559/Hu7u7jA3N1epU1JSYtAxODs7w87OzqB9GMqff/6Jjh07Yv/+/Vi8eDFOnTqF1NRUzJw5E3v27MGBAweU6vft2xdZWVnIyspCcnIyzM3N0b9//1oaPdEzRBCRUX366afCw8NDlJeXK5UPHDhQjB8/XgghxA8//CCCg4OFg4ODcHZ2Fv369ROZmZmKuuXl5eLDDz8UzZo1ExYWFsLLy0ssWrRIsb26/Xv06CGmTZsmZsyYIZycnISbm5uIjY1VGk9VfWzcuFE4OzuLoqIipX0GDRokRo8erXLMERERAoDi1qRJE8U4pkyZIt5++21Rv3590bNnT52P/+m+AIgrV64o+nv77beFEEIUFRWJadOmCRcXFyGTyURwcLA4efKk0rg1idPTDNVuWFiYaNSokbh//77a7XK5XPF3RESEGDRokNL2w4cPCwAiNzdX7f4Vj8WUKVOEvb29qF+/vnj//feV2n0yfkJU/zhpcqzl5eVi8eLFwtvbW1haWgo/Pz+xdevWKmOhiczMTAFA7N69W7zwwgvCyspKtGjRQhw/flzntumfjYkTkZHduXNHWFhYiAMHDijK/v77b6Wybdu2ie3bt4tLly6JU6dOiQEDBoj27dsrkq2ZM2cKJycnsWHDBpGZmSkOHz4sEhMTFe1Vt3+PHj2Evb29mDdvnvjjjz/Exo0bhUQiEfv371e0UVUfDx8+FA4ODuLbb79V1M/JyRHm5ubi559/Vjnme/fuiQULFohGjRqJrKwsxYd3jx49hK2trZgxY4a4cOGCuHDhgs7Hf+/ePREUFCQiIyNFVlaWyMrKEmVlZYr+Kj7433rrLeHp6Sn++9//irNnz4qIiAjh5OQk/v77b8W4NYnT0wzR7u3bt4VEIhFxcXGV9vukpxOnwsJC8cYbbwhfX1+VhP3JMdna2oq3335bXLhwQXz99dfC2tpafPbZZ0p1nkycqnucNDnWRYsWiVatWol9+/aJy5cvi/Xr1wuZTCZSUlI0OtbKbN++XUgkEtGrVy9x8OBB8ccff4jQ0FBFck5UU0yciGrBoEGDxOuvv664/+mnnwpPT89KP9Ty8vIEAPH777+LgoICIZPJlBKl6jy5vxCPP8y6deumVKdLly5i1qxZQgihUR+TJk0SL730kuL+Rx99JHx8fJRmKJ6UkJCgmGmq0KNHD9GxY0etxq/J2J7+gH+6/P79+6JevXoiKSlJsa2kpER4enqKJUuWKNWvKk5PM1S7x48fFwDEjh07lMrr168vbGxshI2NjZg5c6aiPCIiQpiZmSm2ARAeHh4iLS1NbfsVY2rdurXS4zdr1izRunVrpTrq4lrh6edZdcdaVFQkrK2txbFjx5S2T5gwQYwYMaLSfjQRExMjnJyclGbYPvnkE9G2bVud2iXiGieiWjBq1Chs374dxcXFAICkpCQMHz4cUunjl+SlS5cwYsQI+Pj4wN7eHt7e3gCAa9eu4fz58yguLkbv3r0rbb+q/Sv4+fkp7ePh4YHc3FwA0KiPyMhI7N+/Hzdv3gQAbNiwQbEoWRsBAQFajV+TsVXn8uXLKC0tRXBwsKKsXr166Nq1K86fP69Ut6o4Gavdypw8eRIZGRlo27at4rlUoVevXsjIyEBGRgZOnjyJsLAwvPTSS/jrr78qbe+5555TevyCgoJw6dIllJeXq62vyfMMqPxYMzMz8fDhQ7z44ouwtbVV3L788ktcvnxZm1Co+O233zBo0CC4uLgoyq5cuQJfX1+d2iVSXZ1JRAY3YMAACCGwd+9edOnSBYcPH0ZCQoLS9iZNmiAxMRGenp6Qy+Vo164dSkpKYGVlpVH7le1foV69ekr7SCQSyOVyANCoj44dO6JDhw748ssv0adPH5w9exZ79+7VNAQKNjY2Wo1fk7HpU1VxMla7vr6+kEgkuHjxolK5j48PAPWPl42NjVKS8Pnnn8PBwQGJiYlYtGiRrsMHoNnzDKj8WO/fvw8A2Lt3Lxo2bKhURyaT6TS23377DXPmzFEqy8jIQEhIiE7tEnHGiagWWFpaYsiQIUhKSsI333yDli1bolOnTgCAv//+GxcvXsT777+P3r17o3Xr1rh7965i3+bNm8PKygrJyclq265uf01U10eFf/3rX9iwYQPWr1+P0NBQeHl5adWPOroePwBYWFhUOksCAM2aNYOFhQWOHj2qKCstLcWvv/6KNm3a1Hjshmq3fv36ePHFF7Fy5Uo8ePCgRm1IJBJIpVI8evSo0jonTpxQun/8+HE0b94cZmZmKnX18Txr06YNZDIZrl27Bl9fX6WbLs+l/Px8XL16FR07dlQqz8jIgL+/f43bJQI440RUa0aNGoX+/fvj7NmzGD16tKLcyckJ9evXx2effQYPDw9cu3YNs2fPVmy3tLTErFmzMHPmTFhYWCA4OBh5eXk4e/YsJkyYUO3+mqiujwojR47E9OnTkZiYiC+//FL3oOjh+AHA29sbJ06cwNWrV2FrawtnZ2fFaVDg8WzMpEmTMGPGDDg7O6Nx48ZYsmQJHj58qHR82jJUuwCwevVqBAcHo3Pnzpg3bx78/PwglUrx66+/4sKFCyqnPIuLi5GdnQ0AuHv3LlauXIn79+9jwIABlfZx7do1REdH44033kB6ejr+85//4KOPPlJbVx/PMzs7O0yfPh1RUVGQy+Xo1q0b8vPzcfToUdjb2yMiIkKr9iqcPn0a5ubmaN++vaLsr7/+wt27d5k4kc6YOBHVkhdeeAHOzs64ePEiRo4cqSiXSqXYvHkz3nrrLbRr1w4tW7bEJ598gp49eyrqzJ07F+bm5oiJicGtW7fg4eGBN998U+P9NVFVHxUcHBwQHh6OvXv3YvDgwTUNhRJdjx8Apk+fjoiICLRp0waPHj3ClStXFOtvKsTHx0Mul2PMmDEoLCxE586d8eOPP8LJyUmn8Ruq3WbNmuHUqVNYvHgx5syZgxs3bkAmk6FNmzaYPn06Jk+erFR/37598PDwAPA4QWnVqhW2bt1a5fNg7NixePToEbp27QozMzO8/fbbmDhxotq6+nqeLVy4EC4uLoiLi8Off/4JR0dHdOrUCe+++66izoYNGzB+/HgIITRq87fffkPLli1haWmpKDt16hQcHR1VngdE2pIITZ+JRERq9O7dG23btsUnn3xS20MhHfTs2RP+/v5YsWJFbQ9FRWxsLA4dOoSUlJTaHgoRZ5yIqGbu3r2LlJQUpKSkYPXq1bU9HHqG/fDDD1i5cmVtD4MIABMnIqqhjh074u7du/jwww/RsmXL2h4OPcNOnjxZ20MgUuCpOiIiIiIN8XIERERERBpi4kRERESkISZORERERBpi4kRERESkISZORERERBpi4kRERESkISZORERERBpi4kRERESkISZORERERBpi4kRERESkISZORERERBr6f+iuCozXwB7bAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 600x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "lowest Egb in this run: 0.102 J/m² (at iter=0)\n"
+     ]
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(6, 4))\n",
+    "ax.scatter(df[\"n\"], df[\"Egb\"], s=50, edgecolor=\"black\", zorder=3)\n",
+    "ax.set_xlabel(\"vacancy fraction on GB plane,  $n$\")\n",
+    "ax.set_ylabel(\"GB energy,  $E_\\\\mathrm{gb}$  [J/m$^2$]\")\n",
+    "ax.set_title(\"GCO sample of Al FCC tilt GB (EAM, MD+relax, 3 iters)\")\n",
+    "ax.grid(alpha=0.3)\n",
+    "fig.tight_layout()\n",
+    "plt.show()\n",
+    "print(\n",
+    "    f\"\\nlowest Egb in this run: {df['Egb'].min():.3f} J/m² \"\n",
+    "    f\"(at iter={df.loc[df['Egb'].idxmin(), 'iter']})\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42804f48",
+   "metadata": {},
+   "source": [
+    "## Going further\n",
+    "\n",
+    "- **Increase `n_iters` and sweep more `t_min/t_max`.** Real GCO runs\n",
+    "  often use `t_min=300, t_max=1200` with `md_step_sampling=\"exponential\"`\n",
+    "  so the loop tries many short MDs and occasional long ones.\n",
+    "- **Try other potentials.** Swap `calculator=EAM(...)` for any other\n",
+    "  ASE-compatible calculator (MACE, CHGNet, MTP, …) — both engines\n",
+    "  share the calculator so a single substitution applies.\n",
+    "- **Parallelize across seeds.** Wrap `gco_search` in\n",
+    "  `for_node(gco_search, iter_on=\"seed\", seed=range(N), ...)` to run\n",
+    "  N independent searches concurrently. This replaces GRIP's MPI\n",
+    "  launcher."
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py:percent"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Adds an executed example notebook demonstrating `gco_search` on an Al FCC Σ3⟨110⟩ tilt boundary under EAM, **with both MD and relax stages active per iteration**. Modeled on the style of `pure_grain_boundary_study.ipynb` in the same folder.

Builds on the fix in #53 — without that fix, the GCO loop would clamp every iteration's `Egb` to 100 J/m² under an ASE engine.

## What the notebook covers

1. Build two engines under one shared `EAM(Al-Fe.eam.fs)` calculator — a `CalcInputMinimize` (fmax=0.001, BFGS, `logfile=None` to suppress per-step printouts) and a `CalcInputMD` (NVT Langevin, 1 fs timestep).
2. Optimize the bulk reference under the same calculator via `optimise_cubic_lattice_parameter` → derives `a0`, `e_cohesive`, `B`, `v0` from a Birch–Murnaghan EOS fit. Avoids inflated `Egb` from using a literature value.
3. Build matched upper/lower slabs via `build_bicrystal_slabs` using the optimized `a0`.
4. Configure `GCOConfig` with `md_run_probability=1.0`, `t_min=t_max=400 K`, `md_step_sampling="exact"`, `md_min_steps=md_max_steps=50` (50 fs of MD at 400 K per iter, then a tight relax).
5. Run `gco_search` for 3 iterations (intentionally short for demo speed under tight fmax).
6. Plot `Egb` vs vacancy-fraction `n`.

Includes the two-GB-plane convention caveat: with default `vacuum=1.0` Å the cell has two equivalent GB planes (stitch + z-PBC), which is what the `(2 × area)` divisor in `gb_energy` assumes.

## Sample output

```
a0           = 4.0336 Å
e_cohesive   = -3.3697 eV/atom
B            = 80.4 GPa
v0           = 16.407 Å³/atom

Kept 3 structures across 3 iterations:
 iter      Egb   n  rx  ry   T  n_md_steps
    0 0.101962 0.0   1   1 400          50
    1 0.283826 0.5   1   2 400          50
    2 0.199803 0.0   1   1 400          50

lowest Egb in this run: 0.102 J/m² (at iter=0)
```

## Test Plan

- [x] Notebook executes end-to-end against the post-#53 main, MD-then-relax confirmed (all rows have `T=400`, `n_md_steps=50`)
- [x] Reuses the existing `Al-Fe.eam.fs` potential already shipped in `notebooks/`
- [x] No regressions in `tests/unit/physics/test_gco_*.py` (notebook is documentation-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)