### PR TITLE
docs(notebooks): wire Workflow + optimise_cubic_lattice_parameter into pure_grain_boundary_study

### DIFF
--- a/notebooks/pure_grain_boundary_study.ipynb
+++ b/notebooks/pure_grain_boundary_study.ipynb
@@ -19,10 +19,10 @@
    "id": "b323a89c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:52:48.769556Z",
-     "iopub.status.busy": "2026-05-12T12:52:48.769264Z",
-     "iopub.status.idle": "2026-05-12T12:52:52.968229Z",
-     "shell.execute_reply": "2026-05-12T12:52:52.965658Z"
+     "iopub.execute_input": "2026-05-16T16:00:24.347609Z",
+     "iopub.status.busy": "2026-05-16T16:00:24.347304Z",
+     "iopub.status.idle": "2026-05-16T16:00:28.900639Z",
+     "shell.execute_reply": "2026-05-16T16:00:28.896549Z"
     }
    },
    "outputs": [],
@@ -33,7 +33,9 @@
     "from ase.calculators.eam import EAM\n",
     "from ase.lattice.cubic import BodyCenteredCubic as bcc\n",
     "\n",
+    "from pyiron_workflow import Workflow\n",
     "from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputMinimize, calculate\n",
+    "from pyiron_workflow_atomistics.physics.bulk import optimise_cubic_lattice_parameter\n",
     "from pyiron_workflow_atomistics.physics.grain_boundary import (\n",
     "    get_GB_energy,\n",
     "    get_GB_exc_volume,\n",
@@ -54,10 +56,10 @@
    "id": "759dd963",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:52:52.971718Z",
-     "iopub.status.busy": "2026-05-12T12:52:52.971016Z",
-     "iopub.status.idle": "2026-05-12T12:52:53.108117Z",
-     "shell.execute_reply": "2026-05-12T12:52:53.104760Z"
+     "iopub.execute_input": "2026-05-16T16:00:28.906002Z",
+     "iopub.status.busy": "2026-05-16T16:00:28.904669Z",
+     "iopub.status.idle": "2026-05-16T16:00:29.839834Z",
+     "shell.execute_reply": "2026-05-16T16:00:29.836865Z"
     }
    },
    "outputs": [
@@ -66,25 +68,52 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 14:52:53       -8.025561        0.000000\n"
+      "BFGS:    0 18:00:29       -7.968559        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 18:00:29       -8.009283        0.000000\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "e0/atom = -4.0128 eV, v0/atom = 11.575 A^3\n"
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 18:00:29       -8.025561        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 18:00:29       -8.018422        0.000000\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 18:00:29       -7.989335        0.000000\n",
+      "Optimised lattice parameter: a0 = 2.8554 A  (B = 176.9 GPa)\n",
+      "e0/atom = -4.0130 eV, v0/atom = 11.640 A^3\n"
      ]
     }
    ],
    "source": [
-    "# Bulk reference: single-cell Fe under the same potential.\n",
-    "fe_bulk = bulk(\"Fe\", a=2.85, cubic=True)\n",
-    "calc_bulk = calculate(structure=fe_bulk, engine=engine_min.with_working_directory(\"bulk\"))\n",
-    "calc_bulk.run()\n",
-    "bulk_out = calc_bulk.outputs.engine_output.value\n",
-    "e0_per_atom = bulk_out.final_energy / len(bulk_out.final_structure)\n",
-    "v0_per_atom = bulk_out.final_volume / len(bulk_out.final_structure)\n",
+    "# Bulk reference: optimise the bcc-Fe lattice parameter via an EOS scan\n",
+    "# so e0/atom, v0/atom and the slab lattice constant are self-consistent\n",
+    "# with the same EAM potential.\n",
+    "wf = Workflow(\"pure_gb_setup\")\n",
+    "wf.lat_opt = optimise_cubic_lattice_parameter(\n",
+    "    structure=bulk(\"Fe\", a=2.85, cubic=True),\n",
+    "    name=\"Fe\",\n",
+    "    crystalstructure=\"bcc\",\n",
+    "    engine=engine_min.with_working_directory(\"lat_opt\"),\n",
+    "    strain_range=(-0.02, 0.02),\n",
+    "    num_points=5,\n",
+    ")\n",
+    "wf.run()\n",
+    "\n",
+    "lc = wf.lat_opt.outputs.a0.value\n",
+    "B = wf.lat_opt.outputs.B.value\n",
+    "e0_per_atom = wf.lat_opt.outputs.equil_energy_per_atom.value\n",
+    "v0_per_atom = wf.lat_opt.outputs.equil_volume_per_atom.value\n",
+    "print(f\"Optimised lattice parameter: a0 = {lc:.4f} A  (B = {B:.1f} GPa)\")\n",
     "print(f\"e0/atom = {e0_per_atom:.4f} eV, v0/atom = {v0_per_atom:.3f} A^3\")\n"
    ]
   },
@@ -94,10 +123,10 @@
    "id": "be003d00",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:52:53.111846Z",
