### PR TITLE
Fix: macro leaks input channels into CalcInputMinimize → reference cell never relaxes (+ honour max_iterations)

### DIFF
--- a/pyiron_workflow_atomistics/engine/ase.py
+++ b/pyiron_workflow_atomistics/engine/ase.py
@@ -413,7 +413,11 @@ class ASEEngine:
     optimizer_class: type | None = BFGS
     optimizer_kwargs: dict[str, Any] = field(default_factory=dict)
     record_interval: int = 1
-    max_steps: int = 10_000
+    # Engine-level override for the optimiser step cap. ``None`` (the default)
+    # means "defer to the per-calculation setting", i.e. honour
+    # ``CalcInputMinimize.max_iterations``. Set this only to force a global cap
+    # regardless of the calc input.
+    max_steps: int | None = None
     properties: tuple[str, ...] = ("energy", "forces", "stresses", "volume")
     write_to_disk: bool = False
     initial_struct_path: str | None = "initial_structure.xyz"
@@ -456,7 +460,14 @@ class ASEEngine:
                 "optimizer_kwargs": self.optimizer_kwargs,
                 "record_interval": self.record_interval,
                 "fmax": mi.force_convergence_tolerance,
-                "max_steps": self.max_steps if self.max_steps else mi.max_iterations,
+                # Honour the per-calculation step cap by default; only let the
+                # engine-level max_steps win when it was explicitly set (not
+                # None). Previously max_steps defaulted to 10_000 and always
+                # overrode CalcInputMinimize.max_iterations, silently ignoring
+                # a user-requested iteration cap.
+                "max_steps": (
+                    self.max_steps if self.max_steps is not None else mi.max_iterations
+                ),
                 "relax_cell": mi.relax_cell,
                 "energy_convergence_tolerance": mi.energy_convergence_tolerance,
             }

--- a/pyiron_workflow_atomistics/physics/elastic.py
+++ b/pyiron_workflow_atomistics/physics/elastic.py
@@ -185,6 +185,37 @@ def elastic_constants_summary(elastic_tensor, structure: Atoms) -> dict:
     return d
 
 
+@pwf.as_function_node("calc_input")
+def make_minimize_input(
+    relax_cell: bool = False,
+    force_convergence_tolerance: float = 1e-3,
+    max_iterations: int = 300,
+):
+    """Build a concrete :class:`CalcInputMinimize` *at run time*.
+
+    Inside a ``@pwf.as_macro_node`` the macro arguments (``fmax``,
+    ``max_iterations``, ...) are pyiron_workflow input *channels*, not plain
+    Python scalars. Constructing a dataclass directly in the macro body would
+    therefore store those channel objects in the dataclass fields (e.g.
+    ``force_convergence_tolerance`` would hold a ``UserInput`` channel instead
+    of a float). That channel then leaks all the way into ASE's
+    ``BFGS.run(fmax=<channel>)``, where the convergence test
+    ``max_force < fmax`` against a non-numeric object is satisfied immediately,
+    so the relaxation "converges" at step 0 and the cell never moves.
+
+    Routing the construction through this function node delays evaluation to
+    graph-execution time, where the inputs are resolved to concrete scalars, so
+    the returned ``CalcInputMinimize`` carries real floats/ints.
+    """
+    from pyiron_workflow_atomistics.engine import CalcInputMinimize
+
+    return CalcInputMinimize(
+        relax_cell=relax_cell,
+        force_convergence_tolerance=force_convergence_tolerance,
+        max_iterations=max_iterations,
+    )
+
+
 @pwf.as_function_node("engine")
 def with_calc_input_node(engine, calc_input):
     """Node wrapper around :func:`with_calc_input` for use inside the macro graph."""
