### PR TITLE
docs(notebooks): wire Workflow + optimise_cubic_lattice_parameter into grain_boundary_segregation

### DIFF
--- a/notebooks/grain_boundary_segregation.ipynb
+++ b/notebooks/grain_boundary_segregation.ipynb
@@ -7,10 +7,15 @@
    "source": [
     "# Grain-boundary segregation: Al in bcc-Fe\n",
     "\n",
-    "Builds a small bicrystal Fe grain boundary, runs the bulk-solute\n",
-    "reference calc, then sweeps an Al substitutional through a layer\n",
-    "of GB sites along the c-axis and computes the segregation energy\n",
-    "`E_seg = E_GB+Al - E_GB - E_sol_bulk`.\n"
+    "Optimises the bulk Fe lattice parameter via an EOS scan, builds a small\n",
+    "bicrystal Fe grain boundary at that lattice constant, runs the bulk-solute\n",
+    "reference calc, then sweeps an Al substitutional through a layer of GB\n",
+    "sites along the c-axis and computes the segregation energy\n",
+    "`E_seg = E_GB+Al - E_GB - E_sol_bulk`.\n",
+    "\n",
+    "The bulk reference (lat-opt + Fe supercell + Al-in-Fe supercell) is wired\n",
+    "as a single `pyiron_workflow.Workflow`; the per-site Al sweep over GB\n",
+    "sites stays as a Python loop driving `calculate(...).run()` calls."
    ]
   },
   {
@@ -19,25 +24,28 @@
    "id": "06f3e13d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:52:25.822895Z",
-     "iopub.status.busy": "2026-05-12T12:52:25.822397Z",
-     "iopub.status.idle": "2026-05-12T12:52:27.553171Z",
-     "shell.execute_reply": "2026-05-12T12:52:27.549912Z"
+     "iopub.execute_input": "2026-05-16T15:58:31.822955Z",
+     "iopub.status.busy": "2026-05-16T15:58:31.822572Z",
+     "iopub.status.idle": "2026-05-16T15:58:36.810145Z",
+     "shell.execute_reply": "2026-05-16T15:58:36.807209Z"
     }
    },
    "outputs": [],
    "source": [
     "import pathlib\n",
     "import numpy as np\n",
-    "from ase.build import bulk, stack\n",
+    "from ase.build import stack\n",
+    "from ase.build import bulk as ase_bulk\n",
     "from ase.calculators.eam import EAM\n",
     "from ase.lattice.cubic import BodyCenteredCubic as bcc\n",
     "\n",
+    "from pyiron_workflow import Workflow\n",
     "from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputMinimize, calculate\n",
     "from pyiron_workflow_atomistics.structure import (\n",
     "    create_supercell_with_min_dimensions,\n",
     "    substitutional_swap,\n",
     ")\n",
+    "from pyiron_workflow_atomistics.physics.bulk import optimise_cubic_lattice_parameter\n",
     "\n",
     "engine_min = ASEEngine(\n",
     "    EngineInput=CalcInputMinimize(\n",
@@ -45,7 +53,7 @@
     "    ),\n",
     "    calculator=EAM(potential=str(next(p for p in [pathlib.Path(\"Al-Fe.eam.fs\"), pathlib.Path(\"notebooks/Al-Fe.eam.fs\"), pathlib.Path(__file__).parent / \"Al-Fe.eam.fs\" if \"__file__\" in globals() else pathlib.Path(\".\")] if p.exists()))),\n",
     "    working_directory=\"./_gbseg_runs\",\n",
-    ")\n"
+    ")"
    ]
   },
   {
@@ -54,10 +62,10 @@
    "id": "d554469d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:52:27.557806Z",
-     "iopub.status.busy": "2026-05-12T12:52:27.557219Z",
-     "iopub.status.idle": "2026-05-12T12:52:29.121534Z",
-     "shell.execute_reply": "2026-05-12T12:52:29.117358Z"
+     "iopub.execute_input": "2026-05-16T15:58:36.814791Z",
+     "iopub.status.busy": "2026-05-16T15:58:36.814011Z",
+     "iopub.status.idle": "2026-05-16T15:58:39.541256Z",
+     "shell.execute_reply": "2026-05-16T15:58:39.538836Z"
     }
    },
    "outputs": [
@@ -66,7 +74,9 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 14:52:28     -216.690138        0.000000\n"
+      "BFGS:    0 17:58:37       -7.968559        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:58:37       -8.009283        0.000000\n"
      ]
     },
     {
@@ -74,38 +84,78 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 14:52:29     -217.042024        0.185068\n"
+      "BFGS:    0 17:58:37       -8.025561        0.000000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "bulk solute Al-in-Fe solution energy reference: -0.352 eV\n"
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:58:37       -8.018422        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:58:37       -7.989335        0.000000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:58:38     -216.701043        0.000000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:58:39     -217.043811        0.179410\n",
+      "optimised a0 (Fe, bcc, Al-Fe.eam.fs) = 2.8554 A (was hardcoded 2.85 A)\n",
+      "bulk solute Al-in-Fe solution energy reference: -0.343 eV\n"
      ]
     }
    ],
    "source": [
-    "# Bulk Fe + Al-in-Fe reference solution energy.\n",
-    "fe_bulk = bulk(\"Fe\", a=2.85, cubic=True)\n",
-    "supercell = create_supercell_with_min_dimensions.node_function(\n",
-    "    fe_bulk, min_dimensions=[7, 7, 7]\n",
+    "# Wire the bulk reference setup (lat-opt + bulk supercell + Al-in-Fe\n",
+    "# supercell) into a single Workflow. The optimised a0 from the EOS scan\n",
+    "# feeds the supercell construction (replacing the hardcoded lc = 2.85 used\n",
+    "# in the old version of this notebook) and is also reused below for the\n",
+    "# bicrystal slab.\n",
+    "wf = Workflow(\"gb_seg_setup\")\n",
+    "wf.lat_opt = optimise_cubic_lattice_parameter(\n",
+    "    structure=ase_bulk(\"Fe\", a=2.85, cubic=True),\n",
+    "    name=\"Fe\",\n",
+    "    crystalstructure=\"bcc\",\n",
+    "    engine=engine_min.with_working_directory(\"lat_opt\"),\n",
+    "    strain_range=(-0.02, 0.02),\n",
+    "    num_points=5,\n",
     ")\n",
-    "supercell_with_al = substitutional_swap.node_function(\n",
-    "    supercell, defect_site=0, new_symbol=\"Al\"\n",
+    "wf.supercell = create_supercell_with_min_dimensions(\n",
+    "    wf.lat_opt.outputs.equil_struct, min_dimensions=[7, 7, 7]\n",
     ")\n",
+    "wf.supercell_with_al = substitutional_swap(\n",
+    "    wf.supercell, defect_site=0, new_symbol=\"Al\"\n",
+    ")\n",
+    "wf.calc_bulk_ref = calculate(\n",
+    "    wf.supercell,\n",
+    "    engine=engine_min.with_working_directory(\"bulk_ref\"),\n",
+    "    label=\"calc_bulk_ref\",\n",
+    ")\n",
+    "wf.calc_sol_ref = calculate(\n",
+    "    wf.supercell_with_al,\n",
+    "    engine=engine_min.with_working_directory(\"sol_ref\"),\n",
+    "    label=\"calc_sol_ref\",\n",
+    ")\n",
+    "wf.run()\n",
     "\n",
-    "calc_bulk_ref = calculate(structure=supercell,\n",
-    "                    engine=engine_min.with_working_directory(\"bulk_ref\"))\n",
-    "calc_bulk_ref.run()\n",
-    "calc_sol_ref = calculate(structure=supercell_with_al,\n",
-    "                   engine=engine_min.with_working_directory(\"sol_ref\"))\n",
-    "calc_sol_ref.run()\n",
-    "\n",
-    "E_bulk_ref = calc_bulk_ref.outputs.engine_output.value.final_energy\n",
-    "E_sol_ref = calc_sol_ref.outputs.engine_output.value.final_energy\n",
+    "lc = float(wf.lat_opt.outputs.a0.value)\n",
+    "E_bulk_ref = wf.calc_bulk_ref.outputs.engine_output.value.final_energy\n",
+    "E_sol_ref = wf.calc_sol_ref.outputs.engine_output.value.final_energy\n",
     "E_soln = E_sol_ref - E_bulk_ref\n",
-    "print(f\"bulk solute Al-in-Fe solution energy reference: {E_soln:.3f} eV\")\n"
+    "\n",
+    "print(f\"optimised a0 (Fe, bcc, Al-Fe.eam.fs) = {lc:.4f} A (was hardcoded 2.85 A)\")\n",
+    "print(f\"bulk solute Al-in-Fe solution energy reference: {E_soln:.3f} eV\")"
    ]
   },
   {
@@ -114,10 +164,10 @@
    "id": "d8f1839b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:52:29.126181Z",
-     "iopub.status.busy": "2026-05-12T12:52:29.125697Z",
-     "iopub.status.idle": "2026-05-12T12:52:34.408980Z",
-     "shell.execute_reply": "2026-05-12T12:52:34.406249Z"
+     "iopub.execute_input": "2026-05-16T15:58:39.545546Z",
+     "iopub.status.busy": "2026-05-16T15:58:39.545163Z",
+     "iopub.status.idle": "2026-05-16T15:58:45.292271Z",
+     "shell.execute_reply": "2026-05-16T15:58:45.289193Z"
     }
    },
    "outputs": [
@@ -126,72 +176,66 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 14:52:29     -121.713946       25.953139\n"
+      "BFGS:    0 17:58:40     -122.019606       25.579957\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    1 14:52:30     -138.154261        1.822774\n"
+      "BFGS:    1 17:58:40     -138.235616        1.824672\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    2 14:52:31     -138.469296        1.581394\n"
+      "BFGS:    2 17:58:41     -138.552215        1.615560\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    3 14:52:31     -139.372537        0.891014\n"
+      "BFGS:    3 17:58:42     -139.329550        1.077139\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    4 14:52:32     -139.478102        0.579342\n"
+      "BFGS:    4 17:58:43     -139.516265        0.647736\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    5 14:52:33     -139.532687        0.344194\n"
+      "BFGS:    5 17:58:43     -139.579311        0.347231\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    6 14:52:33     -139.567862        0.297878\n"
+      "BFGS:    6 17:58:44     -139.611712        0.310276\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    7 14:52:34     -139.613565        0.130983\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "bicrystal: 36 atoms, E_gb = -139.614 eV, c = 14.81 A\n"
+      "BFGS:    7 17:58:45     -139.659747        0.183129\n",
+      "bicrystal: 36 atoms, E_gb = -139.660 eV, c = 14.84 A\n"
      ]
     }
    ],
    "source": [
-    "# Build a small S3-RA110 Fe bicrystal and relax it.\n",
+    "# Build a small S3-RA110 Fe bicrystal at the optimised lattice constant `lc`\n",
+    "# and relax it. Kept as a direct calculate(...).run() since it's a single node.\n",
     "surface1 = [1, 1, 1]\n",
     "surface2 = [1, 1, -1]\n",
     "rotation_axis = [1, -1, 0]\n",
-    "lc = 2.85\n",
     "v1 = list(-np.cross(rotation_axis, surface1))\n",
     "v2 = list(-np.cross(rotation_axis, surface2))\n",
     "slab1 = bcc(symbol=\"Fe\", latticeconstant=lc,\n",
@@ -206,7 +250,7 @@
     "gb_relaxed = calc_gb.outputs.engine_output.value.final_structure\n",
     "E_gb = calc_gb.outputs.engine_output.value.final_energy\n",
     "gb_z = gb_relaxed.cell[-1, -1]\n",
-    "print(f\"bicrystal: {len(gb_relaxed)} atoms, E_gb = {E_gb:.3f} eV, c = {gb_z:.2f} A\")\n"
+    "print(f\"bicrystal: {len(gb_relaxed)} atoms, E_gb = {E_gb:.3f} eV, c = {gb_z:.2f} A\")"
    ]
   },
   {
@@ -215,10 +259,10 @@
    "id": "35207b8f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:52:34.413028Z",
-     "iopub.status.busy": "2026-05-12T12:52:34.412630Z",
-     "iopub.status.idle": "2026-05-12T12:52:41.000004Z",
-     "shell.execute_reply": "2026-05-12T12:52:40.997287Z"
+     "iopub.execute_input": "2026-05-16T15:58:45.297768Z",
+     "iopub.status.busy": "2026-05-16T15:58:45.297233Z",
+     "iopub.status.idle": "2026-05-16T15:58:54.908540Z",
+     "shell.execute_reply": "2026-05-16T15:58:54.905001Z"
     }
    },
    "outputs": [
@@ -226,7 +270,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "considering 4 sites near midplane (c = 7.40 A)\n"
+      "considering 4 sites near midplane (c = 7.42 A)\n"
      ]
     },
     {
@@ -234,43 +278,28 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 14:52:35     -140.084512        0.374744\n"
+      "BFGS:    0 17:58:45     -140.104472        0.417562\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    1 14:52:35     -140.093550        0.335143\n"
+      "BFGS:    1 17:58:46     -140.117241        0.377975\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    2 14:52:36     -140.126430        0.099884\n"
+      "BFGS:    2 17:58:47     -140.160237        0.208107\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 14:52:36     -140.084512        0.374744\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    1 14:52:37     -140.093550        0.335143\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    2 14:52:38     -140.126430        0.099884\n"
+      "BFGS:    3 17:58:48     -140.163691        0.143906\n"
      ]
     },
     {
@@ -278,21 +307,28 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 14:52:38     -140.026991        0.330118\n"
+      "BFGS:    0 17:58:48     -140.104472        0.417562\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    1 14:52:39     -140.037525        0.268804\n"
+      "BFGS:    1 17:58:49     -140.117241        0.377975\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    2 14:52:39     -140.062703        0.194054\n"
+      "BFGS:    2 17:58:50     -140.160237        0.208107\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFGS:    3 17:58:50     -140.163691        0.143906\n"
      ]
     },
     {
@@ -300,37 +336,54 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 14:52:39     -140.026991        0.330118\n"
+      "BFGS:    0 17:58:51     -140.064190        0.340933\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    1 14:52:40     -140.037525        0.268804\n"
+      "BFGS:    1 17:58:52     -140.076518        0.308717\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    2 14:52:40     -140.062703        0.194054\n"
+      "BFGS:    2 17:58:52     -140.109737        0.172617\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "   site         z   dist_GB   E_with_Al     E_seg\n",
-      "0    21  7.404517  0.000000 -140.126430 -0.160980\n",
-      "1    18  7.404517  0.000000 -140.126430 -0.160980\n",
-      "2    19  8.526799  1.122282 -140.062703 -0.097252\n",
-      "3    22  8.526799  1.122282 -140.062703 -0.097252\n"
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:58:53     -140.064190        0.340933\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFGS:    1 17:58:54     -140.076518        0.308717\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BFGS:    2 17:58:54     -140.109737        0.172617\n",
+      "   site         z       dist_GB   E_with_Al     E_seg\n",
+      "0    18  7.418462  0.000000e+00 -140.163691 -0.161176\n",
+      "1    21  7.418462  8.881784e-16 -140.163691 -0.161176\n",
+      "2    19  8.545754  1.127291e+00 -140.109737 -0.107222\n",
+      "3    22  8.545754  1.127291e+00 -140.109737 -0.107222\n"
      ]
     }
    ],
    "source": [
     "# Sweep Al on a handful of Fe sites closest to the bicrystal midplane.\n",
+    "# Per-site calls stay as a plain Python loop driving calculate(...).run().\n",
     "# (Keeping the site count small so the notebook executes quickly under EAM.)\n",
     "import pandas as pd\n",
     "positions = gb_relaxed.get_positions()\n",
@@ -356,7 +409,7 @@
     "                  \"E_seg\": float(e_seg)})\n",
     "\n",
     "df = pd.DataFrame(rows).sort_values(\"dist_GB\").reset_index(drop=True)\n",
-    "print(df)\n"
+    "print(df)"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- Replace the imperative `node_function(...)` + bare `calculate(...).run()` setup block with a single `Workflow("gb_seg_setup")` wiring `optimise_cubic_lattice_parameter` → `create_supercell_with_min_dimensions` → `substitutional_swap` → two `calculate` nodes (`calc_bulk_ref`, `calc_sol_ref`), each scoped via `engine_min.with_working_directory(...)`.
- The optimised `a0` (`wf.lat_opt.outputs.a0.value`) is threaded into both the bulk-ref supercell (via the macro's `equil_struct`) and the `BodyCenteredCubic` slab construction (replacing `lc = 2.85`).
- The per-site Al sweep over the 4 sites nearest the GB midplane intentionally stays as a Python `for` loop driving per-site `calculate(...).run()` — only the setup is wrapped in a Workflow.
- Optimised `a0 = 2.8554 Å`; `E_soln` (reference) = −0.343 eV; example `E_seg` for closest pair of GB sites = −0.161 eV (finite, non-NaN across all four sites).

## Test plan
- [x] `jupyter nbconvert --to notebook --execute --inplace notebooks/grain_boundary_segregation.ipynb`
- [ ] Spot-check optimised `a0`
- [ ] Spot-check `E_soln` and `E_seg`

🤖 Generated with [Claude Code](https://claude.com/claude-code)