### PR TITLE
docs(notebooks): wire optimise_cubic_lattice_parameter per backend in foundation_model_example

### DIFF
--- a/notebooks/foundation_model_example.ipynb
+++ b/notebooks/foundation_model_example.ipynb
@@ -9,10 +9,17 @@
     "\n",
     "Demonstrates that the `Engine` Protocol composes with **any** ASE calculator, including the recent universal/foundation interatomic potentials:\n",
     "\n",
-    "- [**MACE-MP**](https://github.com/ACEsuit/mace) — `mace.calculators.mace_mp(...)`\n",
-    "- [**GRACE-FS**](https://gracemaker.readthedocs.io) — `tensorpotential.calculator.grace_fm(...)`\n",
+    "- [**MACE-MP**](https://github.com/ACEsuit/mace) - `mace.calculators.mace_mp(...)`\n",
+    "- [**GRACE-FS**](https://gracemaker.readthedocs.io) - `tensorpotential.calculator.grace_fm(...)`\n",
     "\n",
-    "Both ship ASE-compatible calculator wrappers, so the *only* line that changes between EMT, MACE, and GRACE is the `calculator=` argument to `ASEEngine`. The physics task description (vacancy formation energy on a small FCC Al supercell, below) is identical across all three backends.\n",
+    "Both ship ASE-compatible calculator wrappers, so the *only* line that changes between EMT, MACE, and GRACE is the `calculator=` argument to `ASEEngine`. The physics task description (FCC Al vacancy formation energy on a small supercell, below) is identical across all three backends.\n",
+    "\n",
+    "For each backend we build a parent `pyiron_workflow.Workflow` that:\n",
+    "\n",
+    "1. **Optimises the cubic lattice parameter** with `optimise_cubic_lattice_parameter` (cheap 5-point EOS scan).\n",
+    "2. **Feeds the equilibrium structure** straight into `get_vacancy_formation_energy`.\n",
+    "\n",
+    "This way each foundation model picks its *own* a0 for Al, instead of inheriting a hardcoded value - the cross-FM comparison is then apples-to-apples.\n",
     "\n",
     "If MACE / GRACE aren't installed, the corresponding cells skip with an `Install with: ...` hint so the notebook still runs end-to-end."
    ]
@@ -23,10 +30,10 @@
    "id": "f32f42fd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T15:59:16.367580Z",
-     "iopub.status.busy": "2026-05-12T15:59:16.367053Z",
-     "iopub.status.idle": "2026-05-12T15:59:18.447083Z",
-     "shell.execute_reply": "2026-05-12T15:59:18.443659Z"
+     "iopub.execute_input": "2026-05-16T15:59:22.351837Z",
+     "iopub.status.busy": "2026-05-16T15:59:22.351413Z",
+     "iopub.status.idle": "2026-05-16T15:59:26.510553Z",
+     "shell.execute_reply": "2026-05-16T15:59:26.507693Z"
     }
    },
    "outputs": [
@@ -34,7 +41,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Al bulk: Al4, n=4\n"
+      "Al bulk seed: Al4, n=4, a_seed=4.05 A\n"
      ]
     }
    ],
@@ -51,11 +58,15 @@
     "from ase.build import bulk\n",
     "from ase.calculators.emt import EMT\n",
     "\n",
+    "from pyiron_workflow import Workflow\n",
     "from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputMinimize\n",
+    "from pyiron_workflow_atomistics.physics.bulk import optimise_cubic_lattice_parameter\n",
     "from pyiron_workflow_atomistics.physics.point_defect import get_vacancy_formation_energy\n",
     "\n",
+    "# Seed structure for the lat-opt EOS scan. The lattice parameter here is only a\n",
+    "# starting point - each calculator re-optimises a0 in the parent workflow below.\n",
     "al_bulk = bulk(\"Al\", \"fcc\", a=4.05, cubic=True)\n",
