### PR TITLE
docs(notebooks): wire optimise_cubic_lattice_parameter into vacancy_formation_energy

### DIFF
--- a/notebooks/vacancy_formation_energy.ipynb
+++ b/notebooks/vacancy_formation_energy.ipynb
@@ -7,9 +7,12 @@
    "source": [
     "# Vacancy formation energy in bcc Fe (EAM)\n",
     "\n",
-    "Builds a Fe supercell from `bulk('Fe', a=2.85, cubic=True)`, removes\n",
-    "one atom, and computes `E_vac - E_bulk` (the bare difference) under\n",
-    "the included Al-Fe.eam.fs EAM potential.\n",
+    "First refines the bcc Fe lattice parameter via an EOS scan\n",
+    "(`optimise_cubic_lattice_parameter`) starting from `a=2.85`, then\n",
+    "builds a supercell from the equilibrium structure, removes one\n",
+    "atom, and computes the vacancy formation energy\n",
+    "`E_vac - ((N-1)/N) * E_bulk` under the included Al-Fe.eam.fs EAM\n",
+    "potential.\n",
     "\n",
     "Driven from a `Workflow` so that `engine.with_working_directory(...)`\n",
     "is evaluated eagerly with the resolved engine value.\n"
@@ -21,10 +24,10 @@
    "id": "a3b24a65",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T15:56:05.237736Z",
-     "iopub.status.busy": "2026-05-12T15:56:05.237319Z",
-     "iopub.status.idle": "2026-05-12T15:56:07.193562Z",
-     "shell.execute_reply": "2026-05-12T15:56:07.189830Z"
+     "iopub.execute_input": "2026-05-16T15:58:07.036363Z",
+     "iopub.status.busy": "2026-05-16T15:58:07.036018Z",
+     "iopub.status.idle": "2026-05-16T15:58:11.796583Z",
+     "shell.execute_reply": "2026-05-16T15:58:11.794108Z"
     }
    },
    "outputs": [],
@@ -39,6 +42,7 @@
     "    create_supercell_with_min_dimensions,\n",
     "    create_vacancy,\n",
     ")\n",
+    "from pyiron_workflow_atomistics.physics.bulk import optimise_cubic_lattice_parameter\n",
     "from pyiron_workflow_atomistics.physics.point_defect import (\n",
     "    calculate_vacancy_formation_energy,\n",
     ")\n",
@@ -58,10 +62,10 @@
    "id": "02d7dc02",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T15:56:07.198180Z",
