### PR TITLE
docs(notebooks): wire optimise_cubic_lattice_parameter into bulk_solution_energy

### DIFF
--- a/notebooks/bulk_solution_energy.ipynb
+++ b/notebooks/bulk_solution_energy.ipynb
@@ -19,10 +19,10 @@
    "id": "3329e197",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:52:05.352619Z",
-     "iopub.status.busy": "2026-05-12T12:52:05.352351Z",
-     "iopub.status.idle": "2026-05-12T12:52:07.112901Z",
-     "shell.execute_reply": "2026-05-12T12:52:07.109296Z"
+     "iopub.execute_input": "2026-05-16T15:58:23.673493Z",
+     "iopub.status.busy": "2026-05-16T15:58:23.673203Z",
+     "iopub.status.idle": "2026-05-16T15:58:28.632640Z",
+     "shell.execute_reply": "2026-05-16T15:58:28.629016Z"
     }
    },
    "outputs": [],
@@ -33,6 +33,7 @@
     "from ase.calculators.eam import EAM\n",
     "\n",
     "from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputMinimize, calculate\n",
+    "from pyiron_workflow_atomistics.physics.bulk import optimise_cubic_lattice_parameter\n",
     "from pyiron_workflow_atomistics.structure import (\n",
     "    create_supercell_with_min_dimensions,\n",
     "    substitutional_swap,\n",
@@ -53,10 +54,10 @@
    "id": "41299ce9",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:52:07.116905Z",
-     "iopub.status.busy": "2026-05-12T12:52:07.116128Z",
-     "iopub.status.idle": "2026-05-12T12:52:10.219937Z",
-     "shell.execute_reply": "2026-05-12T12:52:10.217377Z"
+     "iopub.execute_input": "2026-05-16T15:58:28.637189Z",
+     "iopub.status.busy": "2026-05-16T15:58:28.636446Z",
+     "iopub.status.idle": "2026-05-16T15:58:31.902937Z",
+     "shell.execute_reply": "2026-05-16T15:58:31.901608Z"
     }
    },
    "outputs": [
@@ -65,7 +66,9 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 14:52:07     -216.690138        0.000000\n"
+      "BFGS:    0 17:58:28       -7.968559        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:58:29       -8.009283        0.000000\n"
      ]
     },
     {
@@ -73,36 +76,57 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 14:52:08     -217.042024        0.185068\n"
+      "BFGS:    0 17:58:29       -8.025561        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:58:29       -8.018422        0.000000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    1 14:52:08     -217.046282        0.164879\n"
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:58:29       -7.989335        0.000000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    2 14:52:09     -217.064899        0.058957\n"
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:58:30     -216.701043        0.000000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    3 14:52:10     -217.065708        0.048944\n"
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:58:29     -217.043811        0.179410\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Solution energy of Al in Fe BCC (Al-Fe.eam.fs): -0.376 eV\n",
-      "E_bulk (54 Fe) = -216.690 eV\n",
+      "BFGS:    1 17:58:30     -217.047838        0.160072\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFGS:    2 17:58:30     -217.065588        0.056327\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFGS:    3 17:58:31     -217.066334        0.046761\n",
+      "Optimised lattice parameter: a0 = 2.8554 A  (B = 176.9 GPa)\n",
+      "Solution energy of Al in Fe BCC (Al-Fe.eam.fs): -0.365 eV\n",
+      "E_bulk (54 Fe) = -216.701 eV\n",
       "E_sol  (53 Fe + 1 Al) = -217.066 eV\n"
      ]
     }
@@ -114,11 +138,17 @@
     "def calculate_soln_energy(bulk_energy, sol_energy):\n",
     "    return sol_energy - bulk_energy\n",
     "\n",
-    "fe_bulk = bulk(\"Fe\", a=2.85, cubic=True)\n",
-    "\n",
     "wf = Workflow(\"bulk_solution_energy\")\n",
+    "wf.lat_opt = optimise_cubic_lattice_parameter(\n",
+    "    structure=bulk(\"Fe\", a=2.85, cubic=True),\n",
+    "    name=\"Fe\",\n",
+    "    crystalstructure=\"bcc\",\n",
+    "    engine=engine.with_working_directory(\"lat_opt\"),\n",
+    "    strain_range=(-0.02, 0.02),\n",
+    "    num_points=5,\n",
+    ")\n",
     "wf.supercell = create_supercell_with_min_dimensions(\n",
-    "    fe_bulk, min_dimensions=[7, 7, 7]\n",
+    "    wf.lat_opt.outputs.equil_struct, min_dimensions=[7, 7, 7]\n",
     ")\n",
     "wf.supercell_with_1sol = substitutional_swap(\n",
     "    wf.supercell, defect_site=0, new_symbol=\"Al\"\n",
@@ -138,6 +168,10 @@
     "    sol_energy=wf.calc_sol.outputs.engine_output.final_energy,\n",
     ")\n",
     "wf.run()\n",
+    "\n",
+    "a0 = wf.lat_opt.outputs.a0.value\n",
+    "B = wf.lat_opt.outputs.B.value\n",
+    "print(f\"Optimised lattice parameter: a0 = {a0:.4f} A  (B = {B:.1f} GPa)\")\n",
     "\n",
     "n_atoms = len(wf.supercell.value)\n",
     "print(f\"Solution energy of Al in Fe BCC (Al-Fe.eam.fs): \"\n",


### PR DESCRIPTION
## Summary
- Wire `optimise_cubic_lattice_parameter` (5-point EOS, ±2% strain) into the existing `Workflow` so the bcc-Fe lattice parameter is fit from Al-Fe.eam.fs instead of hardcoded to `a=2.85 Å`.
- Optimised `a0 = 2.8554 Å` (`B = 176.9 GPa`); bare solution energy `E_soln(Al in Fe) = -0.365 eV` (was -0.376 eV at the un-optimised lattice).

## Test plan
- [x] `jupyter nbconvert --to notebook --execute --inplace notebooks/bulk_solution_energy.ipynb`
- [ ] Spot-check optimised `a0` / `B`
- [ ] Spot-check `E_soln`

🤖 Generated with [Claude Code](https://claude.com/claude-code)