-    "print(f\"Al bulk: {al_bulk.get_chemical_formula()}, n={len(al_bulk)}\")"
+    "print(f\"Al bulk seed: {al_bulk.get_chemical_formula()}, n={len(al_bulk)}, a_seed=4.05 A\")"
    ]
   },
   {
@@ -63,9 +74,11 @@
    "id": "ea03d5b7",
    "metadata": {},
    "source": [
-    "## Helper: build an ASEEngine + vacancy-formation workflow from any calculator\n",
+    "## Helper: parent `Workflow` = lat-opt -> vacancy-formation per calculator\n",
     "\n",
-    "The same `get_vacancy_formation_energy` macro is reused with each backend; only the `calculator=` field of the engine changes."
+    "The helper below wires both macros into a single parent `Workflow`. Sub-folders for each macro's\n",
+    "runs are kept tidy via `engine.with_working_directory(...)`. The same parent shape runs for every\n",
+    "backend; the only line that changes is the `calculator=` argument to `ASEEngine`."
    ]
   },
   {
@@ -74,10 +87,10 @@
    "id": "b9f8cd2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T15:59:18.452432Z",
-     "iopub.status.busy": "2026-05-12T15:59:18.452072Z",
-     "iopub.status.idle": "2026-05-12T15:59:18.461727Z",
-     "shell.execute_reply": "2026-05-12T15:59:18.458835Z"
+     "iopub.execute_input": "2026-05-16T15:59:26.514562Z",
+     "iopub.status.busy": "2026-05-16T15:59:26.514299Z",
+     "iopub.status.idle": "2026-05-16T15:59:26.526321Z",
+     "shell.execute_reply": "2026-05-16T15:59:26.522873Z"
     }
    },
    "outputs": [],
@@ -88,15 +101,25 @@
     "        calculator=calculator,\n",
     "        working_directory=workdir,\n",
     "    )\n",
-    "    wf = get_vacancy_formation_energy(\n",
+    "    wf = Workflow(f\"fm_{label.lower().replace('-', '_')}\")\n",
+    "    wf.lat_opt = optimise_cubic_lattice_parameter(\n",
     "        structure=al_bulk,\n",
-    "        engine=engine,\n",
-    "        min_dimensions=[8, 8, 8],  # ~3x3x3 FCC Al primitive ~ 108 atoms\n",
+    "        name=\"Al\",\n",
+    "        crystalstructure=\"fcc\",\n",
+    "        engine=engine.with_working_directory(\"lat_opt\"),\n",
+    "        strain_range=(-0.02, 0.02),\n",
+    "        num_points=5,\n",
+    "    )\n",
+    "    wf.vac = get_vacancy_formation_energy(\n",
+    "        structure=wf.lat_opt.outputs.equil_struct,\n",
+    "        engine=engine.with_working_directory(\"vac\"),\n",
+    "        min_dimensions=[8, 8, 8],\n",
     "    )\n",
     "    wf.run()\n",
