### PR TITLE
docs(notebooks): wire optimise_cubic_lattice_parameter into surface_energy

### DIFF
--- a/notebooks/surface_energy.ipynb
+++ b/notebooks/surface_energy.ipynb
@@ -7,10 +7,15 @@
    "source": [
     "# Surface energy of bcc Fe(111) under EAM\n",
     "\n",
-    "Builds a bcc-Fe bulk crystal with `ase.build.bulk`, cuts a\n",
-    "(1,1,1) slab via `physics.surface.calculate_surface_energy`, and\n",
-    "reports the surface energy in J/m^2. The bundled `Al-Fe.eam.fs`\n",
-    "potential is used so the notebook is self-contained.\n"
+    "Optimises the bcc-Fe lattice parameter with\n",
+    "`physics.bulk.optimise_cubic_lattice_parameter`, cuts a (1,1,1) slab from\n",
+    "the relaxed bulk via `physics.surface.calculate_surface_energy`, and reports\n",
+    "the surface energy in J/m^2. Both steps are wired together inside a parent\n",
+    "`pyiron_workflow.Workflow` so the relaxed lattice parameter is forwarded\n",
+    "directly into the slab construction (no hardcoded `a`).\n",
+    "\n",
+    "The bundled `Al-Fe.eam.fs` potential is used so the notebook is\n",
+    "self-contained."
    ]
   },
   {
@@ -19,10 +24,10 @@
    "id": "0472c8d7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T15:33:05.153019Z",
-     "iopub.status.busy": "2026-05-12T15:33:05.152636Z",
-     "iopub.status.idle": "2026-05-12T15:33:06.106778Z",
-     "shell.execute_reply": "2026-05-12T15:33:06.105330Z"
+     "iopub.execute_input": "2026-05-16T15:56:16.304942Z",
+     "iopub.status.busy": "2026-05-16T15:56:16.304530Z",
+     "iopub.status.idle": "2026-05-16T15:56:20.663087Z",
+     "shell.execute_reply": "2026-05-16T15:56:20.659354Z"
     }
    },
    "outputs": [],
@@ -31,7 +36,9 @@
     "from ase.build import bulk\n",
     "from ase.calculators.eam import EAM\n",
     "\n",
+    "from pyiron_workflow import Workflow\n",
     "from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputMinimize\n",
+    "from pyiron_workflow_atomistics.physics.bulk import optimise_cubic_lattice_parameter\n",
     "from pyiron_workflow_atomistics.physics.surface import calculate_surface_energy\n",
     "\n",
     "# The Al-Fe.eam.fs potential is shipped in notebooks/\n",
@@ -41,7 +48,7 @@
     "    ),\n",
     "    calculator=EAM(potential=str(next(p for p in [pathlib.Path(\"Al-Fe.eam.fs\"), pathlib.Path(\"notebooks/Al-Fe.eam.fs\"), pathlib.Path(__file__).parent / \"Al-Fe.eam.fs\" if \"__file__\" in globals() else pathlib.Path(\".\")] if p.exists()))),\n",
     "    working_directory=\"./_surf_runs\",\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -50,10 +57,10 @@
    "id": "2b625a50",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T15:33:06.108973Z",
-     "iopub.status.busy": "2026-05-12T15:33:06.108602Z",
-     "iopub.status.idle": "2026-05-12T15:33:06.379124Z",
-     "shell.execute_reply": "2026-05-12T15:33:06.377737Z"
+     "iopub.execute_input": "2026-05-16T15:56:20.668338Z",
+     "iopub.status.busy": "2026-05-16T15:56:20.667614Z",
+     "iopub.status.idle": "2026-05-16T15:56:22.754666Z",
+     "shell.execute_reply": "2026-05-16T15:56:22.751269Z"
     }
    },
    "outputs": [
@@ -62,7 +69,9 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:33:06       -8.025561        0.000000\n"
+      "BFGS:    0 17:56:21       -7.968559        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:56:21       -8.009283        0.000000\n"
      ]
     },
     {
@@ -70,35 +79,54 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:33:06      -28.624013        0.294117\n"
+      "BFGS:    0 17:56:21       -8.025561        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:56:21       -8.018422        0.000000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    1 17:33:06      -28.627320        0.248189\n"
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:56:21       -7.989335        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:56:21      -28.617889        0.277910\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    2 17:33:06      -28.637682        0.057145\n"
+      "BFGS:    1 17:56:21      -28.621559        0.233318\n",
+      "BFGS:    2 17:56:22      -28.634205        0.070391\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    3 17:33:06      -28.637890        0.048423\n"
+      "BFGS:    3 17:56:22      -28.634560        0.060199\n",
+      "BFGS:    4 17:56:22      -28.635292        0.072726\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Fe(111) surface energy (Al-Fe.eam.fs): 1.973 J/m^2 (0.123 eV/A^2)\n",
+      "BFGS:    5 17:56:22      -28.635934        0.058321\n",
+      "BFGS:    6 17:56:22      -28.636344        0.021139\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:56:22       -8.025965        0.000000\n",
+      "Optimised bcc Fe a0 = 2.8554 A (vs. hardcoded 2.85 A)\n",
+      "Bulk modulus      B  = 176.9 GPa\n",
+      "Fe(111) surface energy (Al-Fe.eam.fs): 1.967 J/m^2 (0.123 eV/A^2)\n",
       "n atoms in relaxed slab: 8\n"
      ]
     },
