### PR TITLE
docs(notebooks): wire Workflow + optimise_cubic_lattice_parameter into gb_cleavage

### DIFF
--- a/notebooks/gb_cleavage.ipynb
+++ b/notebooks/gb_cleavage.ipynb
@@ -20,27 +20,50 @@
    "id": "8d7e9f7e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:52:18.005757Z",
-     "iopub.status.busy": "2026-05-12T12:52:18.005409Z",
-     "iopub.status.idle": "2026-05-12T12:52:22.222910Z",
-     "shell.execute_reply": "2026-05-12T12:52:22.220261Z"
+     "iopub.execute_input": "2026-05-16T15:59:13.962928Z",
+     "iopub.status.busy": "2026-05-16T15:59:13.962634Z",
+     "iopub.status.idle": "2026-05-16T15:59:18.868347Z",
+     "shell.execute_reply": "2026-05-16T15:59:18.864990Z"
     }
    },
    "outputs": [],
    "source": [
     "import pathlib\n",
     "import numpy as np\n",
-    "from ase.build import stack\n",
+    "from ase.build import bulk, stack\n",
     "from ase.calculators.eam import EAM\n",
     "from ase.lattice.cubic import BodyCenteredCubic as bcc\n",
     "\n",
-    "from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic, calculate\n",
+    "from pyiron_workflow import Workflow\n",
+    "from pyiron_workflow_atomistics.engine import (\n",
+    "    ASEEngine,\n",
+    "    CalcInputMinimize,\n",
+    "    CalcInputStatic,\n",
+    "    calculate,\n",
+    ")\n",
+    "from pyiron_workflow_atomistics.physics.bulk import optimise_cubic_lattice_parameter\n",
     "from pyiron_workflow_atomistics.physics.grain_boundary import cleave_gb_structure\n",
     "from pyiron_workflow_atomistics.structure import add_vacuum\n",
     "\n",
+    "_pot_path = str(next(p for p in [\n",
+    "    pathlib.Path(\"Al-Fe.eam.fs\"),\n",
+    "    pathlib.Path(\"notebooks/Al-Fe.eam.fs\"),\n",
+    "    pathlib.Path(__file__).parent / \"Al-Fe.eam.fs\" if \"__file__\" in globals() else pathlib.Path(\".\"),\n",
+    "] if p.exists()))\n",
+    "\n",
+    "# Static engine for the cleavage scan (single-point energies).\n",
     "engine_static = ASEEngine(\n",
     "    EngineInput=CalcInputStatic(),\n",
-    "    calculator=EAM(potential=str(next(p for p in [pathlib.Path(\"Al-Fe.eam.fs\"), pathlib.Path(\"notebooks/Al-Fe.eam.fs\"), pathlib.Path(__file__).parent / \"Al-Fe.eam.fs\" if \"__file__\" in globals() else pathlib.Path(\".\")] if p.exists()))),\n",
+    "    calculator=EAM(potential=_pot_path),\n",
+    "    working_directory=\"./_gb_cleave_runs\",\n",
+    ")\n",
+    "\n",
+    "# Minimising engine reusing the same EAM potential, for bulk lat-opt.\n",
+    "engine_min = ASEEngine(\n",
+    "    EngineInput=CalcInputMinimize(\n",
+    "        force_convergence_tolerance=0.05, max_iterations=100\n",
+    "    ),\n",
+    "    calculator=EAM(potential=_pot_path),\n",
     "    working_directory=\"./_gb_cleave_runs\",\n",
     ")\n"
    ]
@@ -51,10 +74,10 @@
    "id": "d3b1ba4a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:52:22.226801Z",