-    "    e_f = wf.outputs.vacancy_formation_energy.value\n",
-    "    print(f\"{label:8s}  E_vac_form(Al FCC) = {e_f:.3f} eV\")\n",
-    "    return e_f"
+    "    a0 = wf.lat_opt.outputs.a0.value\n",
+    "    e_f = wf.vac.outputs.vacancy_formation_energy.value\n",
+    "    print(f\"{label:8s}  a0(Al FCC) = {a0:.4f} A   E_vac_form = {e_f:.3f} eV\")\n",
+    "    return a0, e_f"
    ]
   },
   {
@@ -115,10 +138,10 @@
    "id": "5f4aaf87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T15:59:18.467133Z",
-     "iopub.status.busy": "2026-05-12T15:59:18.466805Z",
-     "iopub.status.idle": "2026-05-12T15:59:18.812643Z",
-     "shell.execute_reply": "2026-05-12T15:59:18.809564Z"
+     "iopub.execute_input": "2026-05-16T15:59:26.530566Z",
+     "iopub.status.busy": "2026-05-16T15:59:26.530290Z",
+     "iopub.status.idle": "2026-05-16T15:59:27.099615Z",
+     "shell.execute_reply": "2026-05-16T15:59:27.098061Z"
     }
    },
    "outputs": [
@@ -127,7 +150,7 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:59:18       -0.048066        0.000000\n"
+      "BFGS:    0 17:59:26       -0.016663        0.000000\n"
      ]
     },
     {
@@ -135,33 +158,31 @@
      "output_type": "stream",
      "text": [
       "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:59:18        0.926900        0.067070\n"
+      "BFGS:    0 17:59:26       -0.018504        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:59:26       -0.006008        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:59:26        0.020062        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:59:26        0.058934        0.000000\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:59:26        0.453946        0.103855\n",
+      "BFGS:    1 17:59:26        0.451677        0.098047\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "BFGS:    1 17:59:18        0.926106        0.063977\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    2 17:59:18        0.918670        0.019346\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "EMT       E_vac_form(Al FCC) = 0.965 eV\n"
+      "BFGS:    2 17:59:26        0.433813        0.024509\n",
+      "      Step     Time          Energy          fmax\n",
+      "BFGS:    0 17:59:27       -0.527330        0.000000\n",
+      "EMT       a0(Al FCC) = 3.9942 A   E_vac_form = 0.956 eV\n"
      ]
     }
    ],
    "source": [
-    "e_emt = vacancy_e_form(EMT(), label=\"EMT\", workdir=\"./_fm_emt\")"
+    "a0_emt, e_emt = vacancy_e_form(EMT(), label=\"EMT\", workdir=\"./_fm_emt\")"
    ]
   },
   {
@@ -182,10 +203,10 @@
    "id": "fe950daf",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T15:59:18.825597Z",
-     "iopub.status.busy": "2026-05-12T15:59:18.824949Z",
-     "iopub.status.idle": "2026-05-12T15:59:28.141770Z",
-     "shell.execute_reply": "2026-05-12T15:59:28.138808Z"
+     "iopub.execute_input": "2026-05-16T15:59:27.104705Z",
+     "iopub.status.busy": "2026-05-16T15:59:27.104292Z",
+     "iopub.status.idle": "2026-05-16T15:59:27.117074Z",
+     "shell.execute_reply": "2026-05-16T15:59:27.116040Z"
     }
    },
    "outputs": [
@@ -193,52 +214,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "cuequivariance or cuequivariance_torch is not available. Cuequivariance acceleration will be disabled.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using Materials Project MACE for MACECalculator with /home/liger/.cache/mace/20231210mace128L0_energy_epoch249model\n",
-      "Using float64 for MACECalculator, which is slower but more accurate. Recommended for geometry optimization.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:59:26     -118.706220        0.000000\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:59:27     -114.379872        0.134386\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    1 17:59:27     -114.382950        0.126796\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    2 17:59:28     -114.407101        0.029141\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "MACE-MP   E_vac_form(Al FCC) = 0.590 eV\n"
+      "MACE not installed - skipping.\n",
+      "Install with: pip install mace-torch  (or `uv pip install mace-torch`)\n"
      ]
     }
    ],
@@ -246,9 +223,9 @@
     "try:\n",
     "    from mace.calculators import mace_mp\n",
     "    mace_calc = mace_mp(model=\"small\", default_dtype=\"float64\", device=\"cpu\")\n",
-    "    e_mace = vacancy_e_form(mace_calc, label=\"MACE-MP\", workdir=\"./_fm_mace\")\n",
+    "    a0_mace, e_mace = vacancy_e_form(mace_calc, label=\"MACE-MP\", workdir=\"./_fm_mace\")\n",
     "except ImportError:\n",
-    "    e_mace = None\n",
+    "    a0_mace, e_mace = None, None\n",
     "    print(\"MACE not installed - skipping.\\nInstall with: pip install mace-torch  (or `uv pip install mace-torch`)\")"
    ]
   },
@@ -270,10 +247,10 @@
    "id": "e4fe790d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T15:59:28.146993Z",
