### PR TITLE
docs(notebooks): wire optimise_cubic_lattice_parameter into substitutional_formation_energy

### DIFF
--- a/notebooks/substitutional_formation_energy.ipynb
+++ b/notebooks/substitutional_formation_energy.ipynb
@@ -22,10 +22,10 @@
    "id": "be133b79",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:53:07.008022Z",
-     "iopub.status.busy": "2026-05-12T12:53:07.007571Z",
-     "iopub.status.idle": "2026-05-12T12:53:08.571524Z",
-     "shell.execute_reply": "2026-05-12T12:53:08.568264Z"
+     "iopub.execute_input": "2026-05-16T15:55:33.332640Z",
+     "iopub.status.busy": "2026-05-16T15:55:33.332178Z",
+     "iopub.status.idle": "2026-05-16T15:55:37.522219Z",
+     "shell.execute_reply": "2026-05-16T15:55:37.519013Z"
     }
    },
    "outputs": [],
@@ -42,6 +42,7 @@
     "from pyiron_workflow_atomistics.physics.point_defect import (\n",
     "    _substitutional_formation_energy,\n",
     ")\n",
+    "from pyiron_workflow_atomistics.physics.bulk import optimise_cubic_lattice_parameter\n",
     "\n",
     "engine = ASEEngine(\n",
     "    EngineInput=CalcInputMinimize(\n",
@@ -58,10 +59,10 @@
    "id": "28f34ddb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:53:08.575479Z",
-     "iopub.status.busy": "2026-05-12T12:53:08.574835Z",
-     "iopub.status.idle": "2026-05-12T12:53:08.952325Z",
-     "shell.execute_reply": "2026-05-12T12:53:08.949733Z"
+     "iopub.execute_input": "2026-05-16T15:55:37.527382Z",
+     "iopub.status.busy": "2026-05-16T15:55:37.526543Z",
+     "iopub.status.idle": "2026-05-16T15:55:38.054099Z",
+     "shell.execute_reply": "2026-05-16T15:55:38.052551Z"
     }
    },
    "outputs": [
@@ -70,7 +71,15 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 14:53:08       -0.722387        0.000000\n"
+      "BFGS:    0 17:55:37        0.026625        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:55:37       -0.018891        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:55:37       -0.026755        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:55:37       -0.000405        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:55:37        0.056968        0.000000\n"
      ]
     },
     {
@@ -78,21 +87,26 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 14:53:08       -0.638133        0.058053\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Substitutional formation energy of Ni in Cu (EMT, mu_solute=mu_host=0): 0.084 eV\n"
+      "BFGS:    0 17:55:37       -0.759941        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:55:38       -0.682568        0.057888\n",
+      "Optimised lattice parameter a0 = 3.5898 A\n",
+      "Substitutional formation energy of Ni in Cu (EMT, mu_solute=mu_host=0): 0.077 eV\n"
      ]
     }
    ],
    "source": [
     "wf = Workflow(\"substitutional_formation_energy\")\n",
+    "wf.lat_opt = optimise_cubic_lattice_parameter(\n",
+    "    structure=bulk(\"Cu\", \"fcc\", a=3.6, cubic=True),\n",
+    "    name=\"Cu\",\n",
+    "    crystalstructure=\"fcc\",\n",
+    "    engine=engine.with_working_directory(\"lat_opt\"),\n",
+    "    strain_range=(-0.02, 0.02),\n",
+    "    num_points=5,\n",
+    ")\n",
     "wf.supercell = create_supercell_with_min_dimensions(\n",
-    "    bulk(\"Cu\", \"fcc\", a=3.6, cubic=True), min_dimensions=[8, 8, 8]\n",
+    "    wf.lat_opt.outputs.equil_struct, min_dimensions=[8, 8, 8]\n",
     ")\n",
     "wf.with_substitute = substitutional_swap(\n",
     "    wf.supercell, defect_site=0, new_symbol=\"Ni\"\n",
@@ -110,6 +124,9 @@
     "    mu_host=0.0,\n",
     ")\n",
     "wf.run()\n",
+    "\n",
+    "a0 = wf.lat_opt.outputs.a0.value\n",
+    "print(f\"Optimised lattice parameter a0 = {a0:.4f} A\")\n",
     "\n",
     "e_f = wf.E_form.outputs.E_f.value\n",
     "print(f\"Substitutional formation energy of Ni in Cu (EMT, mu_solute=mu_host=0): \"\n",


### PR DESCRIPTION
## Summary
- Wire `optimise_cubic_lattice_parameter` (5-point EOS, ±2% strain) into the existing `Workflow` so the fcc-Cu lattice parameter is fit from EMT instead of hardcoded to `a=3.6 Å`.
- Optimised `a0 = 3.5898 Å`; substitutional formation energy `E_sub = 0.077 eV` (the small number is by-design — EMT Ni/Cu cohesive energies are near-degenerate and `mu_solute = mu_host = 0` is documented in the notebook).

## Test plan
- [x] `jupyter nbconvert --to notebook --execute --inplace notebooks/substitutional_formation_energy.ipynb`
- [ ] Spot-check optimised `a0`
- [ ] Spot-check `E_sub`

🤖 Generated with [Claude Code](https://claude.com/claude-code)