### PR TITLE
fix(notebooks/gb_cleavage): pre-relax bicrystal so cleavage energies are positive

### DIFF
--- a/notebooks/gb_cleavage.ipynb
+++ b/notebooks/gb_cleavage.ipynb
@@ -20,10 +20,10 @@
    "id": "8d7e9f7e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-16T15:59:13.962928Z",
-     "iopub.status.busy": "2026-05-16T15:59:13.962634Z",
-     "iopub.status.idle": "2026-05-16T15:59:18.868347Z",
-     "shell.execute_reply": "2026-05-16T15:59:18.864990Z"
+     "iopub.execute_input": "2026-05-17T00:55:28.667289Z",
+     "iopub.status.busy": "2026-05-17T00:55:28.666811Z",
+     "iopub.status.idle": "2026-05-17T00:55:33.966111Z",
+     "shell.execute_reply": "2026-05-17T00:55:33.962445Z"
     }
    },
    "outputs": [],
@@ -74,39 +74,27 @@
    "id": "d3b1ba4a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-16T15:59:18.875290Z",
-     "iopub.status.busy": "2026-05-16T15:59:18.873844Z",
-     "iopub.status.idle": "2026-05-16T15:59:19.743923Z",
-     "shell.execute_reply": "2026-05-16T15:59:19.741102Z"
+     "iopub.execute_input": "2026-05-17T00:55:33.970979Z",
+     "iopub.status.busy": "2026-05-17T00:55:33.970088Z",
+     "iopub.status.idle": "2026-05-17T00:55:34.984058Z",
+     "shell.execute_reply": "2026-05-17T00:55:34.980848Z"
     }
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
-     "text": [
-      "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:59:19       -7.968559        0.000000\n",
-      "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:59:19       -8.009283        0.000000\n"
-     ]
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:59:19       -8.025561        0.000000\n",
-      "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:59:19       -8.018422        0.000000\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "      Step     Time          Energy          fmax\n",
-      "BFGS:    0 17:59:19       -7.989335        0.000000\n",
       "optimised a0 = 2.8554 A (was hard-coded as 2.85 A)\n",
       "bicrystal: 24 atoms, c = 24.07 A, area = 28.24 A^2\n"
      ]
@@ -153,33 +141,171 @@
    "id": "25b88fcd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-16T15:59:19.748329Z",