-     "iopub.status.busy": "2026-05-12T12:52:22.225946Z",
-     "iopub.status.idle": "2026-05-12T12:52:22.253825Z",
-     "shell.execute_reply": "2026-05-12T12:52:22.250653Z"
+     "iopub.execute_input": "2026-05-16T15:59:18.875290Z",
+     "iopub.status.busy": "2026-05-16T15:59:18.873844Z",
+     "iopub.status.idle": "2026-05-16T15:59:19.743923Z",
+     "shell.execute_reply": "2026-05-16T15:59:19.741102Z"
     }
    },
    "outputs": [
@@ -62,16 +85,54 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "bicrystal: 24 atoms, c = 24.05 A, area = 28.14 A^2\n"
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:59:19       -7.968559        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:59:19       -8.009283        0.000000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:59:19       -8.025561        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:59:19       -8.018422        0.000000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:59:19       -7.989335        0.000000\n",
+      "optimised a0 = 2.8554 A (was hard-coded as 2.85 A)\n",
+      "bicrystal: 24 atoms, c = 24.07 A, area = 28.24 A^2\n"
      ]
     }
    ],
    "source": [
-    "# Build a small S3-RA110 like bicrystal from oriented bcc slabs.\n",
+    "# Optimise the bcc Fe lattice parameter via Workflow so the bicrystal slab\n",
+    "# uses a self-consistent a0, rather than a hard-coded 2.85 A.\n",
+    "wf_setup = Workflow(\"gb_cleave_setup\")\n",
+    "wf_setup.lat_opt = optimise_cubic_lattice_parameter(\n",
+    "    structure=bulk(\"Fe\", a=2.85, cubic=True),\n",
+    "    name=\"Fe\",\n",
+    "    crystalstructure=\"bcc\",\n",
+    "    engine=engine_min.with_working_directory(\"lat_opt\"),\n",
+    "    strain_range=(-0.02, 0.02),\n",
+    "    num_points=5,\n",
+    ")\n",
+    "wf_setup.run()\n",
+    "\n",
+    "lc = float(wf_setup.lat_opt.outputs.a0.value)\n",
+    "print(f\"optimised a0 = {lc:.4f} A (was hard-coded as 2.85 A)\")\n",
+    "\n",
+    "# Build a small S3-RA110 like bicrystal from oriented bcc slabs using the optimised lc.\n",
     "surface1 = [1, 1, 1]\n",
     "surface2 = [1, 1, -1]\n",
     "rotation_axis = [1, -1, 0]\n",
-    "lc = 2.85\n",
     "v1 = list(-np.cross(rotation_axis, surface1))\n",
     "v2 = list(-np.cross(rotation_axis, surface2))\n",
     "\n",
@@ -92,10 +153,10 @@
    "id": "25b88fcd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:52:22.257636Z",
-     "iopub.status.busy": "2026-05-12T12:52:22.257249Z",
-     "iopub.status.idle": "2026-05-12T12:52:22.557503Z",
-     "shell.execute_reply": "2026-05-12T12:52:22.555195Z"
+     "iopub.execute_input": "2026-05-16T15:59:19.748329Z",
+     "iopub.status.busy": "2026-05-16T15:59:19.747934Z",
+     "iopub.status.idle": "2026-05-16T15:59:20.152377Z",
+     "shell.execute_reply": "2026-05-16T15:59:20.149625Z"
     }
    },
    "outputs": [
@@ -103,18 +164,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "uncleaved energy: -77.977 eV\n"
+      "uncleaved energy: -78.116 eV\n"
      ]
     }
    ],
    "source": [
-    "# Compute the uncleaved (reference) energy with a static engine.\n",
-    "calc_uncleaved = calculate(\n",
+    "# Compute the uncleaved (reference) energy with the static engine,\n",
+    "# wired through a small Workflow for parity with the lat-opt step.\n",
+    "wf_ref = Workflow(\"gb_cleave_ref\")\n",
+    "wf_ref.uncleaved = calculate(\n",
     "    structure=gb_with_vacuum,\n",
     "    engine=engine_static.with_working_directory(\"uncleaved\"),\n",
+    "    label=\"uncleaved\",\n",
     ")\n",
-    "calc_uncleaved.run()\n",
-    "E_uncleaved = calc_uncleaved.outputs.engine_output.value.final_energy\n",
+    "wf_ref.run()\n",
+    "E_uncleaved = wf_ref.uncleaved.outputs.engine_output.value.final_energy\n",
     "print(f\"uncleaved energy: {E_uncleaved:.3f} eV\")\n"
    ]
   },