-     "iopub.status.busy": "2026-05-12T15:56:07.197447Z",
-     "iopub.status.idle": "2026-05-12T15:56:12.605682Z",
-     "shell.execute_reply": "2026-05-12T15:56:12.603117Z"
+     "iopub.execute_input": "2026-05-16T15:58:11.800734Z",
+     "iopub.status.busy": "2026-05-16T15:58:11.799971Z",
+     "iopub.status.idle": "2026-05-16T15:58:18.770081Z",
+     "shell.execute_reply": "2026-05-16T15:58:18.766501Z"
     }
    },
    "outputs": [
@@ -77,7 +81,7 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:56:08     -216.690138        0.000000\n"
+      "BFGS:    0 17:58:12       -7.968559        0.000000\n"
      ]
     },
     {
@@ -85,57 +89,90 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:56:08     -210.847774        0.368379\n"
+      "BFGS:    0 17:58:12       -8.009283        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:58:12       -8.025561        0.000000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    1 17:56:09     -210.864488        0.330939\n"
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:58:12       -8.018422        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:58:12       -7.989335        0.000000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    2 17:56:10     -210.942616        0.131664\n"
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:58:13     -216.701043        0.000000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    3 17:56:11     -210.947698        0.119259\n"
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:58:14     -210.851130        0.351019\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    4 17:56:12     -210.961581        0.038241\n"
+      "BFGS:    1 17:58:15     -210.866653        0.315744\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Vacancy formation energy of Fe in BCC Fe (Al-Fe.eam.fs): 1.716 eV\n"
+      "BFGS:    2 17:58:16     -210.939713        0.123929\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFGS:    3 17:58:17     -210.944387        0.112243\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFGS:    4 17:58:18     -210.956916        0.036699\n",
+      "Optimised bcc Fe lattice parameter (Al-Fe.eam.fs): a0 = 2.8554 A (initial scan centre 2.85 A)\n",
+      "Vacancy formation energy of Fe in BCC Fe (Al-Fe.eam.fs): 1.731 eV\n"
      ]
     }
    ],
    "source": [
-    "# Pre-build the supercell so we know N at workflow-construction time \u2014\n",
-    "# the corrected formula E_f = E_vac - ((N-1)/N) * E_bulk needs N as a scalar.\n",
-    "fe_supercell = create_supercell_with_min_dimensions.node_function(\n",
+    "# Pre-build a supercell from the *initial* a=2.85 structure just to\n",
+    "# count atoms — N for E_f = E_vac - ((N-1)/N) * E_bulk must be a\n",
+    "# scalar at workflow-construction time. The optimised-a0 supercell\n",
+    "# uses the same min_dimensions, so it has the same atom count.\n",
+    "fe_supercell_init = create_supercell_with_min_dimensions.node_function(\n",
     "    bulk(\"Fe\", a=2.85, cubic=True), min_dimensions=[7, 7, 7]\n",
     ")\n",
-    "n_atoms_supercell = len(fe_supercell)\n",
+    "n_atoms_supercell = len(fe_supercell_init)\n",
     "print(f\"supercell: {n_atoms_supercell} Fe atoms\")\n",
     "\n",
     "wf = Workflow(\"vacancy_formation_energy\")\n",
+    "wf.lat_opt = optimise_cubic_lattice_parameter(\n",
+    "    structure=bulk(\"Fe\", a=2.85, cubic=True),\n",
+    "    name=\"Fe\",\n",
+    "    crystalstructure=\"bcc\",\n",
+    "    engine=engine.with_working_directory(\"lat_opt\"),\n",
+    "    strain_range=(-0.02, 0.02),\n",
+    "    num_points=5,\n",
+    ")\n",
     "wf.supercell = create_supercell_with_min_dimensions(\n",
-    "    bulk(\"Fe\", a=2.85, cubic=True), min_dimensions=[7, 7, 7]\n",
+    "    wf.lat_opt.outputs.equil_struct, min_dimensions=[7, 7, 7]\n",
     ")\n",
     "wf.with_vacancy = create_vacancy(wf.supercell, remove_atom_index=0)\n",
     "wf.calc_bulk = calculate(\n",
@@ -150,6 +187,9 @@
     "    n_atoms_supercell=n_atoms_supercell,\n",
     ")\n",
     "wf.run()\n",
+    "\n",
+    "a0 = wf.lat_opt.outputs.a0.value\n",
+    "print(f\"Optimised bcc Fe lattice parameter (Al-Fe.eam.fs): a0 = {a0:.4f} A (initial scan centre 2.85 A)\")\n",
     "\n",
     "e_f = wf.E_form.outputs.formation_energy.value\n",
     "print(f\"Vacancy formation energy of Fe in BCC Fe (Al-Fe.eam.fs): {e_f:.3f} eV\")"


### PR DESCRIPTION
## Summary
- Wire `optimise_cubic_lattice_parameter` (5-point EOS, ±2% strain) into the existing `Workflow` so the bcc-Fe lattice parameter is fit from the EAM potential instead of being hardcoded to `a=2.85 Å`.
- Optimised `a0 = 2.8554 Å`; vacancy formation energy `E_f^vac = 1.731 eV` (vs. 1.716 eV at the hardcoded lattice — within the expected 1.5–2.5 eV range for Fe under Al-Fe.eam.fs).
- `n_atoms_supercell` is still pre-computed from `bulk("Fe", a=2.85, cubic=True)` so the `((N-1)/N) * E_bulk` scaling stays correct (N is invariant under uniform scaling).

## Test plan
- [x] `jupyter nbconvert --to notebook --execute --inplace notebooks/vacancy_formation_energy.ipynb`
- [ ] Spot-check optimised `a0` value
- [ ] Spot-check `E_f^vac`

🤖 Generated with [Claude Code](https://claude.com/claude-code)