-     "iopub.status.busy": "2026-05-12T15:59:28.146584Z",
-     "iopub.status.idle": "2026-05-12T15:59:40.168991Z",
-     "shell.execute_reply": "2026-05-12T15:59:40.165486Z"
+     "iopub.execute_input": "2026-05-16T15:59:27.121214Z",
+     "iopub.status.busy": "2026-05-16T15:59:27.121063Z",
+     "iopub.status.idle": "2026-05-16T15:59:27.131396Z",
+     "shell.execute_reply": "2026-05-16T15:59:27.129687Z"
     }
    },
    "outputs": [
@@ -281,81 +258,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[tensorpotential] Info: Environment variable TF_USE_LEGACY_KERAS is automatically set to '1'.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
-      "E0000 00:00:1778601568.738634  148815 cuda_dnn.cc:8579] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered\n",
-      "E0000 00:00:1778601568.746124  148815 cuda_blas.cc:1407] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered\n",
-      "W0000 00:00:1778601568.762432  148815 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
-      "W0000 00:00:1778601568.762472  148815 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
-      "W0000 00:00:1778601568.762475  148815 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n",
-      "W0000 00:00:1778601568.762477  148815 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using cached GRACE model from /home/liger/.cache/grace/GRACE-FS-OAM\n",
-      "Model license: Academic Software License\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
-      "I0000 00:00:1778601574.527422  148815 service.cc:152] XLA service 0x58f69f3f6240 initialized for platform Host (this does not guarantee that XLA will be used). Devices:\n",
-      "I0000 00:00:1778601574.527612  148815 service.cc:160]   StreamExecutor device (0): Host, Default Version\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:59:39     -119.204487        0.000000\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:59:39     -115.172399        0.128413\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "I0000 00:00:1778601579.642611  148815 device_compiler.h:188] Compiled cluster using XLA!  This line is logged at most once for the lifetime of the process.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    1 17:59:39     -115.175619        0.122301\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "BFGS:    2 17:59:40     -115.204123        0.023990\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "GRACE-FS  E_vac_form(Al FCC) = 0.275 eV\n"
+      "GRACE / tensorpotential not installed - skipping.\n",
+      "Install with: pip install tensorpotential  (or `uv pip install tensorpotential`)\n"
      ]
     }
    ],
@@ -363,9 +267,9 @@
     "try:\n",
     "    from tensorpotential.calculator import grace_fm\n",
     "    grace_calc = grace_fm(\"GRACE-FS-OAM\")\n",
-    "    e_grace = vacancy_e_form(grace_calc, label=\"GRACE-FS\", workdir=\"./_fm_grace\")\n",
+    "    a0_grace, e_grace = vacancy_e_form(grace_calc, label=\"GRACE-FS\", workdir=\"./_fm_grace\")\n",
     "except ImportError:\n",
-    "    e_grace = None\n",
+    "    a0_grace, e_grace = None, None\n",
     "    print(\"GRACE / tensorpotential not installed - skipping.\\nInstall with: pip install tensorpotential  (or `uv pip install tensorpotential`)\")"
    ]
   },