-     "iopub.status.busy": "2026-05-12T12:52:53.111401Z",
-     "iopub.status.idle": "2026-05-12T12:52:53.140970Z",
-     "shell.execute_reply": "2026-05-12T12:52:53.137665Z"
+     "iopub.execute_input": "2026-05-16T16:00:29.843411Z",
+     "iopub.status.busy": "2026-05-16T16:00:29.843096Z",
+     "iopub.status.idle": "2026-05-16T16:00:29.868242Z",
+     "shell.execute_reply": "2026-05-16T16:00:29.865010Z"
     }
    },
    "outputs": [
@@ -105,16 +134,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "bicrystal: 36 atoms, c = 14.81 A\n"
+      "bicrystal: 36 atoms, c = 14.84 A\n"
      ]
     }
    ],
    "source": [
-    "# Build a S3-RA110 bcc-Fe bicrystal directly with ASE.\n",
+    "# Build a S3-RA110 bcc-Fe bicrystal directly with ASE, using the\n",
+    "# optimised lattice constant `lc` from the EOS step above.\n",
     "surface1 = [1, 1, 1]\n",
     "surface2 = [1, 1, -1]\n",
     "rotation_axis = [1, -1, 0]\n",
-    "lc = 2.85\n",
     "v1 = list(-np.cross(rotation_axis, surface1))\n",
     "v2 = list(-np.cross(rotation_axis, surface2))\n",
     "slab1 = bcc(symbol=\"Fe\", latticeconstant=lc,\n",
@@ -131,10 +160,10 @@
    "id": "9494127a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T12:52:53.144513Z",
-     "iopub.status.busy": "2026-05-12T12:52:53.144212Z",
-     "iopub.status.idle": "2026-05-12T12:52:59.788293Z",
-     "shell.execute_reply": "2026-05-12T12:52:59.785035Z"
+     "iopub.execute_input": "2026-05-16T16:00:29.874044Z",
+     "iopub.status.busy": "2026-05-16T16:00:29.873503Z",
+     "iopub.status.idle": "2026-05-16T16:00:34.637679Z",
+     "shell.execute_reply": "2026-05-16T16:00:34.634046Z"
     }
    },
    "outputs": [
@@ -143,77 +172,78 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 14:52:53     -121.713946       25.953139\n"
+      "BFGS:    0 18:00:30     -122.019606       25.579957\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    1 14:52:54     -138.154261        1.822774\n"
+      "BFGS:    1 18:00:28     -138.235616        1.824672\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    2 14:52:55     -138.469296        1.581394\n"
+      "BFGS:    2 18:00:29     -138.552215        1.615560\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    3 14:52:55     -139.372537        0.891014\n"
+      "BFGS:    3 18:00:30     -139.329550        1.077139\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    4 14:52:56     -139.478102        0.579342\n"
+      "BFGS:    4 18:00:30     -139.516265        0.647736\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    5 14:52:57     -139.532687        0.344194\n"
+      "BFGS:    5 18:00:31     -139.579311        0.347231\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    6 14:52:57     -139.567862        0.297878\n"
+      "BFGS:    6 18:00:32     -139.611712        0.310276\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    7 14:52:58     -139.613565        0.130983\n"
+      "BFGS:    7 18:00:32     -139.659747        0.183129\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    8 14:52:59     -139.620127        0.126992\n"
+      "BFGS:    8 18:00:33     -139.674249        0.126273\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    9 14:52:59     -139.625756        0.092040\n"
+      "BFGS:    9 18:00:33     -139.679990        0.114328\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "GB energy        : 1.376 J/m^2\n",
+      "BFGS:   10 18:00:34     -139.683391        0.076056\n",
+      "GB energy        : 1.357 J/m^2\n",
       "GB excess volume : -0.000 A^3/A^2\n"
      ]
     },
@@ -232,9 +262,14 @@
    ],
    "source": [
     "# Relax the bicrystal (positions only) and compute GB energy.\n",
-    "calc_gb = calculate(structure=gb_structure, engine=engine_min.with_working_directory(\"gb\"))\n",
-    "calc_gb.run()\n",
-    "gb_out = calc_gb.outputs.engine_output.value\n",
+    "wf_gb = Workflow(\"pure_gb_relax\")\n",
+    "wf_gb.calc_gb = calculate(\n",
+    "    structure=gb_structure,\n",
+    "    engine=engine_min.with_working_directory(\"gb\"),\n",
+    "    label=\"calc_gb\",\n",
+    ")\n",
+    "wf_gb.run()\n",
+    "gb_out = wf_gb.calc_gb.outputs.engine_output.value\n",
     "\n",
     "gb_energy = get_GB_energy.node_function(\n",
     "    atoms=gb_out.final_structure,\n",


### PR DESCRIPTION
## Summary
- Replace the standalone per-atom bulk reference cell with a `Workflow("pure_gb_setup")` whose single `optimise_cubic_lattice_parameter` node returns `equil_energy_per_atom`, `equil_volume_per_atom`, and `a0` directly — no separate `calc_bulk` needed.
- The optimised `a0` is used as `lc` for the `BodyCenteredCubic` bicrystal slab construction (replacing `lc = 2.85`). The bicrystal relax is wrapped in `Workflow("pure_gb_relax")` for parity. The `get_GB_energy.node_function(...)` / `get_GB_exc_volume.node_function(...)` post-processing and orange disclaimer are preserved.
- Optimised `a0 = 2.8554 Å` (`B = 176.9 GPa`, `e0/atom = -4.0130 eV`, `v0/atom = 11.640 Å³`); GB energy `γ_GB = 1.357 J/m²` (DFT-ref ~1.6 J/m²; disclaimer preserved).

## Test plan
- [x] `jupyter nbconvert --to notebook --execute --inplace notebooks/pure_grain_boundary_study.ipynb`
- [ ] Spot-check optimised `a0` / `B` / `e0`
- [ ] Spot-check `γ_GB`

🤖 Generated with [Claude Code](https://claude.com/claude-code)