### PR TITLE
docs(notebooks): wire optimise_cubic_lattice_parameter into dynaphopy_grace_example_long

### DIFF
--- a/notebooks/dynaphopy_grace_example_long.ipynb
+++ b/notebooks/dynaphopy_grace_example_long.ipynb
@@ -70,16 +70,11 @@
    "cell_type": "markdown",
    "id": "601be70e",
    "metadata": {},
-   "source": [
-    "## 1. Structure + GRACE foundation model\n",
-    "\n",
-    "Si primitive (diamond, 2-atom basis, a=5.43 Å) → 2×2×2 supercell for MD (16 atoms).\n",
-    "Same supercell is used by both halves for apples-to-apples comparison."
-   ]
+   "source": "## 1. Structure + GRACE foundation model\n\nSi primitive (diamond, 2-atom basis) → 2×2×2 supercell for MD (16 atoms).\nWe seed the EOS scan with the textbook value `a = 5.43 Å`, but the\nGRACE-optimised `a0` (refit in Section A by `optimise_cubic_lattice_parameter`)\nis what both halves of the notebook actually use — the textbook value is\nonly the initial guess and a sanity-check anchor."
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "db5632c3",
    "metadata": {
     "execution": {
@@ -89,27 +84,12 @@
      "shell.execute_reply": "2026-05-15T16:51:34.629296Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Si primitive: 2 atoms, cell=[3.83958982 3.83958982 3.83958982]\n",
-      "2x2x2 supercell: 16 atoms\n"
-     ]
-    }
-   ],
-   "source": [
-    "si_prim = bulk(\"Si\", \"diamond\", a=5.43)\n",
-    "fc2_multiplier = 2 * np.eye(3, dtype=int)\n",
-    "si_supercell = make_supercell(si_prim, fc2_multiplier)\n",
-    "print(f\"Si primitive: {len(si_prim)} atoms, cell={si_prim.cell.lengths()}\")\n",
-    "print(f\"2x2x2 supercell: {len(si_supercell)} atoms\")"
-   ]
+   "outputs": [],
+   "source": "# Initial-guess primitive at the textbook Si lattice constant (5.43 Å). The\n# GRACE-1L-OAM equilibrium will be re-derived in Section A by an EOS scan +\n# Birch–Murnaghan fit (`optimise_cubic_lattice_parameter`), and `si_supercell`\n# is rebuilt below from that optimised primitive so Section A's MD and\n# Section B's LAMMPS run share the same GRACE-equilibrated geometry. The\n# `a=5.43` value here is only the starting point for the EOS scan and the\n# smoke-test single-point evaluation in the next cell.\nsi_prim_initial = bulk(\"Si\", \"diamond\", a=5.43)\nfc2_multiplier = 2 * np.eye(3, dtype=int)\nprint(f\"Si primitive (initial guess @ a=5.43 Å): {len(si_prim_initial)} atoms, \"\n      f\"cell={si_prim_initial.cell.lengths()}\")\nprint(f\"FC2 multiplier diagonal: {fc2_multiplier.diagonal().tolist()} \"\n      f\"→ {len(si_prim_initial) * int(round(np.linalg.det(fc2_multiplier)))}-atom supercell\")"
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "6d40f81b",
    "metadata": {
     "execution": {
@@ -119,78 +99,18 @@
      "shell.execute_reply": "2026-05-15T16:51:57.391154Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[tensorpotential] Info: Environment variable TF_USE_LEGACY_KERAS is automatically set to '1'.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using cached GRACE model from /home/liger/.cache/grace/GRACE-1L-OAM\n",
-      "Model license: Academic Software License\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: All log messages before absl::InitializeLog() is called are written to STDERR\n",
-      "W0000 00:00:1778863906.129419  317976 gpu_device.cc:2431] TensorFlow was not built with CUDA kernel binaries compatible with compute capability 12.0. CUDA kernels will be jit-compiled from PTX, which could take 30 minutes or longer.\n",
-      "W0000 00:00:1778863906.140005  317976 gpu_device.cc:2431] TensorFlow was not built with CUDA kernel binaries compatible with compute capability 12.0. CUDA kernels will be jit-compiled from PTX, which could take 30 minutes or longer.\n",
-      "I0000 00:00:1778863907.606090  317976 gpu_device.cc:2020] Created device /job:localhost/replica:0/task:0/device:GPU:0 with 9226 MB memory:  -> device: 0, name: NVIDIA GeForce RTX 5070 Ti Laptop GPU, pci bus id: 0000:63:00.0, compute capability: 12.0\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "I0000 00:00:1778863917.133422  317976 device_compiler.h:196] Compiled cluster using XLA!  This line is logged at most once for the lifetime of the process.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "GRACE-1L-OAM on Si primitive: E = -10.8372 eV  (-5.4186 eV/atom)\n"
-     ]
-    }
-   ],
-   "source": [
-    "from tensorpotential.calculator.foundation_models import grace_fm\n",
-    "\n",
-    "grace_calc = grace_fm(\"GRACE-1L-OAM\")\n",
-    "si_prim_check = si_prim.copy()\n",
-    "si_prim_check.calc = grace_calc\n",
-    "e0 = si_prim_check.get_potential_energy()\n",
-    "print(f\"GRACE-1L-OAM on Si primitive: E = {e0:.4f} eV  ({e0/len(si_prim_check):.4f} eV/atom)\")"
-   ]
+   "outputs": [],
+   "source": "from tensorpotential.calculator.foundation_models import grace_fm\n\ngrace_calc = grace_fm(\"GRACE-1L-OAM\")\nsi_prim_check = si_prim_initial.copy()\nsi_prim_check.calc = grace_calc\ne0 = si_prim_check.get_potential_energy()\nprint(f\"GRACE-1L-OAM on Si primitive (a=5.43 Å): \"\n      f\"E = {e0:.4f} eV  ({e0/len(si_prim_check):.4f} eV/atom)\")"
   },
   {
    "cell_type": "markdown",
    "id": "f11cdf7a",
    "metadata": {},
-   "source": [
-    "## 2. Section A — ASE-driven workflow through `calculate_phonon_md_renormalisation`\n",
-    "\n",
-    "The macro is the single user-facing entry point. It internally:\n",
-    "1. resolves arguments (`_resolve_md_defaults`),\n",
-    "2. fits FC2 from displacement-force evals through `engine.calculate` (`_compute_fc2_from_scratch`),\n",
-    "3. runs ASE Langevin NVT MD borrowing the engine's calculator (`_run_nvt_trajectory`),\n",
-    "4. builds `dynaphopy.Quasiparticle` and fits Lorentzians (`_project_with_dynaphopy`).\n",
-    "\n",
-    "Returns a typed `MdPhononOutput` dataclass with harmonic and renormalised\n",
-    "frequencies, per-band power spectra, linewidths, MD diagnostics, and\n",
-    "optional handles to the underlying dynaphopy / phonopy objects."
-   ]
+   "source": "## 2. Section A — ASE-driven workflow through `calculate_phonon_md_renormalisation`\n\nThis section is wired as a single `pyiron_workflow.Workflow` so that\nupstream-vs-downstream dependencies are explicit. The graph has two nodes:\n\n1. **`wf.lat_opt = optimise_cubic_lattice_parameter(...)`** — a cubic EOS\n   scan (`strain_range=(-0.02, 0.02)`, `num_points=5`) followed by a\n   Birch–Murnaghan fit. This re-derives the GRACE-1L-OAM equilibrium\n   lattice parameter `a0`, which can drift from the textbook value\n   (`a=5.43 Å`) by a fraction of a percent. We feed that optimised\n   geometry into both the ASE phonon-MD path (here) and the LAMMPS\n   path (Section B) — apples-to-apples.\n2. **`wf.phonon = calculate_phonon_md_renormalisation(...)`** — the\n   user-facing macro. It internally:\n   1. resolves arguments (`_resolve_md_defaults`),\n   2. fits FC2 from displacement-force evals through `engine.calculate`\n      (`_compute_fc2_from_scratch`),\n   3. runs ASE Langevin NVT MD borrowing the engine's calculator\n      (`_run_nvt_trajectory`),\n   4. builds `dynaphopy.Quasiparticle` and fits Lorentzians\n      (`_project_with_dynaphopy`).\n\n   Returns a typed `MdPhononOutput` dataclass with harmonic and\n   renormalised frequencies, per-band power spectra, linewidths, MD\n   diagnostics, and optional handles to the underlying dynaphopy /\n   phonopy objects.\n\nWe use two engines:\n- `engine_min` (`CalcInputMinimize`, `force_convergence_tolerance=0.05`) — drives\n  the per-strain relaxations inside the EOS scan.\n- `ase_engine` (`CalcInputStatic`) — drives FC2 displacements and supplies\n  the calculator the macro borrows for Langevin NVT MD.\n\nBoth engines wrap the same `grace_calc`; `engine.with_working_directory(...)`\nkeeps the on-disk artefacts separated."
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "40be6b3f",
    "metadata": {
     "execution": {
@@ -200,496 +120,8 @@
      "shell.execute_reply": "2026-05-15T17:12:42.780744Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "No velocity provided! calculating it from coordinates...\n",
-      "MD cell size relation: [2 2 2]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Using 50000 steps\n",
-      "Calculating phonon projection power spectra\n",
-      "Projecting into phonon mode\n",
-      "Projecting into wave vector\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Harmonic frequencies (THz):\n",
-      "[2.52669885e-07 3.29447212e-07 4.08406407e-07 2.41045897e+01\n",
-      " 2.41045897e+01 2.41045897e+01]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Peak # 1\n",
-      "----------------------------------------------\n",
-      "Width                             1.960977 THz\n",
-      "Position                         12.336521 THz\n",
-      "Area (<K>)    (Lorentzian)        1.011224 eV\n",
-      "Area (<K>)    (Total)            13.482631 eV\n",
-      "<|dQ/dt|^2>                       2.022449 eV\n",
-      "Base line                         0.312558 eV * ps\n",
-      "Maximum height                    0.328288 eV * ps\n",
-      "Fitting global error              0.120241\n",
-      "Frequency shift                  12.336521 THz\n",
-      "\n",
-      "Peak # 2\n",
-      "----------------------------------------------\n",
-      "Width                             1.960977 THz\n",
-      "Position                         12.336521 THz\n",
-      "Area (<K>)    (Lorentzian)        1.011224 eV\n",
-      "Area (<K>)    (Total)            13.482631 eV\n",
-      "<|dQ/dt|^2>                       2.022449 eV\n",
-      "Base line                         0.312558 eV * ps\n",
-      "Maximum height                    0.328288 eV * ps\n",
-      "Fitting global error              0.120241\n",
-      "Frequency shift                  12.336521 THz\n",
-      "\n",
-      "Peak # 3\n",
-      "----------------------------------------------\n",
-      "Width                             1.960977 THz\n",
-      "Position                         12.336521 THz\n",
-      "Area (<K>)    (Lorentzian)        1.011224 eV\n",
-      "Area (<K>)    (Total)            13.482631 eV\n",
-      "<|dQ/dt|^2>                       2.022449 eV\n",
-      "Base line                         0.312558 eV * ps\n",
-      "Maximum height                    0.328288 eV * ps\n",
-      "Fitting global error              0.120241\n",
-      "Frequency shift                  12.336521 THz\n",
-      "\n",
-      "Peak # 4\n",
-      "----------------------------------------------\n",
-      "Width                             2.066022 THz\n",
-      "Position                         13.538997 THz\n",
-      "Area (<K>)    (Lorentzian)        1.840801 eV\n",
-      "Area (<K>)    (Total)            13.863428 eV\n",
-      "<|dQ/dt|^2>                       3.681602 eV\n",
-      "Base line                         0.302106 eV * ps\n",
-      "Maximum height                    0.567221 eV * ps\n",
-      "Fitting global error              0.048189\n",
-      "Frequency shift                 -10.565593 THz\n",
-      "\n",
-      "Peak # 5\n",
-      "----------------------------------------------\n",
-      "Width                             2.066022 THz\n",
-      "Position                         13.538997 THz\n",
-      "Area (<K>)    (Lorentzian)        1.840801 eV\n",
-      "Area (<K>)    (Total)            13.863428 eV\n",
-      "<|dQ/dt|^2>                       3.681602 eV\n",
-      "Base line                         0.302106 eV * ps\n",
-      "Maximum height                    0.567221 eV * ps\n",
-      "Fitting global error              0.048189\n",
-      "Frequency shift                 -10.565593 THz\n",
-      "\n",
-      "Peak # 6\n",
-      "----------------------------------------------\n",
-      "Width                             2.066022 THz\n",
-      "Position                         13.538997 THz\n",
-      "Area (<K>)    (Lorentzian)        1.840801 eV\n",
-      "Area (<K>)    (Total)            13.863428 eV\n",
-      "<|dQ/dt|^2>                       3.681602 eV\n",
-      "Base line                         0.302106 eV * ps\n",
-      "Maximum height                    0.567221 eV * ps\n",
-      "Fitting global error              0.048189\n",
-      "Frequency shift                 -10.565593 THz\n",
-      "Calculating phonon projection power spectra\n",
-      "Projecting into phonon mode\n",
-      "Projecting into wave vector\n",
-      "Harmonic frequencies (THz):\n",
-      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Projecting into phonon mode\n",
-      "Projecting into wave vector\n",
-      "Harmonic frequencies (THz):\n",
-      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Projecting into phonon mode\n",
-      "Projecting into wave vector\n",
-      "Harmonic frequencies (THz):\n",
-      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Projecting into phonon mode\n",
-      "Projecting into wave vector\n",
-      "Harmonic frequencies (THz):\n",
-      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Peak # 1\n",
-      "----------------------------------------------\n",
-      "Width                             2.314049 THz\n",
-      "Position                         13.095756 THz\n",
-      "Area (<K>)    (Lorentzian)        1.183044 eV\n",
-      "Area (<K>)    (Total)            13.428333 eV\n",
-      "<|dQ/dt|^2>                       2.366088 eV\n",
-      "Base line                         0.307202 eV * ps\n",
-      "Maximum height                    0.325468 eV * ps\n",
-      "Fitting global error              0.099967\n",
-      "Frequency shift                   6.391205 THz\n",
-      "\n",
-      "Peak # 2\n",
-      "----------------------------------------------\n",
-      "Width                             2.314049 THz\n",
-      "Position                         13.095756 THz\n",
-      "Area (<K>)    (Lorentzian)        1.183044 eV\n",
-      "Area (<K>)    (Total)            13.428333 eV\n",
-      "<|dQ/dt|^2>                       2.366088 eV\n",
-      "Base line                         0.307202 eV * ps\n",
-      "Maximum height                    0.325468 eV * ps\n",
-      "Fitting global error              0.099967\n",
-      "Frequency shift                   6.391205 THz\n",
-      "\n",
-      "Peak # 3\n",
-      "----------------------------------------------\n",
-      "Width                             3.149097 THz\n",
-      "Position                         13.206055 THz\n",
-      "Area (<K>)    (Lorentzian)        2.185645 eV\n",
-      "Area (<K>)    (Total)            13.704608 eV\n",
-      "<|dQ/dt|^2>                       4.371290 eV\n",
-      "Base line                         0.290934 eV * ps\n",
-      "Maximum height                    0.441849 eV * ps\n",
-      "Fitting global error              0.079543\n",
-      "Frequency shift                  -3.867679 THz\n",
-      "\n",
-      "Peak # 4\n",
-      "----------------------------------------------\n",
-      "Width                             2.207238 THz\n",
-      "Position                         11.082478 THz\n",
-      "Area (<K>)    (Lorentzian)        1.118892 eV\n",
-      "Area (<K>)    (Total)            13.398960 eV\n",
-      "<|dQ/dt|^2>                       2.237784 eV\n",
-      "Base line                         0.308063 eV * ps\n",
-      "Maximum height                    0.322715 eV * ps\n",
-      "Fitting global error              0.111510\n",
-      "Frequency shift                  -7.926440 THz\n",
-      "\n",
-      "Peak # 5\n",
-      "----------------------------------------------\n",
-      "Width                             2.594471 THz\n",
-      "Position                         13.203341 THz\n",
-      "Area (<K>)    (Lorentzian)        1.497081 eV\n",
-      "Area (<K>)    (Total)            13.548029 eV\n",
-      "<|dQ/dt|^2>                       2.994162 eV\n",
-      "Base line                         0.302882 eV * ps\n",
-      "Maximum height                    0.367347 eV * ps\n",
-      "Fitting global error              0.091173\n",
-      "Frequency shift                  -9.689549 THz\n",
-      "\n",
-      "Peak # 6\n",
-      "----------------------------------------------\n",
-      "Width                             2.594471 THz\n",
-      "Position                         13.203341 THz\n",
-      "Area (<K>)    (Lorentzian)        1.497081 eV\n",
-      "Area (<K>)    (Total)            13.548029 eV\n",
-      "<|dQ/dt|^2>                       2.994162 eV\n",
-      "Base line                         0.302882 eV * ps\n",
-      "Maximum height                    0.367347 eV * ps\n",
-      "Fitting global error              0.091173\n",
-      "Frequency shift                  -9.689549 THz\n",
-      "Calculating phonon projection power spectra\n",
-      "Projecting into phonon mode\n",
-      "Projecting into wave vector\n",
-      "Harmonic frequencies (THz):\n",
-      "[ 9.0391301   9.0391301  18.66589077 18.66589077 21.78408021 21.78408021]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Projecting into phonon mode\n",
-      "Projecting into wave vector\n",
-      "Harmonic frequencies (THz):\n",
-      "[ 9.0391301   9.0391301  18.66589077 18.66589077 21.78408021 21.78408021]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Projecting into phonon mode\n",
-      "Projecting into wave vector\n",
-      "Harmonic frequencies (THz):\n",
-      "[ 9.0391301   9.0391301  18.66589077 18.66589077 21.78408021 21.78408021]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Harmonic frequencies (THz):\n",
-      "[ 9.0391301   9.0391301  18.66589077 18.66589077 21.78408021 21.78408021]\n",
-      "\n",
-      "Peak # 1\n",
-      "----------------------------------------------\n",
-      "Width                             2.634452 THz\n",
-      "Position                         13.367815 THz\n",
-      "Area (<K>)    (Lorentzian)        1.594925 eV\n",
-      "Area (<K>)    (Total)            13.598847 eV\n",
-      "<|dQ/dt|^2>                       3.189850 eV\n",
-      "Base line                         0.301836 eV * ps\n",
-      "Maximum height                    0.385416 eV * ps\n",
-      "Fitting global error              0.082342\n",
-      "Frequency shift                   4.328685 THz\n",
-      "\n",
-      "Peak # 2\n",
-      "----------------------------------------------\n",
-      "Width                             2.634452 THz\n",
-      "Position                         13.367815 THz\n",
-      "Area (<K>)    (Lorentzian)        1.594925 eV\n",
-      "Area (<K>)    (Total)            13.598847 eV\n",
-      "<|dQ/dt|^2>                       3.189850 eV\n",
-      "Base line                         0.301836 eV * ps\n",
-      "Maximum height                    0.385416 eV * ps\n",
-      "Fitting global error              0.082342\n",
-      "Frequency shift                   4.328685 THz\n",
-      "\n",
-      "Peak # 3\n",
-      "----------------------------------------------\n",
-      "Width                             3.868821 THz\n",
-      "Position                         12.583148 THz\n",
-      "Area (<K>)    (Lorentzian)        1.759154 eV\n",
-      "Area (<K>)    (Total)            13.550873 eV\n",
-      "<|dQ/dt|^2>                       3.518308 eV\n",
-      "Base line                         0.297771 eV * ps\n",
-      "Maximum height                    0.289471 eV * ps\n",
-      "Fitting global error              0.138069\n",
-      "Frequency shift                  -6.082743 THz\n",
-      "\n",
-      "Peak # 4\n",
-      "----------------------------------------------\n",
-      "Width                             3.868821 THz\n",
-      "Position                         12.583148 THz\n",
-      "Area (<K>)    (Lorentzian)        1.759154 eV\n",
-      "Area (<K>)    (Total)            13.550873 eV\n",
-      "<|dQ/dt|^2>                       3.518308 eV\n",
-      "Base line                         0.297771 eV * ps\n",
-      "Maximum height                    0.289471 eV * ps\n",
-      "Fitting global error              0.138069\n",
-      "Frequency shift                  -6.082743 THz\n",
-      "\n",
-      "Peak # 5\n",
-      "----------------------------------------------\n",
-      "Width                             2.355574 THz\n",
-      "Position                         12.774174 THz\n",
-      "Area (<K>)    (Lorentzian)        1.084584 eV\n",
-      "Area (<K>)    (Total)            13.292361 eV\n",
-      "<|dQ/dt|^2>                       2.169167 eV\n",
-      "Base line                         0.306196 eV * ps\n",
-      "Maximum height                    0.293121 eV * ps\n",
-      "Fitting global error              0.116376\n",
-      "Frequency shift                  -9.009907 THz\n",
-      "\n",
-      "Peak # 6\n",
-      "----------------------------------------------\n",
-      "Width                             2.355574 THz\n",
-      "Position                         12.774174 THz\n",
-      "Area (<K>)    (Lorentzian)        1.084584 eV\n",
-      "Area (<K>)    (Total)            13.292361 eV\n",
-      "<|dQ/dt|^2>                       2.169167 eV\n",
-      "Base line                         0.306196 eV * ps\n",
-      "Maximum height                    0.293121 eV * ps\n",
-      "Fitting global error              0.116376\n",
-      "Frequency shift                  -9.009907 THz\n",
-      "Calculating phonon projection power spectra\n",
-      "Projecting into phonon mode\n",
-      "Projecting into wave vector\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Harmonic frequencies (THz):\n",
-      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Projecting into phonon mode\n",
-      "Projecting into wave vector\n",
-      "Harmonic frequencies (THz):\n",
-      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Projecting into phonon mode\n",
-      "Projecting into wave vector\n",
-      "Harmonic frequencies (THz):\n",
-      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Projecting into phonon mode\n",
-      "Projecting into wave vector\n",
-      "Harmonic frequencies (THz):\n",
-      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Harmonic frequencies (THz):\n",
-      "[ 6.70455074  6.70455074 17.07373311 19.00891776 22.89288977 22.89288977]\n",
-      "\n",
-      "Peak # 1\n",
-      "----------------------------------------------\n",
-      "Width                             2.314049 THz\n",
-      "Position                         13.095756 THz\n",
-      "Area (<K>)    (Lorentzian)        1.183044 eV\n",
-      "Area (<K>)    (Total)            13.428332 eV\n",
-      "<|dQ/dt|^2>                       2.366088 eV\n",
-      "Base line                         0.307202 eV * ps\n",
-      "Maximum height                    0.325468 eV * ps\n",
-      "Fitting global error              0.099967\n",
-      "Frequency shift                   6.391205 THz\n",
-      "\n",
-      "Peak # 2\n",
-      "----------------------------------------------\n",
-      "Width                             2.314049 THz\n",
-      "Position                         13.095756 THz\n",
-      "Area (<K>)    (Lorentzian)        1.183044 eV\n",
-      "Area (<K>)    (Total)            13.428332 eV\n",
-      "<|dQ/dt|^2>                       2.366088 eV\n",
-      "Base line                         0.307202 eV * ps\n",
-      "Maximum height                    0.325468 eV * ps\n",
-      "Fitting global error              0.099967\n",
-      "Frequency shift                   6.391205 THz\n",
-      "\n",
-      "Peak # 3\n",
-      "----------------------------------------------\n",
-      "Width                             3.149097 THz\n",
-      "Position                         13.206055 THz\n",
-      "Area (<K>)    (Lorentzian)        2.185645 eV\n",
-      "Area (<K>)    (Total)            13.704608 eV\n",
-      "<|dQ/dt|^2>                       4.371290 eV\n",
-      "Base line                         0.290934 eV * ps\n",
-      "Maximum height                    0.441849 eV * ps\n",
-      "Fitting global error              0.079543\n",
-      "Frequency shift                  -3.867679 THz\n",
-      "\n",
-      "Peak # 4\n",
-      "----------------------------------------------\n",
-      "Width                             2.207238 THz\n",
-      "Position                         11.082478 THz\n",
-      "Area (<K>)    (Lorentzian)        1.118892 eV\n",
-      "Area (<K>)    (Total)            13.398960 eV\n",
-      "<|dQ/dt|^2>                       2.237784 eV\n",
-      "Base line                         0.308063 eV * ps\n",
-      "Maximum height                    0.322715 eV * ps\n",
-      "Fitting global error              0.111510\n",
-      "Frequency shift                  -7.926440 THz\n",
-      "\n",
-      "Peak # 5\n",
-      "----------------------------------------------\n",
-      "Width                             2.594471 THz\n",
-      "Position                         13.203341 THz\n",
-      "Area (<K>)    (Lorentzian)        1.497081 eV\n",
-      "Area (<K>)    (Total)            13.548029 eV\n",
-      "<|dQ/dt|^2>                       2.994162 eV\n",
-      "Base line                         0.302882 eV * ps\n",
-      "Maximum height                    0.367347 eV * ps\n",
-      "Fitting global error              0.091173\n",
-      "Frequency shift                  -9.689549 THz\n",
-      "\n",
-      "Peak # 6\n",
-      "----------------------------------------------\n",
-      "Width                             2.594471 THz\n",
-      "Position                         13.203341 THz\n",
-      "Area (<K>)    (Lorentzian)        1.497081 eV\n",
-      "Area (<K>)    (Total)            13.548029 eV\n",
-      "<|dQ/dt|^2>                       2.994162 eV\n",
-      "Base line                         0.302882 eV * ps\n",
-      "Maximum height                    0.367347 eV * ps\n",
-      "Fitting global error              0.091173\n",
-      "Frequency shift                  -9.689549 THz\n",
-      "⟨T⟩ measured: 294.5 K  (target 300 K)\n",
-      "σ_T: 60.9 K\n",
-      "harmonic   freqs (THz): [2.85225322e-07 4.03488783e-07 4.94219497e-07 2.41048043e+01\n",
-      " 2.41048043e+01 2.41048043e+01]\n",
-      "renormalised freqs (THz): [ 0.          0.          0.         13.53899696 13.53899696 13.53899696]\n"
-     ]
-    }
-   ],
-   "source": [
-    "from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic\n",
-    "from pyiron_workflow_atomistics.physics.phonons import (\n",
-    "    calculate_phonon_md_renormalisation,\n",
-    ")\n",
-    "\n",
-    "ase_engine = ASEEngine(\n",
-    "    EngineInput=CalcInputStatic(),\n",
-    "    calculator=grace_calc,\n",
-    "    working_directory=\"./_dynaphopy_grace_0p7fs/ase_run\",\n",
-    ")\n",
-    "\n",
-    "# Band-path of commensurate q-points for the 2×2×2 supercell — these\n",
-    "# are the only q's where dynaphopy's mode projection is well-defined.\n",
-    "# Γ → X → K/W-like → L is a standard FCC path through high-symmetry points.\n",
-    "wf_ase = calculate_phonon_md_renormalisation(\n",
-    "    structure=si_prim,\n",
-    "    engine=ase_engine,\n",
-    "    fc2_supercell_matrix=fc2_multiplier,\n",
-    "    temperature=300.0,\n",
-    "    equilibration_steps=5000,\n",
-    "    production_steps=50000,\n",
-    "    time_step=0.7,\n",
-    "    thermostat_time_constant=100.0,\n",
-    "    q_points=[[0.0, 0.0, 0.0], [0.5, 0.0, 0.0], [0.5, 0.5, 0.0], [0.5, 0.5, 0.5]],\n",
-    "    seed=42,\n",
-    "    keep_handles=True,\n",
-    "    power_spectra=True,\n",
-    ")\n",
-    "# GRACE's TF FuncGraph isn't pickleable; disable pyiron_workflow's recovery save.\n",
-    "wf_ase.recovery = None\n",
-    "wf_ase.run()\n",
-    "out_ase = wf_ase.outputs.md_phonon_output.value\n",
-    "\n",
-    "print(f\"⟨T⟩ measured: {out_ase.md_temperature_mean:.1f} K  (target {out_ase.temperature:.0f} K)\")\n",
-    "print(f\"σ_T: {out_ase.md_temperature_std:.1f} K\")\n",
-    "print(f\"harmonic   freqs (THz): {out_ase.harmonic_frequencies[0]}\")\n",
-    "print(f\"renormalised freqs (THz): {out_ase.renormalised_frequencies[0]}\")"
-   ]
+   "outputs": [],
+   "source": "from pyiron_workflow import Workflow\nfrom pyiron_workflow_atomistics.engine import (\n    ASEEngine,\n    CalcInputMinimize,\n    CalcInputStatic,\n)\nfrom pyiron_workflow_atomistics.structure import get_bulk\nfrom pyiron_workflow_atomistics.physics.bulk import optimise_cubic_lattice_parameter\nfrom pyiron_workflow_atomistics.physics.phonons import (\n    calculate_phonon_md_renormalisation,\n)\n\n# Engine for the per-strain relaxations inside the EOS scan. CalcInputMinimize\n# triggers a BFGS minimisation under GRACE forces at each scanned volume.\nengine_min = ASEEngine(\n    EngineInput=CalcInputMinimize(\n        force_convergence_tolerance=0.05, max_iterations=100\n    ),\n    calculator=grace_calc,\n    working_directory=\"./_dynaphopy_grace_long_runs\",\n)\n\n# Engine for FC2 displacement-force evaluations and the Langevin NVT MD\n# trajectory generator borrowed by `calculate_phonon_md_renormalisation`.\nase_engine = ASEEngine(\n    EngineInput=CalcInputStatic(),\n    calculator=grace_calc,\n    working_directory=\"./_dynaphopy_grace_long_runs\",\n)\n\n# Band-path of commensurate q-points for the 2×2×2 supercell — these\n# are the only q's where dynaphopy's mode projection is well-defined.\n# Γ → X → K/W-like → L is a standard FCC path through high-symmetry points.\nq_points_commensurate = [\n    [0.0, 0.0, 0.0],\n    [0.5, 0.0, 0.0],\n    [0.5, 0.5, 0.0],\n    [0.5, 0.5, 0.5],\n]\n\nwf_ase = Workflow(\"dynaphopy_grace_ase\")\n\n# Node 1: GRACE-driven cubic lattice-parameter optimisation. Returns the\n# 8-atom *cubic* equilibrium structure plus the scalar `a0` (in Å).\nwf_ase.lat_opt = optimise_cubic_lattice_parameter(\n    structure=si_prim_initial,\n    name=\"Si\",\n    crystalstructure=\"diamond\",\n    engine=engine_min.with_working_directory(\"lat_opt\"),\n    strain_range=(-0.02, 0.02),\n    num_points=5,\n)\n\n# Node 2: rebuild the 2-atom *primitive* at the optimised lattice parameter.\n# `optimise_cubic_lattice_parameter` returns its `equil_struct` as the\n# conventional cubic cell (it calls `get_bulk(..., cubic=True)` internally).\n# Phonon-MD and the LAMMPS half use the 2-atom primitive × 2×2×2 supercell\n# (16 atoms), so we rebuild the primitive from `a0` here.\nwf_ase.prim_opt = get_bulk(\n    name=\"Si\",\n    crystalstructure=\"diamond\",\n    a=wf_ase.lat_opt.outputs.a0,\n    cubic=False,\n)\n\n# Node 3: the phonon-MD macro on the GRACE-equilibrated primitive.\nwf_ase.phonon = calculate_phonon_md_renormalisation(\n    structure=wf_ase.prim_opt.outputs.equil_struct,\n    engine=ase_engine.with_working_directory(\"phonon\"),\n    fc2_supercell_matrix=fc2_multiplier,\n    temperature=300.0,\n    equilibration_steps=5000,\n    production_steps=50000,\n    time_step=0.7,\n    thermostat_time_constant=100.0,\n    q_points=q_points_commensurate,\n    seed=42,\n    keep_handles=True,\n    power_spectra=True,\n)\n\n# GRACE's TF FuncGraph isn't pickleable; disable pyiron_workflow's recovery save.\nwf_ase.recovery = None\nwf_ase.run()\n\n# Surface the optimised lattice parameter early — this is the geometry both\n# halves of the notebook now share.\na0_grace = float(wf_ase.lat_opt.outputs.a0.value)\nB_grace = float(wf_ase.lat_opt.outputs.B.value)\ne0_per_atom = float(wf_ase.lat_opt.outputs.equil_energy_per_atom.value)\nprint(f\"GRACE-1L-OAM optimised a0 = {a0_grace:.4f} Å \"\n      f\"(vs textbook 5.43 Å, Δ = {a0_grace - 5.43:+.4f} Å)\")\nprint(f\"GRACE-1L-OAM bulk modulus B = {B_grace:.1f} GPa\")\nprint(f\"GRACE-1L-OAM e0/atom       = {e0_per_atom:.4f} eV\")\n\nout_ase = wf_ase.phonon.outputs.md_phonon_output.value\nsi_prim = wf_ase.prim_opt.outputs.equil_struct.value  # optimised 2-atom primitive\n\nprint(f\"⟨T⟩ measured: {out_ase.md_temperature_mean:.1f} K  \"\n      f\"(target {out_ase.temperature:.0f} K)\")\nprint(f\"σ_T: {out_ase.md_temperature_std:.1f} K\")\nprint(f\"harmonic   freqs (THz): {out_ase.harmonic_frequencies[0]}\")\nprint(f\"renormalised freqs (THz): {out_ase.renormalised_frequencies[0]}\")"
   },
   {
    "cell_type": "markdown",
@@ -767,22 +199,11 @@
    "cell_type": "markdown",
    "id": "b0c2b918",
    "metadata": {},
-   "source": [
-    "## 3. Section B — LAMMPS-driven workflow with `pair_style grace`\n",
-    "\n",
-    "Same foundation model, different MD driver. Pieces:\n",
-    "- **`LammpsEngine`** from `pyiron_workflow_lammps` wraps the `lmp` binary at\n",
-    "  `/home/liger/lammps/build/lmp` (built from the `grace` branch with ML-PACE/ML-GRACE).\n",
-    "- For trajectory generation we drive LAMMPS directly (its own integrator is much\n",
-    "  faster than per-step ASE subprocess calls) and dump positions+velocities.\n",
-    "- `dynaphopy.interface.iofile.read_lammps_trajectory` parses the dump and\n",
-    "  builds a `dynaphopy.dynamics.Dynamics` object compatible with `Quasiparticle`.\n",
-    "- FC2 is reused from Section A so both halves are fit against the same harmonic reference."
-   ]
+   "source": "## 3. Section B — LAMMPS-driven workflow with `pair_style grace`\n\nSame foundation model, different MD driver. Pieces:\n- **`LammpsEngine`** from `pyiron_workflow_lammps` wraps the `lmp` binary at\n  `/home/liger/lammps/build/lmp` (built from the `grace` branch with ML-PACE/ML-GRACE).\n- For trajectory generation we drive LAMMPS directly (its own integrator is much\n  faster than per-step ASE subprocess calls) and dump positions+velocities.\n- `dynaphopy.interface.iofile.read_lammps_trajectory` parses the dump and\n  builds a `dynaphopy.dynamics.Dynamics` object compatible with `Quasiparticle`.\n- FC2 is reused from Section A so both halves are fit against the same harmonic reference.\n- **Same geometry as Section A.** The 2×2×2 supercell is rebuilt below from\n  Section A's GRACE-optimised primitive (`a0 = {a0_grace}` Å, surfaced from\n  `wf_ase.lat_opt`), so this LAMMPS path and the ASE path differ *only* in\n  MD driver — never in lattice parameter, supercell tiling, or FC2 reference."
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "2f2203cf",
    "metadata": {
     "execution": {
@@ -792,30 +213,8 @@
      "shell.execute_reply": "2026-05-15T17:12:43.618199Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Wrote /tmp/pwa-grace-0p7/_dynaphopy_grace_0p7fs/lammps_run/si_222.data (16 atoms)\n"
-     ]
-    }
-   ],
-   "source": [
-    "import subprocess\n",
-    "from pathlib import Path\n",
-    "\n",
-    "lammps_workdir = Path(\"./_dynaphopy_grace_0p7fs/lammps_run\").resolve()\n",
-    "lammps_workdir.mkdir(parents=True, exist_ok=True)\n",
-    "LMP_BIN = \"/home/liger/lammps/build/lmp\"\n",
-    "GRACE_MODEL_DIR = \"/home/liger/.cache/grace/GRACE-1L-OAM\"\n",
-    "\n",
-    "# Write Si 2x2x2 LAMMPS data file.\n",
-    "data_file = lammps_workdir / \"si_222.data\"\n",
-    "from ase.io import write as ase_write\n",
-    "ase_write(str(data_file), si_supercell, format=\"lammps-data\", masses=True)\n",
-    "print(f\"Wrote {data_file} ({len(si_supercell)} atoms)\")"
-   ]
+   "outputs": [],
+   "source": "import subprocess\nfrom pathlib import Path\n\nlammps_workdir = Path(\"./_dynaphopy_grace_long_runs/lammps_run\").resolve()\nlammps_workdir.mkdir(parents=True, exist_ok=True)\nLMP_BIN = \"/home/liger/lammps/build/lmp\"\nGRACE_MODEL_DIR = \"/home/liger/.cache/grace/GRACE-1L-OAM\"\n\n# Rebuild the 2×2×2 Si supercell from the GRACE-optimised primitive so\n# Section B's LAMMPS MD runs on the same geometry Section A used for FC2 +\n# ASE Langevin MD. `si_prim` was bound above to `wf_ase.prim_opt.outputs.equil_struct`.\nsi_supercell = make_supercell(si_prim, fc2_multiplier)\nprint(f\"Si primitive (GRACE-equilibrated, a0={a0_grace:.4f} Å): \"\n      f\"{len(si_prim)} atoms, cell={si_prim.cell.lengths()}\")\nprint(f\"2x2x2 supercell: {len(si_supercell)} atoms, \"\n      f\"cell={si_supercell.cell.lengths()}\")\n\n# Write Si 2x2x2 LAMMPS data file.\ndata_file = lammps_workdir / \"si_222.data\"\nfrom ase.io import write as ase_write\nase_write(str(data_file), si_supercell, format=\"lammps-data\", masses=True)\nprint(f\"Wrote {data_file} ({len(si_supercell)} atoms)\")"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
## Summary
- Wrap the ASE-driven half (Section A) in a parent `Workflow("dynaphopy_grace_ase")` with three nodes: `wf.lat_opt = optimise_cubic_lattice_parameter(...)` (using a `CalcInputMinimize` GRACE engine, ±2% strain, 5 points), `wf.prim_opt = get_bulk(..., a=wf.lat_opt.outputs.a0, cubic=False)` to recover the 2-atom diamond primitive (the lat-opt macro's `equil_struct` is the 8-atom conventional cell), and `wf.phonon = calculate_phonon_md_renormalisation(structure=wf.prim_opt.outputs.equil_struct, ...)`.
- Section B (LAMMPS half) now rebuilds `si_supercell` from the GRACE-optimised primitive before writing the LAMMPS data file — apples-to-apples with Section A.
- All MD parameters preserved verbatim (50000 prod / 0.7 fs / 300 K / seed=42).
- `si_prim` renamed to `si_prim_initial` to make the "this is just an EOS scan seed" intent obvious.

## ⚠️ Not executed in this branch
`tensorpotential` (GRACE) is not installed in `/home/liger/miniforge3` (the default env used for the other notebook PRs in this series). The notebook was syntax-checked via `nbformat` round-trip + `nbconvert --to script` (641-line Python output, no syntax errors), but its cell outputs are stale relative to the new wiring.

**To refresh outputs**, re-run in an env that has tensorpotential + dynaphopy + phonopy installed (e.g. `/home/liger/miniforge3/envs/calphy`):

```bash
/path/to/calphy-env/bin/jupyter nbconvert --to notebook --execute --inplace \
  notebooks/dynaphopy_grace_example_long.ipynb
```

## Test plan
- [ ] Run with GRACE-capable env; confirm optimised Si a0 (~5.43 Å seed, GRACE may pick slightly different)
- [ ] Spot-check renormalised frequencies + ⟨T⟩
- [ ] Confirm LAMMPS-half supercell matches the ASE-half optimum
- [ ] Open follow-up issue for the `optimise_cubic_lattice_parameter` primitive-input quirk (see #70)

🤖 Generated with [Claude Code](https://claude.com/claude-code)