-     "iopub.status.busy": "2026-05-16T15:59:19.747934Z",
-     "iopub.status.idle": "2026-05-16T15:59:20.152377Z",
-     "shell.execute_reply": "2026-05-16T15:59:20.149625Z"
+     "iopub.execute_input": "2026-05-17T00:55:34.989562Z",
+     "iopub.status.busy": "2026-05-17T00:55:34.988879Z",
+     "iopub.status.idle": "2026-05-17T00:55:43.220985Z",
+     "shell.execute_reply": "2026-05-17T00:55:43.217929Z"
     }
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": []
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
      "text": [
-      "uncleaved energy: -78.116 eV\n"
+      "uncleaved (relaxed) energy: -87.160 eV\n"
      ]
     }
    ],
    "source": [
-    "# Compute the uncleaved (reference) energy with the static engine,\n",
+    "# Relax the uncleaved bicrystal so E_uncleaved is the equilibrium GB energy,\n",
     "# wired through a small Workflow for parity with the lat-opt step.\n",
+    "# Without this, the as-stacked interface is high-strain and\n",
+    "# (E_cleaved - E_uncleaved) can go negative near the GB plane.\n",
     "wf_ref = Workflow(\"gb_cleave_ref\")\n",
     "wf_ref.uncleaved = calculate(\n",
     "    structure=gb_with_vacuum,\n",
-    "    engine=engine_static.with_working_directory(\"uncleaved\"),\n",
+    "    engine=engine_min.with_working_directory(\"uncleaved\"),\n",
     "    label=\"uncleaved\",\n",
     ")\n",
     "wf_ref.run()\n",
+    "gb_relaxed = wf_ref.uncleaved.outputs.engine_output.value.final_structure\n",
     "E_uncleaved = wf_ref.uncleaved.outputs.engine_output.value.final_energy\n",
-    "print(f\"uncleaved energy: {E_uncleaved:.3f} eV\")\n"
+    "print(f\"uncleaved (relaxed) energy: {E_uncleaved:.3f} eV\")\n"
    ]
   },
   {
@@ -188,10 +314,10 @@
    "id": "1e6dadfb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-16T15:59:20.156901Z",
-     "iopub.status.busy": "2026-05-16T15:59:20.156592Z",
-     "iopub.status.idle": "2026-05-16T15:59:20.167831Z",
-     "shell.execute_reply": "2026-05-16T15:59:20.164919Z"
+     "iopub.execute_input": "2026-05-17T00:55:43.225401Z",
+     "iopub.status.busy": "2026-05-17T00:55:43.225023Z",
+     "iopub.status.idle": "2026-05-17T00:55:43.240984Z",
+     "shell.execute_reply": "2026-05-17T00:55:43.237983Z"
     }
    },
    "outputs": [
@@ -200,18 +326,18 @@
      "output_type": "stream",
      "text": [
       "found 4 candidate cleavage plane(s)\n",
-      "  plane @ c = 10.385 A\n",
-      "  plane @ c = 11.209 A\n",
-      "  plane @ c = 12.034 A\n",
-      "  plane @ c = 12.858 A\n"
+      "  plane @ c = 11.018 A\n",
+      "  plane @ c = 11.873 A\n",
+      "  plane @ c = 13.033 A\n",
+      "  plane @ c = 13.876 A\n"
      ]
     }
    ],
    "source": [
-    "# Identify viable cleavage planes near the bicrystal midplane.\n",
+    "# Identify viable cleavage planes near the bicrystal midplane (on the relaxed structure).\n",
     "gb_midplane = gb_z / 2.0\n",
     "cleaved_structures, cleavage_coords = cleave_gb_structure.node_function(\n",
-    "    base_structure=gb_with_vacuum,\n",
+    "    base_structure=gb_relaxed,\n",
     "    axis_to_cleave=\"c\",\n",
     "    target_coord=gb_midplane,\n",
     "    tol=0.3,\n",
@@ -231,10 +357,10 @@
    "id": "8d6320a2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-16T15:59:20.172221Z",
-     "iopub.status.busy": "2026-05-16T15:59:20.171849Z",
-     "iopub.status.idle": "2026-05-16T15:59:21.445514Z",
-     "shell.execute_reply": "2026-05-16T15:59:21.442319Z"
+     "iopub.execute_input": "2026-05-17T00:55:43.245946Z",
+     "iopub.status.busy": "2026-05-17T00:55:43.245552Z",
+     "iopub.status.idle": "2026-05-17T00:55:44.655830Z",
+     "shell.execute_reply": "2026-05-17T00:55:44.652759Z"
     }
    },
    "outputs": [
@@ -243,11 +369,11 @@
      "output_type": "stream",
      "text": [
       "   cleavage_coord  energy_eV  cleavage_energy_Jm2\n",
-      "0       10.384958 -71.052086             2.003528\n",
-      "1       11.209231 -71.503781             1.875410\n",
-      "2       12.033505 -82.367554            -1.205979\n",
-      "3       12.857778 -82.352069            -1.201586\n",
-      "min cleavage energy: -1.206 J/m^2\n"
+      "0       11.017779 -80.284888             1.950071\n",
+      "1       11.873074 -82.023242             1.457006\n",
+      "2       13.033464 -81.951645             1.477314\n",
+      "3       13.876038 -80.264574             1.955833\n",
+      "min cleavage energy: 1.457 J/m^2\n"
      ]
     }
    ],


### PR DESCRIPTION
## Summary
- The as-stacked Fe Σ3 bicrystal (`ase.build.stack(slab1, slab2)`) has highly compressed interfacial (111) layers, so a static `E_uncleaved` sits ~9 eV above equilibrium and `(E_cleaved − E_uncleaved) / (2A)` goes negative for the two GB-adjacent planes — `min cleavage energy: -1.21 J/m²` on `main` today, which is unphysical.
- Minimise the uncleaved bicrystal first (reusing the existing `engine_min`, fmax = 0.05, max 100 steps) and cleave from the relaxed structure. Cleaved supercells stay static — rigid cleavage of the equilibrium GB is the textbook construction.
- All four (111) planes now report physical `γ_cleave`: **+1.95, +1.46, +1.48, +1.96 J/m²**. The lat-opt step from #67 (a₀ = 2.8554 Å) is preserved unchanged.

## Test plan
- [x] `jupyter nbconvert --to notebook --execute notebooks/gb_cleavage.ipynb` in `test_pyiron_workflow_atomistics` env — runs to completion, all four `cleavage_energy_Jm2` positive

🤖 Generated with [Claude Code](https://claude.com/claude-code)