### PR TITLE
feat(engine): cell_relaxation enum on CalcInputMinimize

### DIFF
--- a/pyiron_workflow_atomistics/engine/ase.py
+++ b/pyiron_workflow_atomistics/engine/ase.py
@@ -9,7 +9,7 @@ import contextlib
 import json
 import os
 from dataclasses import dataclass, field, replace
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -133,7 +133,7 @@ def ase_calc_structure(
     record_interval: int = 1,
     fmax: float = 0.01,
     max_steps: int = 10_000,
-    cell_relaxation: str = "none",
+    cell_relaxation: Literal["none", "volume", "shape", "full"] = "none",
     energy_convergence_tolerance: float | None = None,
     properties: tuple[str, ...] = ("energy", "forces", "stresses", "volume"),
     write_to_disk: bool = False,

--- a/pyiron_workflow_atomistics/engine/ase.py
+++ b/pyiron_workflow_atomistics/engine/ase.py
@@ -133,7 +133,7 @@ def ase_calc_structure(
     record_interval: int = 1,
     fmax: float = 0.01,
     max_steps: int = 10_000,
-    relax_cell: bool = False,
+    cell_relaxation: str = "none",
     energy_convergence_tolerance: float | None = None,
     properties: tuple[str, ...] = ("energy", "forces", "stresses", "volume"),
     write_to_disk: bool = False,
@@ -175,7 +175,14 @@ def ase_calc_structure(
         converged = True
     else:
         # Relaxation
-        if relax_cell:
+        if cell_relaxation in ("volume", "shape"):
+            raise NotImplementedError(
+                f"ASEEngine does not support cell_relaxation={cell_relaxation!r}; "
+                "ASE has no native volume-only or shape-only relaxation primitive. "
+                "Use cell_relaxation='full' or switch to a backend that supports "
+                "it (e.g. VaspEngine)."
+            )
+        if cell_relaxation == "full":
             try:
                 from ase.filters import ExpCellFilter
             except ImportError:  # pragma: no cover  (ASE < 3.23)
@@ -457,7 +464,7 @@ class ASEEngine:
                 "record_interval": self.record_interval,
                 "fmax": mi.force_convergence_tolerance,
                 "max_steps": self.max_steps if self.max_steps else mi.max_iterations,
-                "relax_cell": mi.relax_cell,
+                "cell_relaxation": mi.cell_relaxation,
                 "energy_convergence_tolerance": mi.energy_convergence_tolerance,
             }
             return ase_calc_structure, kwargs

--- a/pyiron_workflow_atomistics/engine/inputs.py
+++ b/pyiron_workflow_atomistics/engine/inputs.py
@@ -19,7 +19,7 @@ class CalcInputStatic:
     pass
 
 
-@dataclass
+@dataclass(init=False)
 class CalcInputMinimize:
     """Structural relaxation parameters.
 
@@ -31,14 +31,60 @@ class CalcInputMinimize:
         Energy change between consecutive steps, in eV. Default 1e-5.
     max_iterations
         Hard cap on optimiser steps.
-    relax_cell
-        If True, relax cell vectors too (variable-cell relaxation).
+    cell_relaxation
+        Which cell degrees of freedom to relax. ``"none"`` (atoms only,
+        fixed cell), ``"volume"`` (cell volume only, shape and atoms
+        fixed), ``"shape"`` (cell shape only, volume and atoms fixed), or
+        ``"full"`` (cell + atoms). Default ``"none"``.
+
+    Notes
+    -----
+    The legacy ``relax_cell: bool`` argument is still accepted but
+    deprecated — ``relax_cell=True`` is an alias for
+    ``cell_relaxation="full"`` and ``relax_cell=False`` for
+    ``cell_relaxation="none"``. Specifying both raises ``ValueError``.
     """
 
     force_convergence_tolerance: float = 1e-2
     energy_convergence_tolerance: float = 1e-5
     max_iterations: int = 1_000_000
-    relax_cell: bool = False
+    cell_relaxation: Literal["none", "volume", "shape", "full"] = "none"
+
+    def __init__(
+        self,
+        force_convergence_tolerance: float = 1e-2,
+        energy_convergence_tolerance: float = 1e-5,
+        max_iterations: int = 1_000_000,
+        cell_relaxation: Literal["none", "volume", "shape", "full"] | None = None,
+        *,
+        relax_cell: bool | None = None,
+    ) -> None:
+        if cell_relaxation is not None and relax_cell is not None:
+            raise ValueError(
+                "Specify cell_relaxation OR relax_cell, not both. "
+                "relax_cell is deprecated; prefer cell_relaxation."
+            )
+        if relax_cell is not None:
+            import warnings as _warnings
+
+            _warnings.warn(
+                "relax_cell is deprecated; use cell_relaxation='full' or "
+                "cell_relaxation='none' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            cell_relaxation = "full" if relax_cell else "none"
+        if cell_relaxation is None:
+            cell_relaxation = "none"
+        object.__setattr__(self, "force_convergence_tolerance", force_convergence_tolerance)
+        object.__setattr__(self, "energy_convergence_tolerance", energy_convergence_tolerance)
+        object.__setattr__(self, "max_iterations", max_iterations)
+        object.__setattr__(self, "cell_relaxation", cell_relaxation)
+
+    @property
+    def relax_cell(self) -> bool:
+        """Deprecated. Backwards-compat property: True iff cell_relaxation != 'none'."""
+        return self.cell_relaxation != "none"
 
 
 @dataclass

--- a/pyiron_workflow_atomistics/engine/inputs.py
+++ b/pyiron_workflow_atomistics/engine/inputs.py
@@ -8,6 +8,7 @@ responsible for translating these to its native parameters.
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 from typing import Literal
 
@@ -65,9 +66,7 @@ class CalcInputMinimize:
                 "relax_cell is deprecated; prefer cell_relaxation."
             )
         if relax_cell is not None:
-            import warnings as _warnings
-
-            _warnings.warn(
+            warnings.warn(
                 "relax_cell is deprecated; use cell_relaxation='full' or "
                 "cell_relaxation='none' instead.",
                 DeprecationWarning,
@@ -76,10 +75,10 @@ class CalcInputMinimize:
             cell_relaxation = "full" if relax_cell else "none"
         if cell_relaxation is None:
             cell_relaxation = "none"
-        object.__setattr__(self, "force_convergence_tolerance", force_convergence_tolerance)
-        object.__setattr__(self, "energy_convergence_tolerance", energy_convergence_tolerance)
-        object.__setattr__(self, "max_iterations", max_iterations)
-        object.__setattr__(self, "cell_relaxation", cell_relaxation)
+        self.force_convergence_tolerance = force_convergence_tolerance
+        self.energy_convergence_tolerance = energy_convergence_tolerance
+        self.max_iterations = max_iterations
+        self.cell_relaxation = cell_relaxation
 
     @property
     def relax_cell(self) -> bool:

--- a/tests/unit/engine/test_ase_branches.py
+++ b/tests/unit/engine/test_ase_branches.py
@@ -59,7 +59,7 @@ def test_ase_calc_structure_static_path_records_one_frame(tmp_path):
         record_interval=1,
         fmax=0.0,
         max_steps=0,
-        relax_cell=False,
+        cell_relaxation="none",
         properties=("energy", "forces", "volume"),
         write_to_disk=False,
         working_directory=str(tmp_path),

--- a/tests/unit/engine/test_ase_cell_relaxation.py
+++ b/tests/unit/engine/test_ase_cell_relaxation.py
@@ -22,12 +22,16 @@ def _make_engine(tmp_path, mode):
 class TestASEMinimizeRouting:
     def test_none_runs(self, tmp_path):
         eng = _make_engine(tmp_path, "none")
-        out = calculate.node_function(structure=bulk("Cu", "fcc", a=3.6, cubic=True), engine=eng)
+        out = calculate.node_function(
+            structure=bulk("Cu", "fcc", a=3.6, cubic=True), engine=eng
+        )
         assert out.final_energy is not None
 
     def test_full_runs(self, tmp_path):
         eng = _make_engine(tmp_path, "full")
-        out = calculate.node_function(structure=bulk("Cu", "fcc", a=3.6, cubic=True), engine=eng)
+        out = calculate.node_function(
+            structure=bulk("Cu", "fcc", a=3.6, cubic=True), engine=eng
+        )
         assert out.final_energy is not None
 
     @pytest.mark.parametrize("mode", ["volume", "shape"])

--- a/tests/unit/engine/test_ase_cell_relaxation.py
+++ b/tests/unit/engine/test_ase_cell_relaxation.py
@@ -1,0 +1,39 @@
+"""ASEEngine routes the new cell_relaxation enum to the right optimiser."""
+
+import pytest
+from ase.build import bulk
+from ase.calculators.emt import EMT
+
+from pyiron_workflow_atomistics.engine import (
+    ASEEngine,
+    CalcInputMinimize,
+    calculate,
+)
+
+
+def _make_engine(tmp_path, mode):
+    return ASEEngine(
+        EngineInput=CalcInputMinimize(cell_relaxation=mode, max_iterations=5),
+        calculator=EMT(),
+        working_directory=str(tmp_path),
+    )
+
+
+class TestASEMinimizeRouting:
+    def test_none_runs(self, tmp_path):
+        eng = _make_engine(tmp_path, "none")
+        out = calculate.node_function(structure=bulk("Cu", "fcc", a=3.6, cubic=True), engine=eng)
+        assert out.final_energy is not None
+
+    def test_full_runs(self, tmp_path):
+        eng = _make_engine(tmp_path, "full")
+        out = calculate.node_function(structure=bulk("Cu", "fcc", a=3.6, cubic=True), engine=eng)
+        assert out.final_energy is not None
+
+    @pytest.mark.parametrize("mode", ["volume", "shape"])
+    def test_volume_and_shape_raise(self, tmp_path, mode):
+        eng = _make_engine(tmp_path, mode)
+        with pytest.raises(NotImplementedError, match=mode):
+            calculate.node_function(
+                structure=bulk("Cu", "fcc", a=3.6, cubic=True), engine=eng
+            )

--- a/tests/unit/engine/test_inputs.py
+++ b/tests/unit/engine/test_inputs.py
@@ -6,11 +6,10 @@ import warnings
 import pytest
 
 from pyiron_workflow_atomistics.engine.inputs import (
+    CalcInputMD,
     CalcInputMinimize,
     CalcInputStatic,
-    CalcInputMD,
 )
-
 
 # ---------------------------------------------------------------------------
 # Legacy tests (preserved from original test_inputs.py)
@@ -66,9 +65,7 @@ class TestCellRelaxationField:
         ci = CalcInputMinimize()
         assert ci.cell_relaxation == "none"
 
-    @pytest.mark.parametrize(
-        "value", ["none", "volume", "shape", "full"]
-    )
+    @pytest.mark.parametrize("value", ["none", "volume", "shape", "full"])
     def test_accepts_all_four_modes(self, value):
         ci = CalcInputMinimize(cell_relaxation=value)
         assert ci.cell_relaxation == value

--- a/tests/unit/engine/test_inputs.py
+++ b/tests/unit/engine/test_inputs.py
@@ -27,6 +27,7 @@ def test_calc_input_minimize_defaults():
     assert inp.force_convergence_tolerance > 0
     assert inp.energy_convergence_tolerance > 0
     assert inp.max_iterations > 0
+    assert inp.cell_relaxation == "none"
     assert inp.relax_cell is False
 
 

--- a/tests/unit/engine/test_inputs.py
+++ b/tests/unit/engine/test_inputs.py
@@ -1,18 +1,28 @@
-"""Tests for the physics-level engine input dataclasses."""
+"""Unit tests for CalcInput* dataclasses, focused on the cell_relaxation
+enum added in feat/cell-relaxation-enum."""
 
-from __future__ import annotations
+import warnings
+
+import pytest
+
+from pyiron_workflow_atomistics.engine.inputs import (
+    CalcInputMinimize,
+    CalcInputStatic,
+    CalcInputMD,
+)
+
+
+# ---------------------------------------------------------------------------
+# Legacy tests (preserved from original test_inputs.py)
+# ---------------------------------------------------------------------------
 
 
 def test_calc_input_static_is_empty_dataclass():
-    from pyiron_workflow_atomistics.engine.inputs import CalcInputStatic
-
     inp = CalcInputStatic()
     assert hasattr(inp, "__dataclass_fields__")
 
 
 def test_calc_input_minimize_defaults():
-    from pyiron_workflow_atomistics.engine.inputs import CalcInputMinimize
-
     inp = CalcInputMinimize()
     assert inp.force_convergence_tolerance > 0
     assert inp.energy_convergence_tolerance > 0
@@ -22,8 +32,6 @@ def test_calc_input_minimize_defaults():
 
 def test_calc_input_md_renamed_field():
     """`thermostat_time_constant` replaces the old `temperature_damping_timescale`."""
-    from pyiron_workflow_atomistics.engine.inputs import CalcInputMD
-
     inp = CalcInputMD()
     assert hasattr(inp, "thermostat_time_constant")
     assert not hasattr(inp, "temperature_damping_timescale")
@@ -31,8 +39,6 @@ def test_calc_input_md_renamed_field():
 
 def test_calc_input_md_time_step_in_fs():
     """time_step is in fs (default ~1 fs), not ps."""
-    from pyiron_workflow_atomistics.engine.inputs import CalcInputMD
-
     inp = CalcInputMD()
     # 1 fs is the conventional ASE/LAMMPS default — anything < 100 means fs
     assert inp.time_step < 100.0
@@ -40,14 +46,56 @@ def test_calc_input_md_time_step_in_fs():
 
 def test_calc_input_md_no_dropped_fields():
     """delta_temp and delta_press are removed."""
-    from pyiron_workflow_atomistics.engine.inputs import CalcInputMD
-
     inp = CalcInputMD()
     assert not hasattr(inp, "delta_temp")
     assert not hasattr(inp, "delta_press")
 
 
 def test_calc_input_md_no_lammps_jargon_in_docstring():
-    from pyiron_workflow_atomistics.engine.inputs import CalcInputMD
-
     assert "LAMMPS units style" not in (CalcInputMD.__doc__ or "")
+
+
+# ---------------------------------------------------------------------------
+# New tests: cell_relaxation enum
+# ---------------------------------------------------------------------------
+
+
+class TestCellRelaxationField:
+    def test_default_is_none(self):
+        ci = CalcInputMinimize()
+        assert ci.cell_relaxation == "none"
+
+    @pytest.mark.parametrize(
+        "value", ["none", "volume", "shape", "full"]
+    )
+    def test_accepts_all_four_modes(self, value):
+        ci = CalcInputMinimize(cell_relaxation=value)
+        assert ci.cell_relaxation == value
+
+
+class TestRelaxCellShim:
+    def test_relax_cell_true_maps_to_full(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            ci = CalcInputMinimize(relax_cell=True)
+        assert ci.cell_relaxation == "full"
+
+    def test_relax_cell_false_maps_to_none(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            ci = CalcInputMinimize(relax_cell=False)
+        assert ci.cell_relaxation == "none"
+
+    def test_relax_cell_property_reflects_cell_relaxation(self):
+        assert CalcInputMinimize(cell_relaxation="full").relax_cell is True
+        assert CalcInputMinimize(cell_relaxation="none").relax_cell is False
+        assert CalcInputMinimize(cell_relaxation="volume").relax_cell is True
+        assert CalcInputMinimize(cell_relaxation="shape").relax_cell is True
+
+    def test_relax_cell_emits_deprecation_warning(self):
+        with pytest.warns(DeprecationWarning, match="cell_relaxation"):
+            CalcInputMinimize(relax_cell=True)
+
+    def test_relax_cell_and_cell_relaxation_together_is_an_error(self):
+        with pytest.raises(ValueError, match="both"):
+            CalcInputMinimize(relax_cell=True, cell_relaxation="shape")


### PR DESCRIPTION
## Summary
- Adds `cell_relaxation: Literal["none","volume","shape","full"]` to `CalcInputMinimize`.
- `relax_cell: bool` becomes a deprecating constructor-only alias / property — `True ⇔ "full"`, `False ⇔ "none"`. Passing both raises `ValueError`. Reading `instance.relax_cell` now reflects `cell_relaxation != "none"`.
- `ASEEngine` routes minimisation on the new enum; raises `NotImplementedError` for `"volume"` / `"shape"` (ASE has no native primitive for these).
- Unblocks downstream packages that need ISIF=7 / ISIF=5 semantics — notably the engine-agnostic `pyiron_workflow_assyst` rewrite.

## Test plan
- [x] \`pytest tests/unit/engine -q\` — 52 passed (was 38 before this branch)
- [x] New \`tests/unit/engine/test_inputs.py\` covers the field, the deprecation shim, the property, the both-provided ValueError, and the legacy default still works
- [x] New \`tests/unit/engine/test_ase_cell_relaxation.py\` covers ASE routing for all four enum values (full / none run; volume / shape raise NotImplementedError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)