@@ -376,9 +280,9 @@
    "source": [
     "## Summary\n",
     "\n",
-    "Same `get_vacancy_formation_energy` macro, same `al_bulk` structure, three calculators. Foundation MLIPs (MACE, GRACE) target DFT-PBE quality (~0.6 eV for Al vacancy in PBE); EMT systematically under-predicts.\n",
+    "Same parent `Workflow` shape (lat-opt -> vacancy-formation), same seed structure, three calculators. Each foundation MLIP picks its own equilibrium a0 for FCC Al before the supercell is built, so the formation energy reflects that backend's own lattice. Foundation MLIPs (MACE, GRACE) target DFT-PBE quality (~0.6 eV for Al vacancy in PBE); EMT systematically under-predicts.\n",
     "\n",
-    "To plug in your own potential — Quip GAP, NequIP, Allegro, an ASE-wrapped DFT code, anything — just hand its ASE calculator to `ASEEngine(calculator=...)` and reuse the rest."
+    "To plug in your own potential - Quip GAP, NequIP, Allegro, an ASE-wrapped DFT code, anything - just hand its ASE calculator to `ASEEngine(calculator=...)` and reuse the rest."
    ]
   },
   {
@@ -387,10 +291,10 @@
    "id": "275eea6f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-12T15:59:40.173577Z",
-     "iopub.status.busy": "2026-05-12T15:59:40.173167Z",
-     "iopub.status.idle": "2026-05-12T15:59:40.187505Z",
-     "shell.execute_reply": "2026-05-12T15:59:40.183993Z"
+     "iopub.execute_input": "2026-05-16T15:59:27.136463Z",
+     "iopub.status.busy": "2026-05-16T15:59:27.134918Z",
+     "iopub.status.idle": "2026-05-16T15:59:27.146971Z",
+     "shell.execute_reply": "2026-05-16T15:59:27.144755Z"
     }
    },
    "outputs": [
@@ -398,19 +302,25 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "backend      E_vac (eV)\n",
-      "-----------------------\n",
-      "EMT        0.9652331842740964\n",
-      "MACE-MP    0.5895501101056055\n",
-      "GRACE-FS   0.2752234431551557\n"
+      "backend        a0 (A)   E_vac (eV)\n",
+      "----------------------------------\n",
+      "EMT            3.9942       0.9563\n",
+      "MACE-MP       skipped      skipped\n",
+      "GRACE-FS      skipped      skipped\n"
      ]
     }
    ],
    "source": [
-    "print(f\"{'backend':10s} {'E_vac (eV)':>12s}\")\n",
-    "print(\"-\" * 23)\n",
-    "for label, val in [(\"EMT\", e_emt), (\"MACE-MP\", e_mace), (\"GRACE-FS\", e_grace)]:\n",
-    "    print(f\"{label:10s} {val if val is not None else 'skipped':>12}\")"
+    "print(f\"{'backend':10s} {'a0 (A)':>10s} {'E_vac (eV)':>12s}\")\n",
+    "print(\"-\" * 34)\n",
+    "for label, a0, ev in [\n",
+    "    (\"EMT\", a0_emt, e_emt),\n",
+    "    (\"MACE-MP\", a0_mace, e_mace),\n",
+    "    (\"GRACE-FS\", a0_grace, e_grace),\n",
+    "]:\n",
+    "    a0_s = f\"{a0:.4f}\" if a0 is not None else \"skipped\"\n",
+    "    ev_s = f\"{ev:.4f}\" if ev is not None else \"skipped\"\n",
+    "    print(f\"{label:10s} {a0_s:>10s} {ev_s:>12s}\")"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- The `vacancy_e_form(calculator, label, workdir)` helper now builds a per-backend `Workflow` that chains `optimise_cubic_lattice_parameter` → `get_vacancy_formation_energy`, with `engine.with_working_directory("lat_opt")` / `("vac")` subdirs. Each backend gets its own apples-to-apples lattice optimisation — hardcoded `a=4.05 Å` is now only the EOS scan seed.
- Helper returns `(a0, e_f)`; call sites and the final summary cell print both columns.

| backend  | optimised a0 (Å) | E_vac_form (eV) |
|----------|------------------|-----------------|
| EMT      | 3.9942           | 0.9563          |
| MACE-MP  | skipped — `mace` not installed in this env |
| GRACE-FS | skipped — `tensorpotential` not installed in this env |

EMT's optimised a0 ≈ 3.99 Å matches the well-known EMT-Al minimum and is meaningfully off the 4.05 Å seed — exactly the motivation for wiring lat-opt per backend. MACE / GRACE branches are gated with `try/except ImportError` (unchanged behaviour) and will pick up their own optimised lattice once those packages are available.

## Test plan
- [x] `jupyter nbconvert --to notebook --execute --inplace notebooks/foundation_model_example.ipynb` (EMT branch only — MACE/GRACE skipped via documented `ImportError` fallback)
- [ ] Spot-check EMT `a0` / `E_vac_form`
- [ ] (Optional) Re-run in an env with MACE-MP and/or GRACE-FS to populate the remaining rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)