### PR TITLE
Fix pip check: bump pyiron_snippets/scikit-learn/tqdm pins to resolved versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,10 @@ dependencies = [
     "scipy==1.17.1",
     "pyiron-workflow==0.15.6",
     "pymatgen==2026.5.4",
-    "pyiron_snippets==1.2.1",
-    "scikit-learn==1.8.0",
+    "pyiron_snippets==1.3.0",
+    "scikit-learn==1.9.0",
     "lz-GB-code==0.1.0",
-    "tqdm==4.67.3",
+    "tqdm==4.68.2",
 ]
 dynamic = ["version"]
 authors = [


### PR DESCRIPTION
`pip check` fails on `main`: the project pins `pyiron_snippets==1.2.1`, `scikit-learn==1.8.0`, `tqdm==4.67.3`, but `uv sync --all-extras --dev` resolves `1.3.0`/`1.9.0`/`4.68.2` (driven by transitive constraints — e.g. `pyiron-workflow==0.15.6`), so the recorded metadata mismatches the installed versions and `pip check` exits 1. This bumps the three direct pins to match the resolved versions.