@@ -124,10 +188,10 @@
    "id": "1e6dadfb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:52:22.560635Z",
-     "iopub.status.busy": "2026-05-12T12:52:22.560352Z",
-     "iopub.status.idle": "2026-05-12T12:52:22.573344Z",
-     "shell.execute_reply": "2026-05-12T12:52:22.570487Z"
+     "iopub.execute_input": "2026-05-16T15:59:20.156901Z",
+     "iopub.status.busy": "2026-05-16T15:59:20.156592Z",
+     "iopub.status.idle": "2026-05-16T15:59:20.167831Z",
+     "shell.execute_reply": "2026-05-16T15:59:20.164919Z"
     }
    },
    "outputs": [
@@ -136,10 +200,10 @@
      "output_type": "stream",
      "text": [
       "found 4 candidate cleavage plane(s)\n",
-      "  plane @ c = 10.380 A\n",
-      "  plane @ c = 11.202 A\n",
-      "  plane @ c = 12.025 A\n",
-      "  plane @ c = 12.848 A\n"
+      "  plane @ c = 10.385 A\n",
+      "  plane @ c = 11.209 A\n",
+      "  plane @ c = 12.034 A\n",
+      "  plane @ c = 12.858 A\n"
      ]
     }
    ],
@@ -167,10 +231,10 @@
    "id": "8d6320a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:52:22.576681Z",
-     "iopub.status.busy": "2026-05-12T12:52:22.576347Z",
-     "iopub.status.idle": "2026-05-12T12:52:23.849694Z",
-     "shell.execute_reply": "2026-05-12T12:52:23.846653Z"
+     "iopub.execute_input": "2026-05-16T15:59:20.172221Z",
+     "iopub.status.busy": "2026-05-16T15:59:20.171849Z",
+     "iopub.status.idle": "2026-05-16T15:59:21.445514Z",
+     "shell.execute_reply": "2026-05-16T15:59:21.442319Z"
     }
    },
    "outputs": [
@@ -179,11 +243,11 @@
      "output_type": "stream",
      "text": [
       "   cleavage_coord  energy_eV  cleavage_energy_Jm2\n",
-      "0       10.379534 -70.929677             2.006482\n",
-      "1       11.202259 -71.368759             1.881472\n",
-      "2       12.024983 -82.393645            -1.257404\n",
-      "3       12.847707 -82.378147            -1.252992\n",
-      "min cleavage energy: -1.257 J/m^2\n"
+      "0       10.384958 -71.052086             2.003528\n",
+      "1       11.209231 -71.503781             1.875410\n",
+      "2       12.033505 -82.367554            -1.205979\n",
+      "3       12.857778 -82.352069            -1.201586\n",
+      "min cleavage energy: -1.206 J/m^2\n"
      ]
     }
    ],


### PR DESCRIPTION
## Summary
- Replace the hardcoded `lc = 2.85` setup with a `Workflow("gb_cleave_setup")` wiring `optimise_cubic_lattice_parameter` (5-point EOS, ±2% strain). Adds a sibling `engine_min` (CalcInputMinimize) that reuses the existing EAM calculator — `engine_static` is retained for the cleavage scan itself.
- The optimised `a0` drives the `BodyCenteredCubic` bicrystal slab construction. The uncleaved-reference `calculate(...)` is also wrapped in `Workflow("gb_cleave_ref")` for parity.
- The per-plane cleavage Python loop (plane identification + DataFrame summary) is intentionally preserved.
- Optimised `a0 = 2.8554 Å`; bicrystal: 24 atoms, c = 24.07 Å, area = 28.24 Å²; uncleaved E = −78.116 eV; valid cleavage planes give **2.003** and **1.875 J/m²** (within the 1–3 J/m² EAM range; two negative entries for non-physical planes are preserved as in the original).

## Test plan
- [x] `jupyter nbconvert --to notebook --execute --inplace notebooks/gb_cleavage.ipynb`
- [ ] Spot-check optimised `a0`
- [ ] Spot-check cleavage energies

🤖 Generated with [Claude Code](https://claude.com/claude-code)