### PR TITLE
fix(physics/phonons): support phonopy/phono3py v4 API

### DIFF
--- a/pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/anharmonic_dynaphopy.py
@@ -9,7 +9,10 @@ from ase import Atoms
 from pyiron_workflow_atomistics.engine import Engine
 from pyiron_workflow_atomistics.physics.free_energy.harmonic import _resolve_simfolder
 from pyiron_workflow_atomistics.physics.free_energy.outputs import FreeEnergyOutput
-from pyiron_workflow_atomistics.physics.phonons._compat import require_phonopy
+from pyiron_workflow_atomistics.physics.phonons._compat import (
+    ir_qpoints_and_weights,
+    require_phonopy,
+)
 from pyiron_workflow_atomistics.physics.phonons.md_renormalised import (
     calculate_phonon_md_renormalisation,
 )
@@ -101,19 +104,17 @@ def _free_energy_from_spectrum(
 def _commensurate_q_points(structure: Atoms, q_mesh) -> tuple[np.ndarray, np.ndarray]:
     """Return (q_points, weights) on a commensurate Monkhorst-Pack mesh.
 
-    Phonopy's `GridPoints` lays out the mesh on the *primitive* cell that
-    phonopy infers via primitive_matrix="auto". We mirror that convention
-    here so the mesh is consistent with the FC2 view dynaphopy projects into.
-    Weights sum to 1.
+    The mesh is laid out on the *primitive* cell that phonopy infers via
+    primitive_matrix="auto", so it stays consistent with the FC2 view
+    dynaphopy projects into. Weights sum to 1.
 
-    Uses ``phonopy.structure.grid_points.GridPoints`` directly so the mesh
-    can be built before force constants exist — ``Phonopy.run_mesh`` requires
-    a built dynamical matrix, which we do not have at this stage.
+    The actual ir-grid reduction is delegated to
+    :func:`pyiron_workflow_atomistics.physics.phonons._compat.ir_qpoints_and_weights`,
+    which bridges the phonopy v3/v4 API split (``GridPoints`` → ``get_ir_qpoints_and_weights``).
     """
     require_phonopy()
     import phonopy
     from phonopy.structure.atoms import PhonopyAtoms
-    from phonopy.structure.grid_points import GridPoints
 
     unitcell = PhonopyAtoms(
         symbols=list(structure.get_chemical_symbols()),
@@ -126,20 +127,12 @@ def _commensurate_q_points(structure: Atoms, q_mesh) -> tuple[np.ndarray, np.nda
         supercell_matrix=np.eye(3, dtype=int),
         primitive_matrix="auto",
     )
-    primitive = phonon.primitive
-    # phonopy reciprocal-lattice convention: column vectors a*, b*, c*.
-    reciprocal_lattice = np.linalg.inv(np.asarray(primitive.cell)).T
-    rotations = phonon.primitive_symmetry.pointgroup_operations
-
-    gp = GridPoints(
-        mesh_numbers=np.asarray(list(q_mesh), dtype="int64"),
-        reciprocal_lattice=reciprocal_lattice,
-        rotations=rotations,
-        is_mesh_symmetry=True,
+    q_points, weights = ir_qpoints_and_weights(
+        mesh=q_mesh,
+        phonopy_obj=phonon,
         is_gamma_center=True,
+        is_mesh_symmetry=True,
     )
-    q_points = np.asarray(gp.qpoints, dtype=float)
-    weights = np.asarray(gp.weights, dtype=float)
     weights = weights / weights.sum()
     return q_points, weights
 

--- a/pyiron_workflow_atomistics/physics/free_energy/harmonic.py
+++ b/pyiron_workflow_atomistics/physics/free_energy/harmonic.py
@@ -86,20 +86,6 @@ def _produce_fc2_view(
     return phonon
 
 
-class _Phono3pyShim:
-    """Minimal adapter exposing the four attributes _compute_harmonic_observables reads.
-
-    `_compute_harmonic_observables` was originally written against a Phono3py
-    object; for the harmonic-only path we hand it a Phonopy view with the
-    same four attributes. Keeps the helper signature unchanged.
-    """
-
-    def __init__(self, phonopy_view) -> None:
-        self.phonon_primitive = phonopy_view.primitive
-        self.phonon_supercell_matrix = phonopy_view.supercell_matrix
-        self.fc2 = phonopy_view.force_constants
-
-
 @pwf.as_function_node("free_energy_output")
 def _pack_harmonic_output(
     structure: Atoms,
@@ -131,7 +117,7 @@ def _pack_harmonic_output(
 
     T = np.asarray(temperatures, dtype=float)
     band_structure, dos, free_energy_dict = _compute_harmonic_observables(
-        ph3=_Phono3pyShim(phonopy_view), temperatures=T
+        ph3=phonopy_view, temperatures=T
     )
     # phonopy → eV / (eV/K) per primitive-cell atom.
     n_atoms_primitive = len(phonopy_view.primitive)

--- a/pyiron_workflow_atomistics/physics/phonons/_compat.py
+++ b/pyiron_workflow_atomistics/physics/phonons/_compat.py
@@ -57,3 +57,56 @@ def require_dynaphopy() -> Any:
             "dynaphopy is required for this workflow. "
             "Install with: pip install pyiron_workflow_atomistics[phonons-md]"
         ) from e
+
+
+def ir_qpoints_and_weights(
+    *,
+    mesh,
+    phonopy_obj,
+    is_gamma_center: bool = True,
+    is_mesh_symmetry: bool = True,
+) -> tuple[Any, Any]:
+    """Return ir-q-points and weights on a Monkhorst-Pack mesh of the primitive cell.
+
+    Bridges the phonopy v3 → v4 API split:
+
+    * v4 (``phonopy>=4.0``) exposes ``phonopy.phonon.grid.get_ir_qpoints_and_weights``
+      which takes the primitive lattice (row vectors) plus a ``Symmetry`` object.
+    * v3 used ``phonopy.structure.grid_points.GridPoints``, which took the
+      reciprocal lattice plus a raw rotations array.
+
+    ``phonopy_obj`` is an already-built ``phonopy.Phonopy`` instance whose
+    ``.primitive`` and ``.primitive_symmetry`` are used to seed the grid.
+    Built before force constants exist so callers cannot rely on
+    ``Phonopy.run_mesh``.
+    """
+    require_phonopy()
+    import numpy as np
+
+    mesh_arr = np.asarray(list(mesh), dtype="int64")
+    primitive_lattice = np.asarray(phonopy_obj.primitive.cell, dtype="double")
+
+    try:
+        from phonopy.phonon.grid import get_ir_qpoints_and_weights  # v4
+    except ImportError:
+        from phonopy.structure.grid_points import GridPoints  # v3
+
+        reciprocal_lattice = np.linalg.inv(primitive_lattice).T
+        rotations = phonopy_obj.primitive_symmetry.pointgroup_operations
+        gp = GridPoints(
+            mesh_numbers=mesh_arr,
+            reciprocal_lattice=reciprocal_lattice,
+            rotations=rotations,
+            is_mesh_symmetry=is_mesh_symmetry,
+            is_gamma_center=is_gamma_center,
+        )
+        return np.asarray(gp.qpoints, dtype=float), np.asarray(gp.weights, dtype=float)
+
+    q_points, weights = get_ir_qpoints_and_weights(
+        mesh=mesh_arr,
+        lattice=primitive_lattice,
+        primitive_symmetry=phonopy_obj.primitive_symmetry,
+        is_gamma_center=is_gamma_center,
+        is_mesh_symmetry=is_mesh_symmetry,
+    )
+    return np.asarray(q_points, dtype=float), np.asarray(weights, dtype=float)

--- a/pyiron_workflow_atomistics/physics/phonons/harmonic.py
+++ b/pyiron_workflow_atomistics/physics/phonons/harmonic.py
@@ -121,9 +121,11 @@ def _compute_harmonic_observables(
     """Compute band structure, total DOS, and Helmholtz free energy F(T).
 
     Builds a lightweight ``Phonopy`` view from ph3's already-computed FC2
-    data (primitive cell, supercell matrix, force constants), avoiding any
-    double force-evaluation.  The default band path is derived automatically
-    by ASE from the primitive cell (``ase.dft.kpoints.bandpath``).
+    data (unit cell, supercell matrix, force constants), avoiding any
+    double force-evaluation.  Accepts either a real ``Phono3py`` instance
+    (κ workflow) or a pre-built ``Phonopy`` view (harmonic-only path).
+    The default band path is derived automatically by ASE from the
+    primitive cell (``ase.dft.kpoints.bandpath``).
 
     Returns
     -------
@@ -132,24 +134,25 @@ def _compute_harmonic_observables(
 
     Notes
     -----
-    The plan originally suggested ``ase_bandpath("GXG", ...)``, but "GXG"
-    is not a recognised high-symmetry label.  We use ``path=None`` instead
-    so ASE auto-derives the canonical path for the lattice (e.g. FCC →
-    "GXWLGKUWLKG").
-
-    ``ph3.phonon`` does not exist in the installed phono3py version; instead
-    we build a ``Phonopy`` instance directly from ``ph3.phonon_primitive``,
-    ``ph3.phonon_supercell_matrix``, and ``ph3.fc2``.
+    Rebuilding from ``ph3.unitcell`` (the original input cell) — *not*
+    ``ph3.phonon_primitive`` — is required so that the supercell built by
+    Phonopy matches the supercell phono3py used when fitting ``fc2``;
+    otherwise the FC2 array shape disagrees with phonopy's expected
+    ``(num_patom_or_satom, num_satom, 3, 3)`` and phonopy v4's Rust
+    dynamical-matrix kernel raises ``ValueError`` (v3 was lenient).
     """
     import phonopy
 
-    # Build a Phonopy view from the already-computed FC2 data.
-    phonopy_view = phonopy.Phonopy(
-        unitcell=ph3.phonon_primitive,
-        supercell_matrix=ph3.phonon_supercell_matrix,
-        primitive_matrix="auto",
-    )
-    phonopy_view.force_constants = ph3.fc2
+    if isinstance(ph3, phonopy.Phonopy):
+        # Harmonic-only path: caller already built a Phonopy with FC fitted.
+        phonopy_view = ph3
+    else:
+        phonopy_view = phonopy.Phonopy(
+            unitcell=ph3.unitcell,
+            supercell_matrix=ph3.phonon_supercell_matrix,
+            primitive_matrix="auto",
+        )
+        phonopy_view.force_constants = ph3.fc2
 
     # ---- band structure (auto path from the unit cell) ----
     from ase.dft.kpoints import bandpath as ase_bandpath


### PR DESCRIPTION
## Summary
- Daily CI started failing when conda-forge upgraded phonopy/phono3py to 4.0.0; this PR makes the phonon free-energy stack compatible with v4 while preserving v3 support.
- Adds `_compat.ir_qpoints_and_weights` to bridge the v3 `phonopy.structure.grid_points.GridPoints` → v4 `phonopy.phonon.grid.get_ir_qpoints_and_weights` rename.
- Fixes a latent FC2 shape bug in `_compute_harmonic_observables` exposed by v4's strict dynamical-matrix shape check: rebuilding the Phonopy view used `ph3.phonon_primitive` as the unitcell while feeding it `ph3.fc2` sized for the *original* `ph3.unitcell`. Now uses `ph3.unitcell` (real `Phono3py` case) or accepts a pre-built `Phonopy` view directly (harmonic-only path, lets us drop `_Phono3pyShim`).

## Tests that were failing on daily (now pass)

- `tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py::test_anharmonic_free_energy_dynaphopy_emt_al`
- `tests/unit/physics/test_free_energy_anharmonic_dynaphopy.py::test_anharmonic_free_energy_dynaphopy_tdi_emt_al`
- `tests/unit/physics/test_free_energy_harmonic.py::test_harmonic_free_energy_emt_al_2x2x2`
- `tests/unit/physics/test_free_energy_qha.py::test_quasiharmonic_free_energy_emt_al`

## Test plan
- [x] All four CI-failing tests pass locally under phonopy 4.0.0 / phono3py 4.0.0
- [x] Same tests still pass under phonopy 3.5.1 / phono3py 3.31.1 (backward compat via try/except in `_compat`)
- [x] `black` + `ruff check` clean on the four modified files
- [ ] Push-Pull CI green

## Dependencies
The `[phonons]` extras and `.ci_support/environment.yml` are already unpinned, so no pin changes are needed — code now supports phonopy 3.x and 4.x simultaneously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)