@@ -116,19 +144,30 @@
     }
    ],
    "source": [
-    "fe_bulk = bulk(\"Fe\", \"bcc\", a=2.85, cubic=True)\n",
-    "\n",
-    "wf = calculate_surface_energy(\n",
-    "    bulk_structure=fe_bulk,\n",
-    "    engine=engine,\n",
+    "wf = Workflow(\"surface_energy\")\n",
+    "wf.lat_opt = optimise_cubic_lattice_parameter(\n",
+    "    structure=bulk(\"Fe\", \"bcc\", a=2.85, cubic=True),\n",
+    "    name=\"Fe\",\n",
+    "    crystalstructure=\"bcc\",\n",
+    "    engine=engine.with_working_directory(\"lat_opt\"),\n",
+    "    strain_range=(-0.02, 0.02),\n",
+    "    num_points=5,\n",
+    ")\n",
+    "wf.surf = calculate_surface_energy(\n",
+    "    bulk_structure=wf.lat_opt.outputs.equil_struct,\n",
+    "    engine=engine.with_working_directory(\"surface\"),\n",
     "    miller_indices=(1, 1, 1),\n",
     "    layers=4,\n",
     "    vacuum=10.0,\n",
     ")\n",
     "wf.run()\n",
     "\n",
-    "se = wf.outputs.surface_energy.value\n",
-    "n_atoms = len(wf.outputs.relaxed_surface.value)\n",
+    "a0 = wf.lat_opt.outputs.a0.value\n",
+    "B = wf.lat_opt.outputs.B.value\n",
+    "se = wf.surf.outputs.surface_energy.value\n",
+    "n_atoms = len(wf.surf.outputs.relaxed_surface.value)\n",
+    "print(f\"Optimised bcc Fe a0 = {a0:.4f} A (vs. hardcoded 2.85 A)\")\n",
+    "print(f\"Bulk modulus      B  = {B:.1f} GPa\")\n",
     "print(f\"Fe(111) surface energy (Al-Fe.eam.fs): {se:.3f} J/m^2 ({se/16.021766208:.3f} eV/A^2)\")\n",
     "print(f\"n atoms in relaxed slab: {n_atoms}\")\n",
     "from IPython.display import HTML, display\n",
@@ -139,7 +178,7 @@
     "    '<a href=\"http://crystalium.materialsvirtuallab.org/\" target=\"_blank\">'\n",
     "    'crystalium.materialsvirtuallab.org</a>.'\n",
     "    '</div>'\n",
-    "))\n"
+    "))"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- Wrap the previously top-level `calculate_surface_energy(...)` call in a parent `Workflow("surface_energy")` that first fits the bcc-Fe lattice parameter via `optimise_cubic_lattice_parameter` (5-point EOS, ±2% strain) and threads `wf.lat_opt.outputs.equil_struct` into the surface macro — `a=2.85 Å` is no longer hardcoded.
- Optimised `a0 = 2.8554 Å` (`B = 176.9 GPa`); Fe(111) surface energy `σ = 1.967 J/m²` for the 8-atom 4-layer slab (DFT disclaimer preserved — DFT gives ~2.73 J/m²).

## Test plan
- [x] `jupyter nbconvert --to notebook --execute --inplace notebooks/surface_energy.ipynb`
- [ ] Spot-check optimised `a0`
- [ ] Spot-check Fe(111) surface energy

🤖 Generated with [Claude Code](https://claude.com/claude-code)