@@ -260,22 +291,28 @@ def calculate_elastic_constants(
     - Stress sign convention is ASE/pymatgen: tension-positive Cauchy stress.
     - Deformations are parameterized by the Green-Lagrange strain tensor.
     """
-    from pyiron_workflow_atomistics.engine import CalcInputMinimize, calculate
+    from pyiron_workflow_atomistics.engine import calculate
     from pyiron_workflow_atomistics.physics.bulk import evaluate_structures
 
-    fixed_cell = CalcInputMinimize(
+    # Build the CalcInputMinimize objects through function nodes rather than
+    # constructing the dataclasses directly here: inside the macro body
+    # ``fmax``/``max_iterations`` are input *channels*, not scalars, so a direct
+    # ``CalcInputMinimize(force_convergence_tolerance=fmax, ...)`` would store a
+    # channel object in the dataclass and silently break relaxation (see
+    # :func:`make_minimize_input`). The node resolves the inputs at run time.
+    wf.fixed_cell_input = make_minimize_input(
         relax_cell=False,
         force_convergence_tolerance=fmax,
         max_iterations=max_iterations,
     )
 
     if relax_initial:
-        full_relax = CalcInputMinimize(
+        wf.full_relax_input = make_minimize_input(
             relax_cell=True,
             force_convergence_tolerance=fmax,
             max_iterations=max_iterations,
         )
-        wf.relax_engine = with_calc_input_node(engine, full_relax)
+        wf.relax_engine = with_calc_input_node(engine, wf.full_relax_input)
         wf.relax = calculate(structure=structure, engine=wf.relax_engine)
         ref_structure = wf.relax.outputs.engine_output.final_structure
         wf.eq_stress = _reference_stress_gpa(wf.relax.outputs.engine_output)
@@ -287,7 +324,7 @@ def calculate_elastic_constants(
     wf.deform = generate_mp_deformations(
         ref_structure, norm_strains=norm_strains, shear_strains=shear_strains
     )
-    wf.deform_engine = with_calc_input_node(engine, fixed_cell)
+    wf.deform_engine = with_calc_input_node(engine, wf.fixed_cell_input)
     wf.evals = evaluate_structures(
         structures=wf.deform.outputs.deformed_structures,
         engine=wf.deform_engine,

--- a/tests/unit/physics/test_elastic.py
+++ b/tests/unit/physics/test_elastic.py
@@ -50,6 +50,55 @@ def test_with_calc_input_swaps_engine_mode():
     assert relaxed.calculator is base.calculator
 
 
+def test_make_minimize_input_returns_concrete_floats():
+    """Regression: the calc-input node must yield a real CalcInputMinimize with
+    plain Python scalars, never a leaked pyiron_workflow input channel.
+
+    The elastic macro builds its CalcInputMinimize objects through this node so
+    that, at run time, ``force_convergence_tolerance``/``max_iterations`` are
+    concrete numbers. If a channel object ever leaked into
+    ``force_convergence_tolerance``, ASE's ``BFGS.run(fmax=<channel>)`` would
+    "converge" at step 0 and the cell would never relax.
+    """
+    from pyiron_workflow_atomistics.engine import CalcInputMinimize
+    from pyiron_workflow_atomistics.physics.elastic import make_minimize_input
+
+    ci = make_minimize_input.node_function(
+        relax_cell=True, force_convergence_tolerance=1e-3, max_iterations=42
+    )
+    assert isinstance(ci, CalcInputMinimize)
+    assert ci.relax_cell is True
+    # Must be genuine scalars, not UserInput/OutputData channel objects.
+    assert isinstance(ci.force_convergence_tolerance, float)
+    assert ci.force_convergence_tolerance == 1e-3
+    assert isinstance(ci.max_iterations, int)
+    assert ci.max_iterations == 42
+
+
+def test_engine_honours_calc_input_max_iterations():
+    """Regression: an explicit CalcInputMinimize.max_iterations must reach the
+    optimiser. Previously ASEEngine.max_steps defaulted to 10_000 and silently
+    overrode it; now max_steps defaults to None and defers to the calc input.
+    """
+    from ase.calculators.emt import EMT
+
+    from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputMinimize
+
+    engine = ASEEngine(
+        EngineInput=CalcInputMinimize(
+            relax_cell=True, force_convergence_tolerance=1e-4, max_iterations=37
+        ),
+        calculator=EMT(),
+        working_directory=".",
+    )
+    assert engine.max_steps is None  # defer-to-calc-input default
+    from ase.build import bulk
+
+    _fn, kwargs = engine.get_calculate_fn(bulk("Cu", "fcc", a=3.6, cubic=True))
+    # The calc-input cap, not the old 10_000 engine default, must be used.
+    assert kwargs["max_steps"] == 37
+
+
 def test_generate_mp_deformations_count_and_pairing():
     from ase.build import bulk
 
@@ -180,6 +229,7 @@ def test_public_import_surface():
         extract_stresses_gpa,
         fit_elastic_tensor,
         generate_mp_deformations,
+        make_minimize_input,
         voigt_stress_to_gpa,
         with_calc_input,
     )
@@ -194,5 +244,6 @@ def test_public_import_surface():
             elastic_constants_summary,
             voigt_stress_to_gpa,
             with_calc_input,
+            make_minimize_input,
         )
     )

--- a/tests/unit/physics/test_elastic_workflows.py
+++ b/tests/unit/physics/test_elastic_workflows.py
@@ -33,3 +33,55 @@ def test_calculate_elastic_constants_emt_cu(tmp_path):
     assert d["K_VRH"] > 0 and d["G_VRH"] > 0
     # EMT Cu bulk modulus is ~ 130-180 GPa range
     assert 80 < d["K_VRH"] < 250
+
+
+@pytest.mark.slow
+def test_calculate_elastic_constants_cell_relaxes_input_independent(tmp_path):
+    """Regression for the macro channel-leak: relaxing the SAME material from
+    two different starting lattice constants must give the SAME relaxed volume
+    and elastic constants.
+
+    With the bug, ``fmax``/``max_iterations`` leaked into CalcInputMinimize as
+    pyiron_workflow channel objects, ASE "converged" the reference relaxation at
+    step 0, the cell was frozen at the (arbitrary) input, and K_VRH came out
+    input-dependent (e.g. a=3.9 -> K~32, a=3.615 -> K~123, both frozen at the
+    input volume). After the fix both starting cells relax to EMT Cu's
+    equilibrium (V ~ 11.57 A^3/atom, K_VRH ~ 134.6, G_VRH ~ 60.1 GPa).
+    """
+    from ase.build import bulk
+    from ase.calculators.emt import EMT
+
+    from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+    from pyiron_workflow_atomistics.physics.elastic import calculate_elastic_constants
+
+    def run(a, subdir):
+        structure = bulk("Cu", "fcc", a=a, cubic=True)
+        input_vol = structure.get_volume() / len(structure)
+        engine = ASEEngine(
+            EngineInput=CalcInputStatic(),
+            calculator=EMT(),
+            working_directory=str(tmp_path / subdir),
+        )
+        wf = calculate_elastic_constants(
+            structure=structure, engine=engine, relax_initial=True
+        )
+        out = wf.run()
+        relaxed = out["relaxed_structure"]
+        relaxed_vol = relaxed.get_volume() / len(relaxed)
+        return input_vol, relaxed_vol, out["elastic_constants"]
+
+    in_a, vol_a, d_a = run(3.615, "near_eq")
+    in_b, vol_b, d_b = run(3.9, "far")
+
+    # Canary: the cell must actually move (not be frozen at the input volume).
+    assert abs(vol_b - in_b) > 1e-3, "cell did not relax (frozen at input volume)"
+
+    # Input independence: both start points converge to the same equilibrium.
+    assert abs(vol_a - vol_b) < 1e-2, (vol_a, vol_b)
+    np.testing.assert_allclose(d_a["K_VRH"], d_b["K_VRH"], rtol=2e-2)
+    np.testing.assert_allclose(d_a["G_VRH"], d_b["G_VRH"], rtol=2e-2)
+
+    # Sanity against the known EMT Cu equilibrium.
+    np.testing.assert_allclose(vol_b, 11.565, rtol=2e-2)
+    np.testing.assert_allclose(d_b["K_VRH"], 134.6, rtol=5e-2)
+    np.testing.assert_allclose(d_b["G_VRH"], 60.1, rtol=5e-2)

--- a/tests/unit/physics/test_pure_gb_study.py
+++ b/tests/unit/physics/test_pure_gb_study.py
@@ -92,8 +92,12 @@ def test_pure_gb_study_runs_end_to_end(tmp_path):
     assert v0 > 0
 
     eng_min = ASEEngine(
+        # max_iterations must actually be honoured now (the engine no longer
+        # silently caps at 10_000 — see ASEEngine.max_steps). The cleavage
+        # relaxations here need a few more than 10 BFGS steps to converge at
+        # fmax=0.5; 50 keeps the smoke test fast while letting them finish.
         EngineInput=CalcInputMinimize(
-            force_convergence_tolerance=0.5, max_iterations=10
+            force_convergence_tolerance=0.5, max_iterations=50
         ),
         calculator=EAM(potential=str(EAM_PATH)),
         working_directory=str(tmp_path),


### PR DESCRIPTION
## Problem

`calculate_elastic_constants` (a `@pwf.as_macro_node`) silently performs **no cell relaxation** even when requested. Its `fmax`/`max_iterations` parameters are macro *input channels*, but they are passed straight into the plain `CalcInputMinimize(...)` dataclass at macro-build time. So `force_convergence_tolerance` ends up holding a `pyiron_workflow` `UserInput` *channel object*, which flows through `ASEEngine.get_calculate_fn` into ASE's `BFGS.run(fmax=<channel>)`. ASE's `max_force < fmax` convergence test against that object is satisfied immediately, so the reference relaxation "converges" in 1 step and the cell never moves.

Second, related defect in `engine/ase.py::ASEEngine.get_calculate_fn`: `"max_steps": self.max_steps if self.max_steps else mi.max_iterations` combined with `ASEEngine.max_steps = 10_000` (default) silently **overrides** any `CalcInputMinimize.max_iterations` a user sets.

### Reproduction (EMT Cu)
Relaxing the same material from different starting cells gives different, input-dependent elastic constants because the cell stays frozen at the (arbitrary) input:
- a=3.615 → K_VRH=123, a=3.9 → K_VRH=32.5, both with `relaxed_volume == input_volume`.

With a correct cell relaxation the result is input-**independent** (K_VRH≈134.6, G_VRH≈60.1 for EMT Cu).

## Fix

- **`physics/elastic.py`** — add `make_minimize_input` (`@pwf.as_function_node`) that builds `CalcInputMinimize` at *run time*; route both the reference full-relax and the fixed-cell deformation inputs through it, so the channels resolve to concrete values instead of leaking into the dataclass at build time.
- **`engine/ase.py`** — `ASEEngine.max_steps` default `10_000 → None` and precedence `self.max_steps if self.max_steps is not None else mi.max_iterations`, so an explicit `CalcInputMinimize.max_iterations` is honoured.

## Tests

- `test_make_minimize_input_returns_concrete_floats` — the node yields a real float/int, not a channel.
- `test_engine_honours_calc_input_max_iterations` — the iteration cap actually reaches the optimiser.
- `test_calculate_elastic_constants_cell_relaxes_input_independent` (slow) — EMT Cu from a=3.615 and a=3.9 both relax to V≈11.57 Å³/atom, K_VRH≈134.6, G_VRH≈60.1, and the cell genuinely moves.
- Adjusted one pre-existing GB test that was relying on the bug (`max_iterations=10` was silently 10_000): bumped to 50.

Full suite: **409 passed, 62 skipped, 0 failed**; ruff + black clean.

> Note: the `feat/cell-relaxation-enum` branch is orthogonal (and currently deletes `physics/elastic.py` as a stale-rebase artifact, since elastic landed on `main` in #76 after that branch diverged). This PR is based on `main`; the enum rename can be re-applied on top.
