### PR TITLE
Melting point via the interface/coexistence method (engine-agnostic)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,10 @@ Thumbs.db
 nohup.out
 pyiron.log
 core.*
+
+# melting verification run artifacts
+_verify_runs/
+lammps_job/
+lammps.data
+dump.out
+log.lammps

--- a/docs/design/plans/2026-06-27-melting-point-VERIFICATION.md
+++ b/docs/design/plans/2026-06-27-melting-point-VERIFICATION.md
@@ -1,0 +1,115 @@
+# Melting-point module — verification report (2026-06-27)
+
+Branch `feat/melting-point-interface-method` (pwa_melting) + `feat/velocity-capture-for-melting` (pwl_dev).
+
+## Summary
+
+The full **interface/coexistence melting-point method** is implemented as an
+engine-agnostic `physics/melting/` subpackage and verified end-to-end on the ASE
+engine with both **EMT** and a real **GRACE foundation model**. The LAMMPS
+(`pair_style grace`) path is wired and unit-verified, but blocked at runtime by a
+GRACE-evaluator/model-build incompatibility in the LAMMPS side (not the module).
+
+## Tests
+
+- **Fast unit suite** (`tests/unit/analysis`, `tests/unit/physics/melting`): **20 passed**.
+  Covers trajectory T/P (virial+kinetic, Voigt-6 & 3×3), CNA descriptors, Voronoi
+  void detection, coexistence structures, KDE solid fraction, ratio-selection +
+  T(P→0) extrapolation, dataclasses.
+- **Integration (EMT/Al, `-m slow`)**: NPT-Berendsen metal smoke; MD step drivers
+  (npt solid, interface build, strain scan); Step-1 bisection; one coexistence
+  iteration; **full `calculate_melting_point` end-to-end** (build → relax → Step 1
+  → Step 2 → `MeltingResult`, 201 s).
+- **LAMMPS velocity-capture** (`pwl_dev`): unit test confirms trajectory frames
+  carry per-atom velocities.
+
+## Engine verification
+
+| Engine | Calculator | Result |
+|---|---|---|
+| ASE | EMT (Al) | ✅ full method runs end-to-end; finite Tm + per-iteration provenance |
+| ASE | **GRACE-1L-OAM** (`grace_fm`) | ✅ **Step-1 estimate = 1006 K for Al** (GPU node; DFT Al melts 933 K — a ~1006 K superheating Step-1 estimate is physically reasonable) |
+| LAMMPS | `pair_style grace`, GRACE-1L-OAM | ⚠️ engine wiring correct, model loads, step-0 forces computed, velocity capture works — **GRACE evaluator crashes at step 1** |
+
+### LAMMPS diagnosis
+`in.lmp` is generated correctly (`pair_style grace`, `pair_coeff * * <model> Al`,
+`vx vy vz` in the dump, NPT `fix npt ... iso`). `lmp` loads the saved_model, maps
+Al→ACE species, builds neighbor lists, computes step-0 forces (1 dump frame), then
+the GRACE evaluator aborts at the first dynamics step — on **both CPU and A100**.
+This is a `pair_style grace` model/build pairing issue in the LAMMPS-GRACE stack,
+independent of the melting module: the engine-agnostic algorithm is identical to
+the EMT/GRACE-ASE paths that succeed. The ready-to-run driver
+(`scripts/_verify_lammps_grace_coex.py`) + SLURM job (`scripts/submit_grace_verify.sh`)
+will run once pointed at a `pair_style grace`-compatible model/build (e.g. a
+`grace/fs` export, which Han uses in the calphy campaigns).
+
+## Bugs found & fixed during verification
+
+1. **pyiron_workflow single-return rule** — `@pwf.as_function_node` bodies may have
+   exactly one `return` and no nested function with a return. Rewrote
+   `solid_fraction_kde`, `ratio_selection` (single-return) and moved the Step-1
+   `heated` closure to a module-level `_heated_solid` helper.
+2. **Bisection runaway** — undersampled MD never melts, so the "both solid" branch
+   expanded temperature without bound (infinite loop / blow-up). Added
+   `max_iterations` + `t_ceiling` guards to `estimate_melting_temperature`.
+3. **Engine-agnostic NPT thermostat** — the method needs *isotropic/orthorhombic*
+   NPT (CNA/Voronoi require it). ASE's isotropic NPT is `berendsen`; LAMMPS's is
+   `nose-hoover` (`fix npt ... iso`), and `LammpsEngine` rejects non-nose-hoover
+   NPT. ASE `nose-hoover` NPT goes full-triclinic and breaks pyscal Voronoi. Added
+   a configurable `npt_thermostat` (default `berendsen`; pass `nose-hoover` for LAMMPS).
+
+## Adversarial code review (multi-agent workflow)
+
+A 4-dimension adversarial review (physics fidelity, numerics/units, pyiron_workflow
+API, robustness) with per-finding skeptic verification: **34 candidates → 24
+confirmed**. Fixed:
+
+- **CRITICAL** NVE strain step re-seeded velocities at 2·T on an already-warm
+  (NVT-equilibrated) config → kinetic T ≈ 1.5·T → runaway melting point. Now 1·T.
+- **MAJOR** convergence loop stopped after `len(schedules)` iterations → rewrote to
+  iterate until `|ΔT| ≤ convergence_goal`, holding the finest schedule (+ safety cap).
+- **MAJOR** strain grid never re-centred → now re-centres on the fitted zero-pressure
+  strain each iteration (`_next_center`).
+- **MAJOR** `solid_fraction_kde` dropped the notebook's coordinate wrap → added
+  `atoms.wrap()` before the KDE.
+- **MINOR** `ratio_selection` selected by ratio value (duplicate ratios broke
+  contiguity) → now selects by index.
+- **MINOR** bisection inverted case (left molten/right solid) silently treated as
+  both-molten → now an explicit branch.
+- **MINOR** `create_coexistence_supercell` crashed for hcp (`cubic=True`) → hcp uses
+  `orthorhombic=True`.
+- **NIT** trajectory T/P silently returned 0 with no momenta → now raises.
+- **NIT** removed dead `with_calc_input`.
+- **LAMMPS (CRITICAL)** velocities attached in pyiron units (Å/fs) → `get_temperature()`
+  ~103.6× low → convert by `/units.fs` in the patch.
+- **LAMMPS (MAJOR)** `seed=None` written literally as "None" → guarded default.
+
+Documented follow-ups (not blocking the ASE path):
+- **LAMMPS stress convention** — `EngineOutput.stresses` is eV/Å³ virial (ASE) vs GPa
+  total-pressure tensor (LAMMPS); `pressures_from_trajectory` assumes the ASE
+  convention, so LAMMPS coexistence pressure needs the conventions reconciled.
+- **n_print vs record_interval** — the ASE MD engine records every step (per the
+  conformance test); for production-scale runs set `record_interval=n_print` to bound
+  memory (engine + conformance-test change).
+- Minor fidelity: solid-fraction gating/diamond detector, eager supercell build.
+
+## Reproduce
+
+```bash
+# fast unit suite
+/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit/analysis tests/unit/physics/melting -q
+# EMT integration (slow)
+/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/integration -q -m slow
+# Step-1 estimate (EMT)
+/ptmp/hmai/pwa_melting/.venv/bin/python scripts/meltingpoint.py --element Al --a 4.05
+# GRACE + LAMMPS on a GPU node
+sbatch /ptmp/hmai/pwa_melting/scripts/submit_grace_verify.sh
+```
+
+## Output locations
+- Code: `/ptmp/hmai/pwa_melting/pyiron_workflow_atomistics/{analysis,physics/melting}/`
+- LAMMPS patch: `/ptmp/hmai/pwl_dev/pyiron_workflow_lammps/lammps.py`
+- Verification runs: `/ptmp/hmai/pwa_melting/_verify_runs/`
+  - `grace_ase_step1/summary.json` → GRACE-ASE Step-1 = 1006 K
+  - `lammps_grace_coex/` → LAMMPS in.lmp + logs (step-1 crash)
+  - `slurm_28365529.out/.err` → GPU job log

--- a/docs/design/plans/2026-06-27-melting-point-interface-method.md
+++ b/docs/design/plans/2026-06-27-melting-point-interface-method.md
@@ -1,0 +1,1666 @@
+# Melting Point (Interface/Coexistence Method) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an engine-agnostic melting-point workflow (full interface/coexistence method) to `pyiron_workflow_atomistics`, runnable on the ASE engine (EMT, GRACE) and the wrapped `pyiron_workflow_lammps` `LammpsEngine` (`pair_style grace`).
+
+**Architecture:** Pure analysis quantities go in the general `analysis/` package; the method lives in a new `physics/melting/` subpackage. Everything consumes the Engine Protocol via `calculate(structure, engine)` + `CalcInputMD`/`CalcInputMinimize`. Adaptive loops (bisection, convergence) are `@pwf.as_function_node` Python drivers calling `.node_function()` per step with `engine.with_working_directory(...)` isolation (Approach A, matching `physics/free_energy/quasiharmonic.py`).
+
+**Tech Stack:** Python 3.11, `pyiron_workflow`, ASE 3.28, numpy 1.26.4, structuretoolkit (CNA + Voronoi), scikit-learn (KDE), `pyiron_workflow_lammps` + `pyiron_lammps` (LAMMPS engine).
+
+## Global Constraints
+
+- Engine-agnostic: method code imports only from `pyiron_workflow_atomistics.engine` (`Engine`, `calculate`, `CalcInputMD`, `CalcInputMinimize`) + `analysis`/`structure`. Never `import ase.md` / LAMMPS directly in method code.
+- Nodes are `@pwf.as_function_node("out_name", ...)`; the top-level orchestrator is `@pwf.as_macro_node(...)`. Loop drivers are `@pwf.as_function_node` that call `<node>.node_function(...)` internally.
+- Per-step isolation: `engine.with_working_directory(f"<tag>_{i:03d}")`. Per-step calc params: `dataclasses.replace(engine, EngineInput=<CalcInput...>)`.
+- CNA via `structuretoolkit.analyse.get_adaptive_cna_descriptors(structure=s, mode=..., ovito_compatibility=False)` → lowercase keys `{'fcc','bcc','hcp','ico','others'}`. Voronoi via `structuretoolkit.analyse.get_voronoi_volumes(structure)`.
+- NVE runs set `CalcInputMD.initial_temperature = 2*temperature` (half-velocity trick).
+- Pressure = virial (`EngineOutput.stresses`, handle Voigt-6 **and** 3×3) + kinetic `N·kB·T/V`; report GPa (`eV/Å³ × 160.21766208`).
+- Dev venv: `/ptmp/hmai/pwa_melting/.venv`. Run tests: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest`. Fast tests under `tests/unit/`, slow MD under `tests/integration/` (`@pytest.mark.slow`).
+- Commit after every task. Ruff-clean (`ruff check`).
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `pyiron_workflow_atomistics/analysis/trajectory.py` | `temperatures_from_trajectory`, `pressures_from_trajectory` (on `EngineOutput`) |
+| `pyiron_workflow_atomistics/analysis/structure_descriptors.py` | `cna_fractions`, `analyse_reference_structure`, `classify_solid`, `voronoi_max_mean`, `holes_mask` |
+| `pyiron_workflow_atomistics/analysis/__init__.py` | export the above |
+| `pyiron_workflow_atomistics/physics/melting/inputs.py` | `MeltingInput` |
+| `pyiron_workflow_atomistics/physics/melting/outputs.py` | `MeltingIterationRecord`, `MeltingResult` |
+| `pyiron_workflow_atomistics/physics/melting/structures.py` | `create_coexistence_supercell`, `freeze_half`, `unfreeze`, `strain_cell_along_z` |
+| `pyiron_workflow_atomistics/physics/melting/solid_fraction.py` | `solid_fraction_kde` |
+| `pyiron_workflow_atomistics/physics/melting/fitting.py` | `ratio_selection`, `predict_melting_point` |
+| `pyiron_workflow_atomistics/physics/melting/md_steps.py` | `with_calc_input`, `npt_relax_solid`, `build_solid_liquid_interface`, `strain_scan_nvt_nve` |
+| `pyiron_workflow_atomistics/physics/melting/initial_guess.py` | `estimate_melting_temperature` |
+| `pyiron_workflow_atomistics/physics/melting/coexistence.py` | `coexistence_iteration`, `refine_melting_point` |
+| `pyiron_workflow_atomistics/physics/melting/study.py` | `calculate_melting_point` macro |
+| `pyiron_workflow_atomistics/physics/melting/__init__.py` | public API |
+| `scripts/meltingpoint.py` | notebook → runnable EMT/Al Step-1 demo |
+| `/ptmp/hmai/pwl_dev/pyiron_workflow_lammps/lammps.py` | velocity-capture patch |
+
+---
+
+### Task 1: Trajectory quantities (temperature & pressure from EngineOutput)
+
+**Files:**
+- Create: `pyiron_workflow_atomistics/analysis/trajectory.py`
+- Test: `tests/unit/analysis/test_trajectory.py`
+
+**Interfaces:**
+- Consumes: `EngineOutput` (`.structures: list[Atoms]` with momenta, `.stresses: list[np.ndarray]` Voigt-6 or 3×3).
+- Produces:
+  - `temperatures_from_trajectory(engine_output, last_n=20) -> float` (mean K over last `last_n` frames)
+  - `pressures_from_trajectory(engine_output, last_n=20) -> float` (mean GPa, virial+kinetic)
+
+- [ ] **Step 1: Write the failing test**
+```python
+# tests/unit/analysis/test_trajectory.py
+import numpy as np
+from ase import Atoms, units
+from pyiron_workflow_atomistics.engine.protocol import EngineOutput
+from pyiron_workflow_atomistics.analysis.trajectory import (
+    temperatures_from_trajectory,
+    pressures_from_trajectory,
+)
+
+def _frame_at_temperature(T_target, n=64, a=10.0, seed=0):
+    rng = np.random.RandomState(seed)
+    atoms = Atoms(f"Ar{n}", positions=rng.rand(n, 3) * a, cell=[a, a, a], pbc=True)
+    atoms.set_momenta(rng.standard_normal((n, 3)))
+    atoms.set_momenta(atoms.get_momenta() * np.sqrt(T_target / atoms.get_temperature()))
+    return atoms
+
+def test_temperatures_from_trajectory_mean():
+    frames = [_frame_at_temperature(300.0, seed=i) for i in range(5)]
+    out = EngineOutput(final_structure=frames[-1], final_energy=0.0,
+                       converged=True, structures=frames)
+    T = temperatures_from_trajectory.node_function(out, last_n=5)
+    assert abs(T - 300.0) < 1e-6
+
+def test_pressures_from_trajectory_virial_plus_kinetic():
+    n, a = 64, 10.0
+    V = a ** 3
+    frame = _frame_at_temperature(300.0, n=n, a=a, seed=1)
+    p_vir = 0.01  # eV/Å^3
+    svoigt = np.array([-p_vir, -p_vir, -p_vir, 0.0, 0.0, 0.0])
+    out = EngineOutput(final_structure=frame, final_energy=0.0, converged=True,
+                       structures=[frame], stresses=[svoigt])
+    P = pressures_from_trajectory.node_function(out, last_n=1)
+    p_kin = n * units.kB * 300.0 / V          # eV/Å^3
+    expected = (p_vir + p_kin) * 160.21766208  # GPa
+    assert abs(P - expected) < 1e-6
+
+def test_pressures_accepts_full_3x3_stress():
+    n, a = 64, 10.0
+    frame = _frame_at_temperature(300.0, n=n, a=a, seed=2)
+    p_vir = 0.02
+    full = np.diag([-p_vir, -p_vir, -p_vir])
+    out = EngineOutput(final_structure=frame, final_energy=0.0, converged=True,
+                       structures=[frame], stresses=[full])
+    P = pressures_from_trajectory.node_function(out, last_n=1)
+    p_kin = n * units.kB * 300.0 / (a ** 3)
+    assert abs(P - (p_vir + p_kin) * 160.21766208) < 1e-6
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit/analysis/test_trajectory.py -v`
+Expected: FAIL (ModuleNotFoundError: analysis.trajectory)
+
+- [ ] **Step 3: Write minimal implementation**
+```python
+# pyiron_workflow_atomistics/analysis/trajectory.py
+"""Derived quantities computed from an EngineOutput trajectory.
+
+Engine-agnostic: works for any engine whose EngineOutput.structures carry
+per-atom momenta (ASE engine; patched LAMMPS engine) and whose .stresses hold
+per-frame virial stress (Voigt-6 or 3x3, in eV/Å^3).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pyiron_workflow as pwf
+from ase import units
+
+_EV_PER_A3_TO_GPA = 160.21766208
+
+
+def _virial_pressure_ev_per_a3(stress: np.ndarray) -> float:
+    """Hydrostatic virial pressure P = -tr(sigma)/3 from Voigt-6 or 3x3 stress."""
+    s = np.asarray(stress, dtype=float)
+    if s.shape == (6,):
+        trace = s[0] + s[1] + s[2]
+    elif s.shape == (3, 3):
+        trace = s[0, 0] + s[1, 1] + s[2, 2]
+    else:
+        raise ValueError(f"Unexpected stress shape {s.shape}; expected (6,) or (3, 3)")
+    return -trace / 3.0
+
+
+@pwf.as_function_node("temperature")
+def temperatures_from_trajectory(engine_output, last_n: int = 20) -> float:
+    """Mean kinetic temperature (K) over the last ``last_n`` trajectory frames."""
+    frames = engine_output.structures
+    if not frames:
+        raise ValueError("engine_output.structures is empty; need an MD trajectory")
+    window = frames[-last_n:]
+    temperature = float(np.mean([f.get_temperature() for f in window]))
+    return temperature
+
+
+@pwf.as_function_node("pressure")
+def pressures_from_trajectory(engine_output, last_n: int = 20) -> float:
+    """Mean total pressure (GPa) over the last ``last_n`` frames: virial + kinetic."""
+    frames = engine_output.structures
+    stresses = engine_output.stresses
+    if not frames or not stresses:
+        raise ValueError("engine_output needs both .structures and .stresses")
+    window_f = frames[-last_n:]
+    window_s = stresses[-last_n:]
+    pressures = []
+    for frame, stress in zip(window_f, window_s):
+        p_vir = _virial_pressure_ev_per_a3(stress)             # eV/Å^3
+        p_kin = (len(frame) * units.kB * frame.get_temperature()
+                 / frame.get_volume())                          # eV/Å^3
+        pressures.append((p_vir + p_kin) * _EV_PER_A3_TO_GPA)   # GPa
+    return float(np.mean(pressures))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit/analysis/test_trajectory.py -v`
+Expected: 3 PASS
+
+- [ ] **Step 5: Commit**
+```bash
+cd /ptmp/hmai/pwa_melting
+git add pyiron_workflow_atomistics/analysis/trajectory.py tests/unit/analysis/test_trajectory.py
+git commit -m "feat(analysis): trajectory temperature & pressure quantities from EngineOutput"
+```
+
+---
+
+### Task 2: CNA structure descriptors (fractions, reference analysis, classify)
+
+**Files:**
+- Create: `pyiron_workflow_atomistics/analysis/structure_descriptors.py`
+- Test: `tests/unit/analysis/test_structure_descriptors.py`
+
+**Interfaces:**
+- Produces:
+  - `cna_fractions(structure) -> dict[str, int]` (counts, lowercase keys)
+  - `analyse_reference_structure(structure) -> tuple[str, int, float]` → `(key_max, n_atoms, distribution_half)`
+  - `classify_solid(structure, key_max, distribution_half) -> bool`
+
+- [ ] **Step 1: Write the failing test**
+```python
+# tests/unit/analysis/test_structure_descriptors.py
+import numpy as np
+from ase.build import bulk
+from pyiron_workflow_atomistics.analysis.structure_descriptors import (
+    cna_fractions, analyse_reference_structure, classify_solid,
+)
+
+def _fcc_al():
+    return bulk("Al", "fcc", a=4.05, cubic=True).repeat((4, 4, 4))
+
+def test_cna_fractions_fcc_dominant():
+    counts = cna_fractions.node_function(_fcc_al())
+    assert counts["fcc"] / sum(counts.values()) > 0.95
+
+def test_analyse_reference_structure_fcc():
+    key_max, n_atoms, half = analyse_reference_structure.node_function(_fcc_al())
+    assert key_max == "fcc"
+    assert n_atoms == 256
+    assert abs(half - 0.5) < 0.05
+
+def test_classify_solid_true_for_crystal():
+    s = _fcc_al()
+    key_max, _, half = analyse_reference_structure.node_function(s)
+    assert classify_solid.node_function(s, key_max, half) is True
+
+def test_classify_solid_false_for_disordered():
+    s = _fcc_al()
+    key_max, _, half = analyse_reference_structure.node_function(s)
+    rng = np.random.RandomState(0)
+    s.set_positions(s.get_positions() + rng.standard_normal((len(s), 3)) * 1.5)
+    assert classify_solid.node_function(s, key_max, half) is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit/analysis/test_structure_descriptors.py -v`
+Expected: FAIL (ModuleNotFoundError)
+
+- [ ] **Step 3: Write minimal implementation**
+```python
+# pyiron_workflow_atomistics/analysis/structure_descriptors.py
+"""Common-neighbour-analysis and Voronoi structure descriptors (general)."""
+
+from __future__ import annotations
+
+import operator
+
+import numpy as np
+import pyiron_workflow as pwf
+from structuretoolkit.analyse import (
+    get_adaptive_cna_descriptors,
+    get_voronoi_volumes,
+)
+
+
+@pwf.as_function_node("counts")
+def cna_fractions(structure) -> dict:
+    """Adaptive CNA counts, lowercase keys {'fcc','bcc','hcp','ico','others'}."""
+    counts = get_adaptive_cna_descriptors(
+        structure=structure, mode="total", ovito_compatibility=False
+    )
+    return dict(counts)
+
+
+@pwf.as_function_node("key_max", "n_atoms", "distribution_half")
+def analyse_reference_structure(structure):
+    """Dominant CNA phase, atom count, and half its population fraction.
+
+    ``distribution_half`` is the solid/liquid threshold: a structure counts as
+    *solid* while the dominant-phase fraction stays above this value.
+    """
+    counts = get_adaptive_cna_descriptors(
+        structure=structure, mode="total", ovito_compatibility=False
+    )
+    key_max = max(counts.items(), key=operator.itemgetter(1))[0]
+    n_atoms = len(structure)
+    distribution_half = (counts[key_max] / n_atoms) / 2.0
+    return key_max, n_atoms, distribution_half
+
+
+@pwf.as_function_node("is_solid")
+def classify_solid(structure, key_max: str, distribution_half: float) -> bool:
+    """True if the dominant-phase fraction exceeds ``distribution_half``."""
+    counts = get_adaptive_cna_descriptors(
+        structure=structure, mode="total", ovito_compatibility=False
+    )
+    fraction = counts.get(key_max, 0) / len(structure)
+    return bool(fraction > distribution_half)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit/analysis/test_structure_descriptors.py -v`
+Expected: 4 PASS
+
+- [ ] **Step 5: Commit**
+```bash
+cd /ptmp/hmai/pwa_melting
+git add pyiron_workflow_atomistics/analysis/structure_descriptors.py tests/unit/analysis/test_structure_descriptors.py
+git commit -m "feat(analysis): CNA structure descriptors (fractions, reference, classify)"
+```
+
+---
+
+### Task 3: Voronoi void detection
+
+**Files:**
+- Modify: `pyiron_workflow_atomistics/analysis/structure_descriptors.py`
+- Test: `tests/unit/analysis/test_structure_descriptors.py` (append)
+
+**Interfaces:**
+- Produces:
+  - `voronoi_max_mean(structure) -> tuple[float, float]` → `(max_volume, mean_volume)`
+  - `holes_mask(max_volumes, mean_volumes, factor=2.0) -> list[bool]` (True = no hole)
+
+- [ ] **Step 1: Write the failing test (append)**
+```python
+# append to tests/unit/analysis/test_structure_descriptors.py
+from pyiron_workflow_atomistics.analysis.structure_descriptors import (
+    voronoi_max_mean, holes_mask,
+)
+
+def test_voronoi_max_mean_uniform_fcc():
+    vmax, vmean = voronoi_max_mean.node_function(_fcc_al())
+    assert vmax / vmean < 1.2  # uniform crystal: max ~ mean
+
+def test_holes_mask_flags_large_void():
+    # one entry has max >> 2*mean -> hole (False), others fine (True)
+    keep = holes_mask.node_function([1.0, 1.0, 5.0], [1.0, 1.0, 1.0], factor=2.0)
+    assert keep == [True, True, False]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit/analysis/test_structure_descriptors.py -k voronoi -v`
+Expected: FAIL (ImportError: voronoi_max_mean)
+
+- [ ] **Step 3: Add implementation (append to structure_descriptors.py)**
+```python
+@pwf.as_function_node("max_volume", "mean_volume")
+def voronoi_max_mean(structure):
+    """Max and mean per-atom Voronoi volume (Å^3)."""
+    volumes = get_voronoi_volumes(structure)
+    return float(np.max(volumes)), float(np.mean(volumes))
+
+
+@pwf.as_function_node("keep_mask")
+def holes_mask(max_volumes, mean_volumes, factor: float = 2.0) -> list:
+    """Per-entry True where no cavity: max_volume < factor * mean(mean_volumes)."""
+    threshold = factor * float(np.mean(mean_volumes))
+    return [bool(m < threshold) for m in max_volumes]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit/analysis/test_structure_descriptors.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Update analysis/__init__.py and commit**
+
+Add to `pyiron_workflow_atomistics/analysis/__init__.py` (preserve existing lines):
+```python
+from pyiron_workflow_atomistics.analysis.structure_descriptors import (
+    analyse_reference_structure,
+    classify_solid,
+    cna_fractions,
+    holes_mask,
+    voronoi_max_mean,
+)
+from pyiron_workflow_atomistics.analysis.trajectory import (
+    pressures_from_trajectory,
+    temperatures_from_trajectory,
+)
+```
+```bash
+cd /ptmp/hmai/pwa_melting
+git add pyiron_workflow_atomistics/analysis/structure_descriptors.py pyiron_workflow_atomistics/analysis/__init__.py tests/unit/analysis/test_structure_descriptors.py
+git commit -m "feat(analysis): Voronoi void detection + export analysis quantities"
+```
+
+---
+
+### Task 4: Melting input/output dataclasses
+
+**Files:**
+- Create: `pyiron_workflow_atomistics/physics/melting/__init__.py` (empty placeholder for now)
+- Create: `pyiron_workflow_atomistics/physics/melting/inputs.py`
+- Create: `pyiron_workflow_atomistics/physics/melting/outputs.py`
+- Test: `tests/unit/physics/melting/test_dataclasses.py`
+
+**Interfaces:**
+- Produces: `MeltingInput`, `MeltingIterationRecord`, `MeltingResult` (plain `@dataclass`; `MeltingResult.to_dict()` excludes nothing heavy here).
+
+- [ ] **Step 1: Write the failing test**
+```python
+# tests/unit/physics/melting/test_dataclasses.py
+from pyiron_workflow_atomistics.physics.melting.inputs import MeltingInput
+from pyiron_workflow_atomistics.physics.melting.outputs import (
+    MeltingIterationRecord, MeltingResult,
+)
+
+def test_melting_input_defaults():
+    mi = MeltingInput(element="Al")
+    assert mi.n_atoms == 8000
+    assert mi.timestep_lst == [2.0, 2.0, 1.0]
+    assert mi.convergence_goal == 1.0
+
+def test_melting_result_to_dict():
+    rec = MeltingIterationRecord(temperature_in=900.0, temperature_next=905.0,
+                                 strains=[1.0], ratios=[0.5], pressures=[0.0],
+                                 temperatures=[905.0], converged=True)
+    res = MeltingResult(melting_temperature=905.0, converged=True, n_iterations=1,
+                        element="Al", crystalstructure="fcc", n_atoms=4000,
+                        initial_guess=914.0, iterations=[rec], report={})
+    d = res.to_dict()
+    assert d["melting_temperature"] == 905.0
+    assert len(d["iterations"]) == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit/physics/melting/test_dataclasses.py -v`
+Expected: FAIL (ModuleNotFoundError)
+
+- [ ] **Step 3: Write implementation**
+```python
+# pyiron_workflow_atomistics/physics/melting/__init__.py
+"""Melting-point via the interface/coexistence method."""
+```
+```python
+# pyiron_workflow_atomistics/physics/melting/inputs.py
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class MeltingInput:
+    """Parameters for an interface-method melting-point run (notebook defaults)."""
+
+    element: str
+    crystalstructure: str | None = None      # default: ASE reference state
+    a: float | None = None
+    n_atoms: int = 8000                       # solid cell targets n_atoms/2
+    temperature_left: float = 0.0
+    temperature_right: float = 1000.0
+    convergence_goal: float = 1.0             # K
+    timestep_lst: list[float] = field(default_factory=lambda: [2.0, 2.0, 1.0])
+    fit_range_lst: list[float] = field(default_factory=lambda: [0.05, 0.01, 0.01])
+    nve_steps_lst: list[int] = field(default_factory=lambda: [25000, 20000, 50000])
+    nvt_run_steps: int = 10000
+    npt_run_steps: int = 50000
+    strain_run_steps: int = 1000
+    n_strain_points: int = 21
+    ratio_boundary: float = 0.25
+    boundary_value: float = 0.25
+    delta_t_melt: float = 1000.0              # superheat for interface build
+    seed: int | None = None
+```
+```python
+# pyiron_workflow_atomistics/physics/melting/outputs.py
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields
+from typing import Any
+
+
+@dataclass
+class MeltingIterationRecord:
+    temperature_in: float
+    temperature_next: float
+    strains: list[float]
+    ratios: list[float]
+    pressures: list[float]
+    temperatures: list[float]
+    converged: bool
+
+
+@dataclass
+class MeltingResult:
+    melting_temperature: float
+    converged: bool
+    n_iterations: int
+    element: str
+    crystalstructure: str
+    n_atoms: int
+    initial_guess: float
+    iterations: list[MeltingIterationRecord] = field(default_factory=list)
+    report: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {f.name: getattr(self, f.name) for f in fields(self)}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit/physics/melting/test_dataclasses.py -v`
+Expected: 2 PASS
+
+- [ ] **Step 5: Commit**
+```bash
+cd /ptmp/hmai/pwa_melting
+git add pyiron_workflow_atomistics/physics/melting/__init__.py pyiron_workflow_atomistics/physics/melting/inputs.py pyiron_workflow_atomistics/physics/melting/outputs.py tests/unit/physics/melting/test_dataclasses.py
+git commit -m "feat(melting): MeltingInput/MeltingResult dataclasses"
+```
+
+---
+
+### Task 5: Coexistence structure operations
+
+**Files:**
+- Create: `pyiron_workflow_atomistics/physics/melting/structures.py`
+- Test: `tests/unit/physics/melting/test_structures.py`
+
+**Interfaces:**
+- Produces:
+  - `create_coexistence_supercell(element, crystalstructure=None, a=None, n_atoms=8000) -> Atoms`
+  - `freeze_half(structure, axis=2, fraction=0.5) -> Atoms` (FixAtoms on lower half)
+  - `unfreeze(structure) -> Atoms`
+  - `strain_cell_along_z(structure, strain) -> Atoms`
+
+- [ ] **Step 1: Write the failing test**
+```python
+# tests/unit/physics/melting/test_structures.py
+import numpy as np
+from ase.constraints import FixAtoms
+from pyiron_workflow_atomistics.physics.melting.structures import (
+    create_coexistence_supercell, freeze_half, unfreeze, strain_cell_along_z,
+)
+
+def test_supercell_targets_half_n_atoms():
+    s = create_coexistence_supercell.node_function("Al", "fcc", a=4.05, n_atoms=8000)
+    assert len(s) == 4000  # fcc cubic = 4 atoms; 4*10^3 = 4000 ~ 8000/2
+
+def test_freeze_half_fixes_lower_half():
+    s = create_coexistence_supercell.node_function("Al", "fcc", a=4.05, n_atoms=2000)
+    frozen = freeze_half.node_function(s, axis=2, fraction=0.5)
+    cons = [c for c in frozen.constraints if isinstance(c, FixAtoms)]
+    assert len(cons) == 1
+    fixed = set(cons[0].get_indices())
+    zsc = frozen.get_scaled_positions()[:, 2]
+    expected = set(np.where(zsc < 0.5)[0])
+    assert fixed == expected
+
+def test_unfreeze_clears_constraints():
+    s = create_coexistence_supercell.node_function("Al", "fcc", a=4.05, n_atoms=2000)
+    assert len(unfreeze.node_function(freeze_half.node_function(s)).constraints) == 0
+
+def test_strain_scales_only_c():
+    s = create_coexistence_supercell.node_function("Al", "fcc", a=4.05, n_atoms=2000)
+    c0 = s.cell[2, 2]
+    strained = strain_cell_along_z.node_function(s, 1.05)
+    assert abs(strained.cell[2, 2] - 1.05 * c0) < 1e-8
+    assert abs(strained.cell[0, 0] - s.cell[0, 0]) < 1e-8
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit/physics/melting/test_structures.py -v`
+Expected: FAIL (ModuleNotFoundError)
+
+- [ ] **Step 3: Write implementation**
+```python
+# pyiron_workflow_atomistics/physics/melting/structures.py
+from __future__ import annotations
+
+import numpy as np
+import pyiron_workflow as pwf
+from ase.build import bulk
+from ase.constraints import FixAtoms
+
+
+@pwf.as_function_node("structure")
+def create_coexistence_supercell(element: str, crystalstructure: str | None = None,
+                                 a: float | None = None, n_atoms: int = 8000):
+    """Cubic bulk repeated i×i×i so the atom count is closest to ``n_atoms/2``."""
+    base = bulk(element, crystalstructure, a=a, cubic=True)
+    target = n_atoms / 2.0
+    reps = range(2, 30)
+    cells = [base.repeat((i, i, i)) for i in reps]
+    structure = cells[int(np.argmin([abs(len(c) - target) for c in cells]))]
+    return structure
+
+
+@pwf.as_function_node("structure")
+def freeze_half(structure, axis: int = 2, fraction: float = 0.5):
+    """Fix atoms whose scaled coordinate along ``axis`` is below ``fraction``."""
+    s = structure.copy()
+    scaled = s.get_scaled_positions()[:, axis]
+    s.set_constraint(FixAtoms(indices=np.where(scaled < fraction)[0]))
+    return s
+
+
+@pwf.as_function_node("structure")
+def unfreeze(structure):
+    """Remove all constraints."""
+    s = structure.copy()
+    s.set_constraint()
+    return s
+
+
+@pwf.as_function_node("structure")
+def strain_cell_along_z(structure, strain: float):
+    """Scale cell vector c by ``strain`` (scale_atoms=True)."""
+    s = structure.copy()
+    cell = s.cell.copy()
+    cell[2, 2] *= strain
+    s.set_cell(cell, scale_atoms=True)
+    return s
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit/physics/melting/test_structures.py -v`
+Expected: 4 PASS
+
+- [ ] **Step 5: Commit**
+```bash
+cd /ptmp/hmai/pwa_melting
+git add pyiron_workflow_atomistics/physics/melting/structures.py tests/unit/physics/melting/test_structures.py
+git commit -m "feat(melting): coexistence supercell, freeze/unfreeze, z-strain"
+```
+
+---
+
+### Task 6: Solid-fraction (CNA + KDE)
+
+**Files:**
+- Create: `pyiron_workflow_atomistics/physics/melting/solid_fraction.py`
+- Test: `tests/unit/physics/melting/test_solid_fraction.py`
+
+**Interfaces:**
+- Produces: `solid_fraction_kde(structure, crystalstructure, threshold=0.1) -> float` (0..1)
+
+- [ ] **Step 1: Write the failing test**
+```python
+# tests/unit/physics/melting/test_solid_fraction.py
+import numpy as np
+from ase.build import bulk
+from pyiron_workflow_atomistics.physics.melting.solid_fraction import solid_fraction_kde
+
+def _half_solid_half_liquid():
+    s = bulk("Al", "fcc", a=4.05, cubic=True).repeat((4, 4, 8))  # long in z
+    z = s.get_scaled_positions()[:, 2]
+    upper = np.where(z >= 0.5)[0]
+    rng = np.random.RandomState(0)
+    pos = s.get_positions()
+    pos[upper] += rng.standard_normal((len(upper), 3)) * 1.6  # melt upper half
+    s.set_positions(pos)
+    return s
+
+def test_full_solid_ratio_near_one():
+    s = bulk("Al", "fcc", a=4.05, cubic=True).repeat((4, 4, 8))
+    assert solid_fraction_kde.node_function(s, "fcc") > 0.9
+
+def test_half_solid_ratio_near_half():
+    frac = solid_fraction_kde.node_function(_half_solid_half_liquid(), "fcc")
+    assert 0.3 < frac < 0.7
+
+def test_all_liquid_ratio_zero():
+    s = bulk("Al", "fcc", a=4.05, cubic=True).repeat((4, 4, 8))
+    rng = np.random.RandomState(1)
+    s.set_positions(s.get_positions() + rng.standard_normal((len(s), 3)) * 2.0)
+    assert solid_fraction_kde.node_function(s, "fcc") == 0.0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit/physics/melting/test_solid_fraction.py -v`
+Expected: FAIL (ModuleNotFoundError)
+
+- [ ] **Step 3: Write implementation**
+```python
+# pyiron_workflow_atomistics/physics/melting/solid_fraction.py
+from __future__ import annotations
+
+import numpy as np
+import pyiron_workflow as pwf
+from sklearn.neighbors import KernelDensity
+from structuretoolkit.analyse import get_adaptive_cna_descriptors
+
+
+@pwf.as_function_node("solid_fraction")
+def solid_fraction_kde(structure, crystalstructure: str, threshold: float = 0.1) -> float:
+    """Fraction of the z-extent occupied by the crystalline phase.
+
+    Per-atom CNA labels the target phase; a 1-D KDE of those atoms' z-positions
+    gives the solid slab width relative to the cell. Mirrors the interface
+    method's ``plot_solid_liquid_ratio`` (minus plotting).
+    """
+    target = crystalstructure.lower()
+    labels = np.array(
+        get_adaptive_cna_descriptors(structure=structure, mode="str",
+                                     ovito_compatibility=False)
+    )
+    z = structure.get_positions()[:, 2]
+    mask = labels == target
+    if mask.sum() <= 0.05 * len(structure):
+        return 0.0
+    bandwidth = (structure.get_volume() / len(structure)) ** (1.0 / 3.0)
+    kde = KernelDensity(kernel="gaussian", bandwidth=bandwidth).fit(z[mask].reshape(-1, 1))
+    grid = np.linspace(z.min(), z.max(), 1000)
+    g = np.exp(kde.score_samples(grid.reshape(-1, 1)))
+    g = g / g.max()
+    above = grid[g > threshold]
+    below = grid[g < threshold]
+    span = grid.max() - grid.min()
+    ratio_above = (above.max() - above.min()) / span if len(above) else 1.0
+    ratio_below = 1.0 - (below.max() - below.min()) / span if len(below) else 0.0
+    if ratio_below == 0.0:
+        ratio = ratio_above
+    elif ratio_above == 1.0:
+        ratio = ratio_below
+    else:
+        ratio = min(ratio_below, ratio_above)
+    return float(ratio)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit/physics/melting/test_solid_fraction.py -v`
+Expected: 3 PASS (if `test_half_solid_ratio_near_half` is borderline, widen the rattle to 2.0 — the boundary is physical, not a code bug)
+
+- [ ] **Step 5: Commit**
+```bash
+cd /ptmp/hmai/pwa_melting
+git add pyiron_workflow_atomistics/physics/melting/solid_fraction.py tests/unit/physics/melting/test_solid_fraction.py
+git commit -m "feat(melting): KDE solid-fraction from per-atom CNA"
+```
+
+---
+
+### Task 7: Coexistence fitting (ratio selection + T(P=0) extrapolation)
+
+**Files:**
+- Create: `pyiron_workflow_atomistics/physics/melting/fitting.py`
+- Test: `tests/unit/physics/melting/test_fitting.py`
+
+**Interfaces:**
+- Produces:
+  - `ratio_selection(strains, ratios, pressures, temperatures, ratio_boundary=0.25) -> tuple[list, list, list, list, int]` → `(sel_strains, sel_ratios, sel_pressures, sel_temperatures, sl_flag)`
+  - `predict_melting_point(strains, pressures, temperatures, boundary_value=0.25) -> tuple[float, float, float, float]` → `(t_next, t_mean, t_left, t_right)`
+
+- [ ] **Step 1: Write the failing test**
+```python
+# tests/unit/physics/melting/test_fitting.py
+from pyiron_workflow_atomistics.physics.melting.fitting import (
+    ratio_selection, predict_melting_point,
+)
+
+def test_ratio_selection_picks_coexistence_window():
+    strains = [0.96, 0.98, 1.00, 1.02, 1.04]
+    ratios = [0.05, 0.45, 0.50, 0.55, 0.95]   # middle three near 0.5
+    pressures = [2.0, 1.0, 0.0, -1.0, -2.0]
+    temps = [900, 905, 910, 915, 920]
+    ss, rr, pp, tt, flag = ratio_selection.node_function(
+        strains, ratios, pressures, temps, ratio_boundary=0.25)
+    assert list(ss) == [0.98, 1.00, 1.02]
+    assert flag in (1, -1)
+
+def test_predict_melting_point_extrapolates_to_zero_pressure():
+    # T = 910 + 250*P  => T(P=0) = 910; P linear in strain
+    strains = [0.98, 1.00, 1.02]
+    pressures = [1.0, 0.0, -1.0]
+    temps = [910 + 250 * p for p in pressures]
+    t_next, t_mean, t_left, t_right = predict_melting_point.node_function(
+        strains, pressures, temps, boundary_value=0.25)
+    assert abs(t_next - 910.0) < 1e-6
+    assert t_left < t_mean < t_right
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit/physics/melting/test_fitting.py -v`
+Expected: FAIL (ModuleNotFoundError)
+
+- [ ] **Step 3: Write implementation**
+```python
+# pyiron_workflow_atomistics/physics/melting/fitting.py
+from __future__ import annotations
+
+import numpy as np
+import pyiron_workflow as pwf
+
+
+@pwf.as_function_node("strains", "ratios", "pressures", "temperatures", "sl_flag")
+def ratio_selection(strains, ratios, pressures, temperatures, ratio_boundary: float = 0.25):
+    """Keep the longest contiguous strain window with ratio in 0.5±boundary.
+
+    ``sl_flag`` is +1 if the selected window is mostly solid (>0.5), else -1.
+    """
+    groups, current = [], []
+    for r in ratios:
+        if (0.5 - ratio_boundary) < r < (0.5 + ratio_boundary):
+            current.append(r)
+        elif current:
+            groups.append(current)
+            current = []
+    if current:
+        groups.append(current)
+    if not groups:
+        flag = 1 if np.mean(ratios) > 0.5 else -1
+        return [], [], [], [], flag
+    best = groups[int(np.argmax([len(g) for g in groups]))]
+    keep = [r in best for r in ratios]
+    sel_r = np.array(ratios)[keep]
+    flag = 1 if np.mean(sel_r) > 0.5 else -1
+    return (
+        np.array(strains)[keep].tolist(),
+        sel_r.tolist(),
+        np.array(pressures)[keep].tolist(),
+        np.array(temperatures)[keep].tolist(),
+        flag,
+    )
+
+
+@pwf.as_function_node("t_next", "t_mean", "t_left", "t_right")
+def predict_melting_point(strains, pressures, temperatures, boundary_value: float = 0.25):
+    """Extrapolate temperature to zero pressure; bracket via boundary_value."""
+    fit_temp_from_press = np.poly1d(np.polyfit(pressures, temperatures, 1))
+    t_next = float(fit_temp_from_press(0.0))
+    t_min, t_max = float(np.min(temperatures)), float(np.max(temperatures))
+    span = t_max - t_min
+    t_mean = t_min + span * 0.5
+    t_left = t_min + span * (0.5 - boundary_value)
+    t_right = t_min + span * (0.5 + boundary_value)
+    return t_next, t_mean, t_left, t_right
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit/physics/melting/test_fitting.py -v`
+Expected: 2 PASS
+
+- [ ] **Step 5: Commit**
+```bash
+cd /ptmp/hmai/pwa_melting
+git add pyiron_workflow_atomistics/physics/melting/fitting.py tests/unit/physics/melting/test_fitting.py
+git commit -m "feat(melting): ratio selection + T(P=0) melting-point extrapolation"
+```
+
+---
+
+### Task 8: ASE NPT robustness (verify/patch compressibility wiring)
+
+**Files:**
+- Modify (if needed): `pyiron_workflow_atomistics/engine/ase.py` (NPT-Berendsen branch)
+- Test: `tests/integration/test_ase_npt_metal.py`
+
+**Interfaces:**
+- Consumes: `ASEEngine`, `CalcInputMD(mode="NPT", thermostat="berendsen", compressibility=...)`.
+- Produces: a confirmed-working NPT path that respects `CalcInputMD.compressibility`.
+
+- [ ] **Step 1: Write the failing test**
+```python
+# tests/integration/test_ase_npt_metal.py
+import pytest
+from ase.build import bulk
+from ase.calculators.emt import EMT
+from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputMD, calculate
+
+@pytest.mark.slow
+def test_npt_berendsen_metal_runs(tmp_path):
+    atoms = bulk("Al", "fcc", a=4.05, cubic=True).repeat((3, 3, 3))
+    md = CalcInputMD(mode="NPT", thermostat="berendsen", temperature=300.0,
+                     pressure=0.0, n_ionic_steps=20, n_print=5, time_step=2.0,
+                     thermostat_time_constant=100.0, pressure_damping_timescale=1000.0,
+                     compressibility=1e-6, seed=1, initial_temperature=600.0)
+    eng = ASEEngine(EngineInput=md, calculator=EMT(), working_directory=str(tmp_path))
+    out = calculate.node_function(atoms, engine=eng)
+    assert out.converged is True
+    assert out.structures and out.structures[-1].get_temperature() > 0
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/integration/test_ase_npt_metal.py -v -m slow`
+Expected: PASS, OR fail with a `NPTBerendsen` compressibility/argument error.
+
+- [ ] **Step 3: If it failed, patch `engine/ase.py`**
+
+In the `md_input.mode == "NPT"` / `thermostat == "berendsen"` branch, ensure compressibility is forwarded:
+```python
+dyn = NPTBerendsen(
+    atoms, dt, temperature_K=T, pressure_au=P_bar,
+    taut=ttime, taup=taup,
+    compressibility_au=md_input.compressibility / (1.0 / units.bar),
+)
+```
+(If the running ASE `NPTBerendsen` signature uses `compressibility` rather than `compressibility_au`, use that name; confirm via `python -c "import ase.md.nptberendsen, inspect; print(inspect.signature(ase.md.nptberendsen.NPTBerendsen.__init__))"`. Convert `CalcInputMD.compressibility` (bar⁻¹) to ASE units accordingly. If already passing, skip this step.)
+
+- [ ] **Step 4: Re-run to verify pass**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/integration/test_ase_npt_metal.py -v -m slow`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+```bash
+cd /ptmp/hmai/pwa_melting
+git add tests/integration/test_ase_npt_metal.py pyiron_workflow_atomistics/engine/ase.py
+git commit -m "test(engine): NPT-Berendsen metal smoke + honour CalcInputMD.compressibility"
+```
+
+---
+
+### Task 9: MD step drivers (engine-agnostic)
+
+**Files:**
+- Create: `pyiron_workflow_atomistics/physics/melting/md_steps.py`
+- Test: `tests/integration/test_melting_md_steps.py`
+
+**Interfaces:**
+- Consumes: `calculate`, `CalcInputMD` (engine), `strain_cell_along_z`, `freeze_half`, `unfreeze`, `temperatures_from_trajectory`, `pressures_from_trajectory`, `solid_fraction_kde`, `voronoi_max_mean`.
+- Produces:
+  - `with_calc_input(engine, calc_input) -> Engine`
+  - `npt_relax_solid(structure, engine, temperature, n_steps=10000, timestep=2.0, seed=None, subdir="npt_solid") -> tuple[Atoms, EngineOutput]`
+  - `build_solid_liquid_interface(structure, engine, t_solid, t_liquid, n_steps=10000, timestep=2.0, seed=None, subdir="interface") -> Atoms`
+  - `strain_scan_nvt_nve(structure, engine, temperature, strains, crystalstructure, nvt_steps=10000, nve_steps=20000, timestep=2.0, seed=None, last_n=20, subdir="strain") -> list[dict]` — each dict: `{strain, mean_T, mean_P, solid_fraction, voronoi_max, voronoi_mean}`
+
+- [ ] **Step 1: Write the failing test**
+```python
+# tests/integration/test_melting_md_steps.py
+import pytest
+from ase.build import bulk
+from ase.calculators.emt import EMT
+from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+from pyiron_workflow_atomistics.physics.melting.md_steps import (
+    npt_relax_solid, build_solid_liquid_interface, strain_scan_nvt_nve,
+)
+
+def _engine(tmp_path):
+    return ASEEngine(EngineInput=CalcInputStatic(), calculator=EMT(),
+                     working_directory=str(tmp_path))
+
+@pytest.mark.slow
+def test_npt_relax_solid_returns_structure(tmp_path):
+    s = bulk("Al", "fcc", a=4.05, cubic=True).repeat((3, 3, 3))
+    struct, out = npt_relax_solid.node_function(
+        s, _engine(tmp_path), temperature=300.0, n_steps=20, timestep=2.0, seed=1)
+    assert len(struct) == len(s)
+    assert out.converged is True
+
+@pytest.mark.slow
+def test_strain_scan_returns_records(tmp_path):
+    s = bulk("Al", "fcc", a=4.05, cubic=True).repeat((3, 3, 6))
+    recs = strain_scan_nvt_nve.node_function(
+        s, _engine(tmp_path), temperature=300.0, strains=[0.99, 1.01],
+        crystalstructure="fcc", nvt_steps=20, nve_steps=20, timestep=2.0, seed=1)
+    assert len(recs) == 2
+    for r in recs:
+        assert set(r) >= {"strain", "mean_T", "mean_P", "solid_fraction",
+                          "voronoi_max", "voronoi_mean"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/integration/test_melting_md_steps.py -v -m slow`
+Expected: FAIL (ModuleNotFoundError)
+
+- [ ] **Step 3: Write implementation**
+```python
+# pyiron_workflow_atomistics/physics/melting/md_steps.py
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pyiron_workflow as pwf
+from pyiron_workflow_atomistics.engine import CalcInputMD, calculate
+from pyiron_workflow_atomistics.analysis.trajectory import (
+    pressures_from_trajectory, temperatures_from_trajectory,
+)
+from pyiron_workflow_atomistics.physics.melting.solid_fraction import solid_fraction_kde
+from pyiron_workflow_atomistics.analysis.structure_descriptors import voronoi_max_mean
+from pyiron_workflow_atomistics.physics.melting.structures import (
+    freeze_half, strain_cell_along_z, unfreeze,
+)
+
+
+def _engine_with(engine, calc_input, subdir):
+    return replace(engine, EngineInput=calc_input).with_working_directory(subdir)
+
+
+@pwf.as_function_node("engine_out")
+def with_calc_input(engine, calc_input):
+    return replace(engine, EngineInput=calc_input)
+
+
+@pwf.as_function_node("relaxed_structure", "engine_output")
+def npt_relax_solid(structure, engine, temperature, n_steps=10000, timestep=2.0,
+                    seed=None, subdir="npt_solid"):
+    md = CalcInputMD(mode="NPT", thermostat="berendsen", temperature=temperature,
+                     pressure=0.0, n_ionic_steps=n_steps,
+                     n_print=max(1, n_steps // 100), time_step=timestep,
+                     initial_temperature=2.0 * temperature, seed=seed,
+                     compressibility=1e-6)
+    out = calculate.node_function(structure, engine=_engine_with(engine, md, subdir))
+    return out.final_structure, out
+
+
+@pwf.as_function_node("interface_structure")
+def build_solid_liquid_interface(structure, engine, t_solid, t_liquid,
+                                 n_steps=10000, timestep=2.0, seed=None,
+                                 subdir="interface"):
+    """Freeze lower half, melt upper half at t_liquid (NVT), recool to t_solid."""
+    frozen = freeze_half.node_function(structure)
+    melt_md = CalcInputMD(mode="NVT", thermostat="langevin", temperature=t_liquid,
+                          n_ionic_steps=n_steps, n_print=max(1, n_steps // 100),
+                          time_step=timestep, initial_temperature=2.0 * t_liquid, seed=seed)
+    melted = calculate.node_function(
+        frozen, engine=_engine_with(engine, melt_md, f"{subdir}_melt")).final_structure
+    cool_md = CalcInputMD(mode="NVT", thermostat="langevin", temperature=t_solid,
+                          n_ionic_steps=n_steps, n_print=max(1, n_steps // 100),
+                          time_step=timestep, initial_temperature=2.0 * t_solid, seed=seed)
+    cooled = calculate.node_function(
+        melted, engine=_engine_with(engine, cool_md, f"{subdir}_cool")).final_structure
+    return unfreeze.node_function(cooled)
+
+
+@pwf.as_function_node("records")
+def strain_scan_nvt_nve(structure, engine, temperature, strains, crystalstructure,
+                        nvt_steps=10000, nve_steps=20000, timestep=2.0, seed=None,
+                        last_n=20, subdir="strain"):
+    records = []
+    for i, strain in enumerate(strains):
+        strained = strain_cell_along_z.node_function(structure, strain)
+        nvt_md = CalcInputMD(mode="NVT", thermostat="langevin", temperature=temperature,
+                             n_ionic_steps=nvt_steps, n_print=max(1, nvt_steps // 100),
+                             time_step=timestep, initial_temperature=2.0 * temperature,
+                             seed=seed)
+        equil = calculate.node_function(
+            strained, engine=_engine_with(engine, nvt_md, f"{subdir}_nvt_{i:03d}")
+        ).final_structure
+        nve_md = CalcInputMD(mode="NVE", temperature=temperature,
+                             n_ionic_steps=nve_steps, n_print=max(1, nve_steps // 100),
+                             time_step=timestep, initial_temperature=2.0 * temperature,
+                             seed=seed)
+        nve_out = calculate.node_function(
+            equil, engine=_engine_with(engine, nve_md, f"{subdir}_nve_{i:03d}"))
+        vmax, vmean = voronoi_max_mean.node_function(nve_out.final_structure)
+        records.append({
+            "strain": strain,
+            "mean_T": temperatures_from_trajectory.node_function(nve_out, last_n=last_n),
+            "mean_P": pressures_from_trajectory.node_function(nve_out, last_n=last_n),
+            "solid_fraction": solid_fraction_kde.node_function(
+                nve_out.final_structure, crystalstructure),
+            "voronoi_max": vmax,
+            "voronoi_mean": vmean,
+        })
+    return records
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/integration/test_melting_md_steps.py -v -m slow`
+Expected: 2 PASS
+
+- [ ] **Step 5: Commit**
+```bash
+cd /ptmp/hmai/pwa_melting
+git add pyiron_workflow_atomistics/physics/melting/md_steps.py tests/integration/test_melting_md_steps.py
+git commit -m "feat(melting): engine-agnostic MD step drivers (npt solid, interface, strain scan)"
+```
+
+---
+
+### Task 10: Step 1 — initial melting-temperature guess (bisection)
+
+**Files:**
+- Create: `pyiron_workflow_atomistics/physics/melting/initial_guess.py`
+- Test: `tests/integration/test_melting_initial_guess.py`
+
+**Interfaces:**
+- Consumes: `calculate`, `CalcInputMD`, `cna_fractions`.
+- Produces: `estimate_melting_temperature(structure, engine, key_max, distribution_half, crystalstructure, temperature_left=0.0, temperature_right=1000.0, strain_run_steps=1000, timestep=2.0, seed=None, t_step_min=10.0, subdir="guess") -> tuple[int, Atoms]` → `(t_guess, structure_at_guess)`
+
+- [ ] **Step 1: Write the failing test**
+```python
+# tests/integration/test_melting_initial_guess.py
+import pytest
+from ase.build import bulk
+from ase.calculators.emt import EMT
+from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+from pyiron_workflow_atomistics.analysis.structure_descriptors import analyse_reference_structure
+from pyiron_workflow_atomistics.physics.melting.initial_guess import estimate_melting_temperature
+
+@pytest.mark.slow
+def test_initial_guess_brackets_a_temperature(tmp_path):
+    s = bulk("Al", "fcc", a=4.05, cubic=True).repeat((3, 3, 3))
+    key_max, _, half = analyse_reference_structure.node_function(s)
+    eng = ASEEngine(EngineInput=CalcInputStatic(), calculator=EMT(),
+                    working_directory=str(tmp_path))
+    t_guess, struct = estimate_melting_temperature.node_function(
+        s, eng, key_max=key_max, distribution_half=half, crystalstructure="fcc",
+        temperature_left=0.0, temperature_right=1400.0, strain_run_steps=40,
+        timestep=2.0, seed=1, t_step_min=200.0)  # coarse for speed
+    assert 0.0 <= t_guess <= 1400.0
+    assert len(struct) == len(s)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/integration/test_melting_initial_guess.py -v -m slow`
+Expected: FAIL (ModuleNotFoundError)
+
+- [ ] **Step 3: Write implementation**
+```python
+# pyiron_workflow_atomistics/physics/melting/initial_guess.py
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pyiron_workflow as pwf
+from pyiron_workflow_atomistics.engine import CalcInputMD, calculate
+from pyiron_workflow_atomistics.analysis.structure_descriptors import cna_fractions
+
+
+def _fraction(structure, key_max):
+    counts = cna_fractions.node_function(structure)
+    return counts.get(key_max, 0) / len(structure)
+
+
+@pwf.as_function_node("t_guess", "structure")
+def estimate_melting_temperature(structure, engine, key_max, distribution_half,
+                                 crystalstructure, temperature_left=0.0,
+                                 temperature_right=1000.0, strain_run_steps=1000,
+                                 timestep=2.0, seed=None, t_step_min=10.0,
+                                 subdir="guess"):
+    """Bisection: heat the bulk solid in NPT; raise T while it stays crystalline.
+
+    Port of ``get_initial_melting_temperature_guess`` + ``next_step_funct``.
+    """
+    def heated(temperature):
+        md = CalcInputMD(mode="NPT", thermostat="berendsen", temperature=temperature,
+                         pressure=0.0, n_ionic_steps=strain_run_steps,
+                         n_print=max(1, strain_run_steps // 10), time_step=timestep,
+                         initial_temperature=2.0 * temperature, seed=seed,
+                         compressibility=1e-6)
+        tag = f"{subdir}_{int(round(temperature))}"
+        eng = replace(engine, EngineInput=md).with_working_directory(tag)
+        return calculate.node_function(structure, engine=eng).final_structure
+
+    t_left, t_right = temperature_left, temperature_right
+    struct_left = structure
+    struct_right = heated(t_right)
+    step = t_right - t_left
+    while step > t_step_min:
+        f_left = _fraction(struct_left, key_max)
+        f_right = _fraction(struct_right, key_max)
+        diff = t_right - t_left
+        if f_left > distribution_half and f_right > distribution_half:
+            struct_left, t_left = struct_right.copy(), t_right
+            t_right += diff
+            struct_right = heated(t_right)
+        elif f_left > distribution_half >= f_right:
+            diff /= 2.0
+            t_left += diff
+            struct_left = heated(t_left)
+        else:  # both molten
+            diff /= 2.0
+            t_right, struct_right = t_left, struct_left.copy()
+            t_left -= diff
+            struct_left = heated(t_left)
+        step = t_right - t_left
+    return int(round(t_left)), struct_left
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/integration/test_melting_initial_guess.py -v -m slow`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+```bash
+cd /ptmp/hmai/pwa_melting
+git add pyiron_workflow_atomistics/physics/melting/initial_guess.py tests/integration/test_melting_initial_guess.py
+git commit -m "feat(melting): Step 1 initial melting-temperature bisection"
+```
+
+---
+
+### Task 11: Step 2 — coexistence iteration + convergence loop
+
+**Files:**
+- Create: `pyiron_workflow_atomistics/physics/melting/coexistence.py`
+- Test: `tests/integration/test_melting_coexistence.py`
+
+**Interfaces:**
+- Consumes: `npt_relax_solid`, `build_solid_liquid_interface`, `strain_scan_nvt_nve`, `ratio_selection`, `predict_melting_point`, `holes_mask`, `MeltingIterationRecord`.
+- Produces:
+  - `coexistence_iteration(structure, engine, temperature, crystalstructure, fit_range, n_strain_points, nvt_steps, nve_steps, npt_steps, timestep, delta_t_melt, ratio_boundary, boundary_value, seed, subdir) -> MeltingIterationRecord`
+  - `refine_melting_point(structure, engine, t_guess, melting_input, crystalstructure) -> MeltingResult`
+
+- [ ] **Step 1: Write the failing test**
+```python
+# tests/integration/test_melting_coexistence.py
+import pytest
+from ase.build import bulk
+from ase.calculators.emt import EMT
+from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+from pyiron_workflow_atomistics.physics.melting.coexistence import coexistence_iteration
+
+@pytest.mark.slow
+def test_one_coexistence_iteration_runs(tmp_path):
+    s = bulk("Al", "fcc", a=4.05, cubic=True).repeat((3, 3, 6))
+    eng = ASEEngine(EngineInput=CalcInputStatic(), calculator=EMT(),
+                    working_directory=str(tmp_path))
+    rec = coexistence_iteration.node_function(
+        s, eng, temperature=900.0, crystalstructure="fcc", fit_range=0.05,
+        n_strain_points=5, nvt_steps=20, nve_steps=20, npt_steps=20, timestep=2.0,
+        delta_t_melt=1000.0, ratio_boundary=0.4, boundary_value=0.25, seed=1,
+        subdir="iter0")
+    assert rec.temperature_in == 900.0
+    assert isinstance(rec.temperature_next, float)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/integration/test_melting_coexistence.py -v -m slow`
+Expected: FAIL (ModuleNotFoundError)
+
+- [ ] **Step 3: Write implementation**
+```python
+# pyiron_workflow_atomistics/physics/melting/coexistence.py
+from __future__ import annotations
+
+import numpy as np
+import pyiron_workflow as pwf
+from pyiron_workflow_atomistics.analysis.structure_descriptors import holes_mask
+from pyiron_workflow_atomistics.physics.melting.fitting import (
+    predict_melting_point, ratio_selection,
+)
+from pyiron_workflow_atomistics.physics.melting.md_steps import (
+    build_solid_liquid_interface, npt_relax_solid, strain_scan_nvt_nve,
+)
+from pyiron_workflow_atomistics.physics.melting.outputs import (
+    MeltingIterationRecord, MeltingResult,
+)
+
+
+def _strain_grid(center, fit_range, n_points):
+    return [round(float(s), 4)
+            for s in np.linspace(center - fit_range, center + fit_range, n_points)]
+
+
+@pwf.as_function_node("record")
+def coexistence_iteration(structure, engine, temperature, crystalstructure,
+                          fit_range=0.05, n_strain_points=21, nvt_steps=10000,
+                          nve_steps=20000, npt_steps=50000, timestep=2.0,
+                          delta_t_melt=1000.0, ratio_boundary=0.25,
+                          boundary_value=0.25, seed=None, subdir="iter"):
+    """One interface-method temperature iteration → next-T estimate."""
+    solid, _ = npt_relax_solid.node_function(
+        structure, engine, temperature=temperature, n_steps=npt_steps,
+        timestep=timestep, seed=seed, subdir=f"{subdir}_npt")
+    interface = build_solid_liquid_interface.node_function(
+        solid, engine, t_solid=temperature, t_liquid=temperature + delta_t_melt,
+        n_steps=npt_steps, timestep=timestep, seed=seed, subdir=f"{subdir}_iface")
+    strains = _strain_grid(1.0, fit_range, n_strain_points)
+    records = strain_scan_nvt_nve.node_function(
+        interface, engine, temperature=temperature, strains=strains,
+        crystalstructure=crystalstructure, nvt_steps=nvt_steps, nve_steps=nve_steps,
+        timestep=timestep, seed=seed, subdir=f"{subdir}_strain")
+    ratios = [r["solid_fraction"] for r in records]
+    pressures = [r["mean_P"] for r in records]
+    temps = [r["mean_T"] for r in records]
+    sel_s, sel_r, sel_p, sel_t, flag = ratio_selection.node_function(
+        strains, ratios, pressures, temps, ratio_boundary=ratio_boundary)
+    if len(sel_s) > 2:
+        sel_index = [strains.index(s) for s in sel_s]
+        vmax = [records[i]["voronoi_max"] for i in sel_index]
+        vmean = [records[i]["voronoi_mean"] for i in sel_index]
+        keep = holes_mask.node_function(vmax, vmean, factor=2.0)
+        sel_s = [s for s, k in zip(sel_s, keep) if k]
+        sel_p = [p for p, k in zip(sel_p, keep) if k]
+        sel_t = [t for t, k in zip(sel_t, keep) if k]
+    if len(sel_s) > 2:
+        t_next, _, _, _ = predict_melting_point.node_function(
+            sel_s, sel_p, sel_t, boundary_value=boundary_value)
+    else:
+        t_next = temperature * (1.10 if flag > 0 else 0.90)
+    return MeltingIterationRecord(
+        temperature_in=float(temperature), temperature_next=float(t_next),
+        strains=list(strains), ratios=list(ratios), pressures=list(pressures),
+        temperatures=list(temps), converged=False)
+
+
+@pwf.as_function_node("result")
+def refine_melting_point(structure, engine, t_guess, melting_input, crystalstructure):
+    """Convergence loop over the refinement schedules until |ΔT| ≤ goal."""
+    mi = melting_input
+    schedules = list(zip(mi.timestep_lst, mi.fit_range_lst, mi.nve_steps_lst))
+    temperature = float(t_guess)
+    iterations: list[MeltingIterationRecord] = []
+    converged = False
+    for step_idx, (timestep, fit_range, nve_steps) in enumerate(schedules):
+        rec = coexistence_iteration.node_function(
+            structure, engine, temperature=temperature,
+            crystalstructure=crystalstructure, fit_range=fit_range,
+            n_strain_points=mi.n_strain_points, nvt_steps=mi.nvt_run_steps,
+            nve_steps=nve_steps, npt_steps=mi.npt_run_steps, timestep=timestep,
+            delta_t_melt=mi.delta_t_melt, ratio_boundary=mi.ratio_boundary,
+            boundary_value=mi.boundary_value, seed=mi.seed, subdir=f"iter_{step_idx}")
+        iterations.append(rec)
+        if abs(rec.temperature_next - temperature) <= mi.convergence_goal:
+            converged = True
+            temperature = rec.temperature_next
+            break
+        temperature = rec.temperature_next
+    return MeltingResult(
+        melting_temperature=float(temperature), converged=converged,
+        n_iterations=len(iterations), element=mi.element,
+        crystalstructure=crystalstructure, n_atoms=len(structure),
+        initial_guess=float(t_guess), iterations=iterations,
+        report={"schedules": schedules})
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/integration/test_melting_coexistence.py -v -m slow`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+```bash
+cd /ptmp/hmai/pwa_melting
+git add pyiron_workflow_atomistics/physics/melting/coexistence.py tests/integration/test_melting_coexistence.py
+git commit -m "feat(melting): Step 2 coexistence iteration + convergence loop"
+```
+
+---
+
+### Task 12: Top-level macro + public API
+
+**Files:**
+- Create: `pyiron_workflow_atomistics/physics/melting/study.py`
+- Modify: `pyiron_workflow_atomistics/physics/melting/__init__.py`
+- Test: `tests/integration/test_melting_study.py`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: `calculate_melting_point(engine, melting_input) -> MeltingResult` (callable as `@pwf.as_function_node` driver returning a `MeltingResult`).
+
+- [ ] **Step 1: Write the failing test**
+```python
+# tests/integration/test_melting_study.py
+import pytest
+from ase.calculators.emt import EMT
+from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+from pyiron_workflow_atomistics.physics.melting import (
+    MeltingInput, calculate_melting_point,
+)
+
+@pytest.mark.slow
+def test_calculate_melting_point_end_to_end(tmp_path):
+    mi = MeltingInput(element="Al", crystalstructure="fcc", a=4.05, n_atoms=500,
+                      temperature_right=1400.0, strain_run_steps=40,
+                      timestep_lst=[2.0], fit_range_lst=[0.05], nve_steps_lst=[20],
+                      nvt_run_steps=20, npt_run_steps=20, n_strain_points=5,
+                      ratio_boundary=0.4, seed=1)
+    eng = ASEEngine(EngineInput=CalcInputStatic(), calculator=EMT(),
+                    working_directory=str(tmp_path))
+    res = calculate_melting_point.node_function(eng, mi)
+    assert res.element == "Al"
+    assert res.initial_guess >= 0
+    assert isinstance(res.melting_temperature, float)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/integration/test_melting_study.py -v -m slow`
+Expected: FAIL (ImportError: calculate_melting_point)
+
+- [ ] **Step 3: Write implementation**
+```python
+# pyiron_workflow_atomistics/physics/melting/study.py
+from __future__ import annotations
+
+import pyiron_workflow as pwf
+from ase.data import atomic_numbers, reference_states
+from pyiron_workflow_atomistics.engine import CalcInputMinimize, calculate
+from dataclasses import replace
+from pyiron_workflow_atomistics.analysis.structure_descriptors import (
+    analyse_reference_structure,
+)
+from pyiron_workflow_atomistics.physics.melting.coexistence import refine_melting_point
+from pyiron_workflow_atomistics.physics.melting.initial_guess import (
+    estimate_melting_temperature,
+)
+from pyiron_workflow_atomistics.physics.melting.structures import (
+    create_coexistence_supercell,
+)
+
+
+def _default_crystalstructure(element):
+    return reference_states[atomic_numbers[element]]["symmetry"]
+
+
+@pwf.as_function_node("result")
+def calculate_melting_point(engine, melting_input):
+    """Full interface-method melting point: build → relax → Step 1 → Step 2."""
+    mi = melting_input
+    crystalstructure = mi.crystalstructure or _default_crystalstructure(mi.element)
+    structure = create_coexistence_supercell.node_function(
+        mi.element, crystalstructure, a=mi.a, n_atoms=mi.n_atoms)
+    relax_engine = replace(
+        engine, EngineInput=CalcInputMinimize(relax_cell=True)
+    ).with_working_directory("minimize")
+    relaxed = calculate.node_function(structure, engine=relax_engine).final_structure
+    key_max, _, distribution_half = analyse_reference_structure.node_function(relaxed)
+    t_guess, struct_at_guess = estimate_melting_temperature.node_function(
+        relaxed, engine, key_max=key_max, distribution_half=distribution_half,
+        crystalstructure=crystalstructure, temperature_left=mi.temperature_left,
+        temperature_right=mi.temperature_right, strain_run_steps=mi.strain_run_steps,
+        timestep=mi.timestep_lst[0], seed=mi.seed)
+    result = refine_melting_point.node_function(
+        struct_at_guess, engine, t_guess=t_guess, melting_input=mi,
+        crystalstructure=crystalstructure)
+    return result
+```
+Then set `pyiron_workflow_atomistics/physics/melting/__init__.py`:
+```python
+"""Melting-point via the interface/coexistence method."""
+
+from pyiron_workflow_atomistics.physics.melting.coexistence import (
+    coexistence_iteration,
+    refine_melting_point,
+)
+from pyiron_workflow_atomistics.physics.melting.initial_guess import (
+    estimate_melting_temperature,
+)
+from pyiron_workflow_atomistics.physics.melting.inputs import MeltingInput
+from pyiron_workflow_atomistics.physics.melting.outputs import (
+    MeltingIterationRecord,
+    MeltingResult,
+)
+from pyiron_workflow_atomistics.physics.melting.study import calculate_melting_point
+
+__all__ = [
+    "MeltingInput",
+    "MeltingIterationRecord",
+    "MeltingResult",
+    "calculate_melting_point",
+    "coexistence_iteration",
+    "estimate_melting_temperature",
+    "refine_melting_point",
+]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/integration/test_melting_study.py -v -m slow`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+```bash
+cd /ptmp/hmai/pwa_melting
+git add pyiron_workflow_atomistics/physics/melting/study.py pyiron_workflow_atomistics/physics/melting/__init__.py tests/integration/test_melting_study.py
+git commit -m "feat(melting): top-level calculate_melting_point + public API"
+```
+
+---
+
+### Task 13: LAMMPS velocity-capture patch (in pwl_dev)
+
+**Files:**
+- Modify: `/ptmp/hmai/pwl_dev/pyiron_workflow_lammps/lammps.py` (`arrays_to_ase_atoms`, `parse_LammpsOutput`)
+- Test: `/ptmp/hmai/pwl_dev/tests/unit/test_velocity_capture.py`
+
+**Interfaces:**
+- Produces: trajectory `Atoms` in `EngineOutput.structures` carry per-atom velocities (so `get_temperature()` works on LAMMPS frames, symmetric with ASE).
+
+- [ ] **Step 1: Inspect the exact functions**
+
+Run: `sed -n '120,140p;216,235p' /ptmp/hmai/pwl_dev/pyiron_workflow_lammps/lammps.py`
+Confirm: `parse_LammpsOutput` builds each frame via `arrays_to_ase_atoms(...)` from `pyiron_lammps_output["generic"]["positions"][i]`, and that `pyiron_lammps_output["generic"]` also has `"velocities"`.
+
+- [ ] **Step 2: Write the failing test**
+```python
+# /ptmp/hmai/pwl_dev/tests/unit/test_velocity_capture.py
+import numpy as np
+from pyiron_workflow_lammps.lammps import arrays_to_ase_atoms
+
+def test_arrays_to_ase_atoms_attaches_velocities():
+    species = [["Al", "Al"]]
+    positions = np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+    cell = np.eye(3) * 5.0
+    velocities = np.array([[0.1, 0.0, 0.0], [0.0, 0.2, 0.0]])
+    atoms = arrays_to_ase_atoms(species, positions, cell, pbc=True, velocities=velocities)
+    assert atoms.get_velocities() is not None
+    assert np.allclose(atoms.get_velocities(), velocities)
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd /ptmp/hmai/pwl_dev && /ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit/test_velocity_capture.py -v`
+Expected: FAIL (TypeError: unexpected keyword 'velocities')
+
+- [ ] **Step 4: Patch `arrays_to_ase_atoms` and `parse_LammpsOutput`**
+
+Add an optional `velocities=None` parameter to `arrays_to_ase_atoms`; after building the `Atoms`, if `velocities is not None: atoms.set_velocities(np.asarray(velocities))`. In `parse_LammpsOutput`, pass `velocities=pyiron_lammps_output["generic"]["velocities"][i]` when the key exists (guard with `.get("velocities")`), else `None`. Exact edit:
+```python
+def arrays_to_ase_atoms(species_lists, positions, cell, pbc=True, velocities=None):
+    pos = positions
+    atoms = Atoms(symbols=species_lists[-1], positions=pos, cell=cell, pbc=pbc)
+    if velocities is not None:
+        atoms.set_velocities(np.asarray(velocities))
+    return atoms
+```
+And in `parse_LammpsOutput`'s frame loop:
+```python
+generic = pyiron_lammps_output["generic"]
+vel_traj = generic.get("velocities")
+... 
+arrays_to_ase_atoms(
+    species_lists,
+    positions=generic["positions"][i],
+    cell=generic["cells"][i],
+    pbc=True,
+    velocities=(vel_traj[i] if vel_traj is not None else None),
+)
+```
+
+- [ ] **Step 5: Run test to verify pass + commit**
+
+Run: `cd /ptmp/hmai/pwl_dev && /ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit/test_velocity_capture.py -v`
+Expected: PASS
+```bash
+cd /ptmp/hmai/pwl_dev
+git add pyiron_workflow_lammps/lammps.py tests/unit/test_velocity_capture.py
+git commit -m "feat: attach per-atom velocities to trajectory frames (coexistence T)"
+```
+
+---
+
+### Task 14: Notebook → runnable script
+
+**Files:**
+- Create: `scripts/meltingpoint.py`
+- Test: `tests/integration/test_meltingpoint_script.py`
+
+**Interfaces:**
+- Produces: a CLI script that runs Step 1 (and optionally the full method) on EMT/Al and prints the result; importable `run(...)` for the test.
+
+- [ ] **Step 1: Write the failing test**
+```python
+# tests/integration/test_meltingpoint_script.py
+import pytest
+
+@pytest.mark.slow
+def test_script_run_returns_result(tmp_path):
+    import importlib.util, pathlib
+    spec = importlib.util.spec_from_file_location(
+        "meltingpoint", pathlib.Path("scripts/meltingpoint.py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    res = mod.run(element="Al", a=4.05, n_atoms=500, working_directory=str(tmp_path),
+                  full=False, temperature_right=1400.0, strain_run_steps=40, seed=1)
+    assert res["initial_guess"] >= 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/integration/test_meltingpoint_script.py -v -m slow`
+Expected: FAIL (FileNotFoundError / no module)
+
+- [ ] **Step 3: Write the script**
+```python
+#!/usr/bin/env python
+"""Interface-method melting point — runnable port of meltingpoint.ipynb.
+
+Step 1 (rough estimate) by default; pass --full for the full coexistence method.
+Uses the ASE engine with EMT by default (swap in a GRACE calculator for production).
+"""
+
+from __future__ import annotations
+
+import argparse
+
+
+def run(element="Al", crystalstructure="fcc", a=4.05, n_atoms=4000,
+        working_directory="melting_run", full=False, temperature_right=1000.0,
+        strain_run_steps=1000, seed=12345):
+    from ase.calculators.emt import EMT
+    from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+    from pyiron_workflow_atomistics.analysis.structure_descriptors import (
+        analyse_reference_structure,
+    )
+    from pyiron_workflow_atomistics.physics.melting import (
+        MeltingInput, calculate_melting_point,
+    )
+    from pyiron_workflow_atomistics.physics.melting.initial_guess import (
+        estimate_melting_temperature,
+    )
+    from pyiron_workflow_atomistics.physics.melting.structures import (
+        create_coexistence_supercell,
+    )
+
+    engine = ASEEngine(EngineInput=CalcInputStatic(), calculator=EMT(),
+                       working_directory=working_directory)
+    if full:
+        mi = MeltingInput(element=element, crystalstructure=crystalstructure, a=a,
+                          n_atoms=n_atoms, temperature_right=temperature_right,
+                          strain_run_steps=strain_run_steps, seed=seed)
+        res = calculate_melting_point.node_function(engine, mi).to_dict()
+        print(f"Melting temperature: {res['melting_temperature']:.1f} K "
+              f"(converged={res['converged']}, guess={res['initial_guess']:.0f} K)")
+        return res
+
+    structure = create_coexistence_supercell.node_function(
+        element, crystalstructure, a=a, n_atoms=n_atoms)
+    key_max, _, half = analyse_reference_structure.node_function(structure)
+    t_guess, _ = estimate_melting_temperature.node_function(
+        structure, engine, key_max=key_max, distribution_half=half,
+        crystalstructure=crystalstructure, temperature_right=temperature_right,
+        strain_run_steps=strain_run_steps, seed=seed)
+    print(f"Step-1 melting-temperature estimate: {t_guess} K")
+    return {"initial_guess": float(t_guess)}
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--element", default="Al")
+    p.add_argument("--crystalstructure", default="fcc")
+    p.add_argument("--a", type=float, default=4.05)
+    p.add_argument("--n-atoms", type=int, default=4000)
+    p.add_argument("--working-directory", default="melting_run")
+    p.add_argument("--full", action="store_true")
+    p.add_argument("--temperature-right", type=float, default=1000.0)
+    p.add_argument("--strain-run-steps", type=int, default=1000)
+    p.add_argument("--seed", type=int, default=12345)
+    args = p.parse_args()
+    run(element=args.element, crystalstructure=args.crystalstructure, a=args.a,
+        n_atoms=args.n_atoms, working_directory=args.working_directory, full=args.full,
+        temperature_right=args.temperature_right, strain_run_steps=args.strain_run_steps,
+        seed=args.seed)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/integration/test_meltingpoint_script.py -v -m slow`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+```bash
+cd /ptmp/hmai/pwa_melting
+git add scripts/meltingpoint.py tests/integration/test_meltingpoint_script.py
+git commit -m "feat(melting): runnable meltingpoint.py script (notebook port)"
+```
+
+---
+
+## Verification phase (after all tasks)
+
+V1. **Full fast suite:** `/ptmp/hmai/pwa_melting/.venv/bin/python -m pytest tests/unit -q` → all green.
+V2. **EMT/Al slow suite:** `… -m slow tests/integration -q` → all green; capture Step-1 guess + a `calculate_melting_point` Tm and report paths.
+V3. **GRACE (ASE):** in `.venv-grace`, build an `ASEEngine` with `grace_fm(<cached model>)` (`GRACE_CACHE=/ptmp/hmai/grace_cache`), run Step 1 on a real element; report Tm.
+V4. **LAMMPS (`pair_style grace`):** build a `LammpsEngine` (`command=/ptmp/hmai/lammps/build/lmp …`, `path_to_model=<exported GRACE>`, patched velocity capture), run one `coexistence_iteration` on a scaled cell; confirm the *same* algorithm runs unchanged and `mean_T` is finite.
+V5. Report all output directories under `/ptmp/...` per the show-output-paths preference.
+
+## Self-review checklist (done at plan close)
+- Spec coverage: analysis quantities (T1–T3), structures (T5), solid fraction (T6), fitting (T7), MD drivers (T9), Step 1 (T10), Step 2 (T11), top-level (T12), LAMMPS wrap+patch (T13), script (T14), NPT robustness (T8), dataclasses (T4). All spec §3.5 nodes mapped.
+- Type consistency: `analyse_reference_structure` → `(key_max, n_atoms, distribution_half)` consumed identically in T6/T9/T10/T12; `EngineOutput.structures/.stresses` consumed in T1; `MeltingIterationRecord`/`MeltingResult` produced in T4, consumed in T11/T12.
+- No placeholders: every step has runnable code/commands.

--- a/docs/design/specs/2026-06-27-melting-point-interface-method-design.md
+++ b/docs/design/specs/2026-06-27-melting-point-interface-method-design.md
@@ -1,0 +1,334 @@
+# Melting point via the interface (coexistence) method — design
+
+**Date:** 2026-06-27
+**Branch:** `feat/melting-point-interface-method`
+**Status:** Design (awaiting review)
+**Author:** Han (with Claude)
+
+---
+
+## 1. Goal
+
+Add an engine-agnostic **melting-point** workflow to `pyiron_workflow_atomistics`
+implementing the full **interface / solid–liquid coexistence method**, as a new
+`physics/melting/` subpackage. It must run on **any conformant `Engine`** —
+verified on the ASE engine (EMT/Al, then a GRACE foundation model) **and** on a
+new **`LammpsEngine`** (full coexistence run with `pair_style grace`).
+
+The source material is `/ptmp/hmai/meltingpoint.ipynb`, a partial port (Step 1
+only) of `pyiron_atomistics.thermodynamics.interfacemethod`. This work ports the
+**complete** algorithm (Steps 1 + 2) onto the modern engine abstraction and
+converts the notebook into a runnable script.
+
+### Deliverables
+1. `physics/melting/` subpackage (full method: nodes + Python drivers).
+2. A conformant `engine/lammps.py` (`LammpsEngine`) running in-process LAMMPS.
+3. `scripts/meltingpoint.py` — the notebook as a runnable script (ASE/EMT demo).
+4. Unit tests (fast, no MD) + integration smoke tests (EMT/Al, slow marker).
+5. A verification run: EMT/Al (Step 1 + ≥1 coexistence iteration), then GRACE
+   (Step 1), then a LAMMPS coexistence run with `pair_style grace`.
+
+---
+
+## 2. The methodology (what we are implementing)
+
+The interface method brackets the melting temperature `T_m` by holding a
+half-solid / half-liquid cell in coexistence and extrapolating the measured
+temperature to zero pressure.
+
+**Step 1 — initial guess (the notebook).** Build a bulk crystal (~`N/2` atoms),
+relax it, then **bisect temperature**: at each `T` run NPT MD on the *bulk solid*
+and classify *solid vs molten* from the dominant CNA fraction (stays crystalline
+⇒ raise `T`; melts ⇒ lower `T`). Converges to a rough `T0` (≈914 K for the
+notebook's EAM Al).
+
+**Step 2 — coexistence refinement (`calc_temp_iteration`, looped).** At the
+current `T`:
+1. **NPT-relax the solid** at `T`.
+2. **Build a solid–liquid interface**: freeze the lower half (`z < 0.5`), melt the
+   upper half at `T + ΔT_melt` (NPT, z-only barostat), then recool the upper half
+   to `T` against the frozen solid → a coexistence cell.
+3. **Strain scan** along `z`: for each strain in a grid around the equilibrium
+   c-length, **NVT-equilibrate** then **NVE**-run; record per-frame temperature
+   and pressure.
+4. **Solid fraction per strain** via CNA + a 1-D **kernel-density estimate** of
+   the crystalline atoms' `z`-positions (fraction of the box that is solid).
+5. **`ratio_selection`**: keep the contiguous strain window where the solid
+   fraction sits near 0.5 (true coexistence).
+6. **Void rejection**: drop strains whose **Voronoi** max-volume indicates holes.
+7. **Predict `T_m`**: fit `P(strain)` and `T(strain)` (and `T(P)`); the new
+   estimate is `T` extrapolated to `P = 0`.
+8. **Convergence loop**: repeat with progressively finer schedules
+   (`timestep_lst`, `fit_range_lst`, `nve_steps_lst`) until
+   `|ΔT_next| ≤ convergence_goal`.
+
+Reference functions (verbatim algorithm) live in
+`pyiron_atomistics.thermodynamics.interfacemethod`; this design re-expresses them
+on `EngineOutput` instead of pyiron-atomistics LAMMPS jobs.
+
+---
+
+## 3. Architecture
+
+### 3.1 Principles
+- **Engine-agnostic**: the algorithm only ever calls
+  `calculate(structure, engine)` (the `engine/protocol.py` node) with
+  `CalcInputMD` / `CalcInputMinimize`. It never imports ASE or LAMMPS. ⇒ "supports
+  both" by construction.
+- **Adaptive loops in Python drivers (Approach A)**: pure operations are
+  `@pwf.as_function_node`s; the bisection and convergence *loops* live inside
+  `@pwf.as_function_node` driver functions that iterate, calling
+  `calculate.node_function(...)` per step — exactly the
+  `physics/free_energy/quasiharmonic.py::_static_energies_per_volume` idiom. A
+  thin top-level `@pwf.as_macro_node` wires the stages.
+- **Per-step isolation** via `engine.with_working_directory(f"...{i:03d}")`
+  (or the `subengine` node inside macros).
+- **Per-step calc parameters** by producing an engine variant carrying a fresh
+  `CalcInputMD`/`CalcInputMinimize` (helper `with_calc_input`, below).
+
+### 3.2 Why the trajectory suffices (verified 2026-06-27)
+`EngineOutput` already carries `structures` (per-frame snapshots), `energies`,
+and `stresses` (per-frame Voigt). Empirically (ASE engine, EMT/Al NVT):
+snapshots **preserve momenta**, so `snapshot.get_temperature()` recovers per-frame
+temperature, and per-frame Voigt stress gives the virial pressure. The analysis
+computes the **total pressure = virial + kinetic ideal-gas term**
+(`P = -tr(σ)/3 + ρ·k_B·T`); omitting the kinetic term would bias the `T(P→0)`
+extrapolation. **No change to `EngineOutput` or the conformance contract is
+required.** (The `LammpsEngine` must likewise populate `structures` with
+velocities and per-frame `stresses`.)
+
+### 3.3 NVE velocity initialisation
+NVE has no thermostat, so kinetic energy equipartitions ⇒ the equilibrated
+temperature is ~½ the initial. To land at the target `T`, NVE/strain runs set
+`CalcInputMD.initial_temperature = 2·T` (the notebook's `half_velocity` trick).
+Verified: a 900 K MaxwellBoltzmann init equilibrates near ~450 K without it.
+
+### 3.4 Module layout
+```
+pyiron_workflow_atomistics/physics/melting/
+  __init__.py          # public API exports
+  inputs.py            # MeltingInput dataclass
+  outputs.py           # MeltingResult dataclass (+ MeltingIterationRecord)
+  structures.py        # coexistence supercell, freeze_half, strain_cell_along_z, unfreeze
+  analysis.py          # cna_fractions, classify_solid, solid_fraction_kde,
+                       #   voronoi_max_mean / holes_mask,
+                       #   temperatures_from_trajectory, pressures_from_trajectory
+  md_steps.py          # with_calc_input, relax_structure, npt_relax_solid,
+                       #   build_solid_liquid_interface, strain_scan_nvt_nve
+  fitting.py           # ratio_selection, predict_melting_point
+  initial_guess.py     # estimate_melting_temperature (Step 1 bisection driver)
+  coexistence.py       # coexistence_iteration + refine_melting_point (Step 2 loop)
+  study.py             # calculate_melting_point (top-level macro/driver)
+
+pyiron_workflow_atomistics/engine/lammps.py   # LammpsEngine (conformant)
+
+scripts/meltingpoint.py                        # notebook → script (EMT/Al Step-1 demo)
+
+tests/unit/physics/melting/                    # fast unit tests
+tests/unit/engine/test_lammps_conformance.py   # LammpsEngine vs conformance suite
+tests/integration/test_melting_emt.py          # EMT/Al smoke (slow marker)
+```
+
+### 3.5 Node & driver inventory
+
+**structures.py** (`@pwf.as_function_node`)
+- `create_coexistence_supercell(element, crystalstructure, a=None, n_atoms=8000) -> Atoms`
+  — `get_bulk(cubic=True)` then pick the `i×i×i` repeat whose atom count is
+  closest to `n_atoms/2` (notebook logic).
+- `freeze_half(structure, axis=2, fraction=0.5) -> Atoms` — `FixAtoms` on
+  `scaled_pos[axis] < fraction`. **New** (not in `structure/defects.py`).
+- `unfreeze(structure) -> Atoms` — clear constraints.
+- `strain_cell_along_z(structure, strain) -> Atoms` — scale `cell[2,2]` by
+  `strain`, `scale_atoms=True`.
+
+**analysis.py** (`@pwf.as_function_node`)
+- `cna_fractions(structure, ovito_compatibility=True) -> dict` — wraps
+  `structuretoolkit.analyse.get_adaptive_cna_descriptors`.
+- `classify_solid(structure, key_max, distribution_half) -> bool`.
+- `analyse_reference_structure(structure) -> (key_max, n_atoms, distribution_half)`.
+- `solid_fraction_kde(structure, crystalstructure, threshold=0.1) -> float`
+  — CNA per-atom (`mode="str"`) + sklearn `KernelDensity` on crystalline `z`.
+- `voronoi_max_mean(structure) -> (max, mean)` and
+  `holes_mask(maxes, means, factor=2.0) -> list[bool]` — structuretoolkit Voronoi.
+- `temperatures_from_trajectory(engine_output, last_n=20) -> list[float]`.
+- `pressures_from_trajectory(engine_output, last_n=20) -> list[float]` — virial
+  (Voigt) + kinetic term, returned in GPa.
+
+**md_steps.py**
+- `with_calc_input(engine, calc_input) -> Engine` (`@pwf.as_function_node`) —
+  `dataclasses.replace(engine, EngineInput=calc_input)`.
+- `npt_relax_solid(structure, engine, temperature, n_steps, timestep, seed) ->
+  EngineOutput` driver: builds `CalcInputMD(mode="NPT", pressure=0, ...)`,
+  `initial_temperature=2T`, runs `calculate.node_function`.
+- `build_solid_liquid_interface(structure, engine, t_solid, t_liquid, ...) ->
+  Atoms` driver: `freeze_half` → NPT-melt upper half at `t_liquid` → NPT-recool to
+  `t_solid` → `unfreeze`.
+- `strain_scan_nvt_nve(structure, engine, temperature, strains, nvt_steps,
+  nve_steps, timestep, seed) -> list[dict]` driver: per strain, NVT then NVE;
+  returns `{strain, mean_T, mean_P, solid_fraction, voronoi_max/mean}`.
+
+**fitting.py** (`@pwf.as_function_node`)
+- `ratio_selection(records, ratio_boundary=0.25) -> (selected_records, sl_flag)`.
+- `predict_melting_point(selected_records, boundary_value=0.25) ->
+  (t_next, t_mean, t_left, t_right)` — `np.polyfit` of P,T vs strain; `T(P=0)`.
+
+**initial_guess.py**
+- `estimate_melting_temperature(structure, engine, t_left=0, t_right=1000,
+  strain_run_steps=1000, timestep=2.0, seed, crystalstructure) ->
+  (t_guess, structure)` (`@pwf.as_function_node`) — Step-1 bisection driver
+  (faithful port of notebook cells 38–48).
+
+**coexistence.py**
+- `coexistence_iteration(structure, engine, temperature, schedule, params) ->
+  MeltingIterationRecord` driver — one `calc_temp_iteration`.
+- `refine_melting_point(structure, engine, t_guess, input) -> MeltingResult`
+  driver — the convergence loop over schedules.
+
+**study.py**
+- `calculate_melting_point(wf, engine, input: MeltingInput) -> MeltingResult`
+  (`@pwf.as_macro_node`) — `create_coexistence_supercell` → relax/minimize →
+  `analyse_reference_structure` → `estimate_melting_temperature` →
+  `refine_melting_point`.
+
+### 3.6 inputs / outputs (mirroring `free_energy` style: plain `@dataclass`, `to_dict()`)
+```python
+@dataclass
+class MeltingInput:
+    element: str
+    crystalstructure: str | None = None     # default: ASE reference state
+    a: float | None = None
+    n_atoms: int = 8000
+    temperature_left: float = 0.0
+    temperature_right: float = 1000.0
+    convergence_goal: float = 1.0            # K
+    timestep_lst: list[float] = (2.0, 2.0, 1.0)        # fs
+    fit_range_lst: list[float] = (0.05, 0.01, 0.01)
+    nve_steps_lst: list[int] = (25000, 20000, 50000)
+    nvt_run_steps: int = 10000
+    npt_run_steps: int = 50000
+    strain_run_steps: int = 1000
+    n_strain_points: int = 21
+    ratio_boundary: float = 0.25
+    boundary_value: float = 0.25
+    delta_t_melt: float = 1000.0             # superheat for interface build
+    seed: int | None = None
+
+@dataclass
+class MeltingIterationRecord:
+    temperature_in: float
+    temperature_next: float
+    strains: list[float]; ratios: list[float]
+    pressures: list[float]; temperatures: list[float]
+    converged: bool
+
+@dataclass
+class MeltingResult:
+    melting_temperature: float
+    converged: bool
+    n_iterations: int
+    element: str; crystalstructure: str; n_atoms: int
+    initial_guess: float
+    iterations: list[MeltingIterationRecord]
+    report: dict[str, Any]
+    def to_dict(self) -> dict[str, Any]: ...
+```
+
+---
+
+## 4. The `LammpsEngine`
+
+A new `engine/lammps.py::LammpsEngine` conforming to the `Engine` Protocol so the
+*same* melting algorithm runs on LAMMPS.
+
+- **Backend**: in-process LAMMPS via the `lammps` Python module
+  (`/ptmp/hmai/lammps/python` + `liblammps.so`), reusing the notebook's
+  `atomistics`-style command templating (NPT/NVT/NVE via jinja templates), or
+  `pyiron_workflow_lammps` (pulled by the `free-energy` extra) if it offers a
+  clean structure-in / results-out call. Final choice made in the plan.
+- **Inputs**: `EngineInput ∈ {CalcInputStatic, CalcInputMinimize, CalcInputMD}` —
+  same dataclasses as ASE; the engine translates to LAMMPS commands (units metal,
+  `fix npt/nvt/nve`, `velocity create`, `box/relax`).
+- **Potential**: a `LammpsPotential(pair_style, pair_coeff, potential_file)`
+  (reuse `physics/free_energy/inputs.py::LammpsPotential`); for GRACE,
+  `pair_style grace` + the exported model dir.
+- **Output**: builds `EngineOutput` with `final_structure`, `final_energy`,
+  `converged`, `final_forces/stress`, and trajectory `structures` (**with
+  velocities**), `energies`, `stresses` so the coexistence analysis works
+  unchanged.
+- **Contract methods**: `working_directory`, `get_calculate_fn(structure)`,
+  `with_working_directory(subdir)`; must be a pickleable `@dataclass`.
+- **Validation**: a `tests/unit/engine/test_lammps_conformance.py` inheriting
+  `pyiron_workflow_atomistics.testing.EngineConformanceTests`, plus a short MD
+  smoke test (skipped if `lammps` import / LAMMPS build is unavailable).
+
+---
+
+## 5. Testing strategy
+
+**Fast unit tests** (`tests/unit/physics/melting/`, no MD):
+- `structures`: `create_coexistence_supercell` atom-count selection; `freeze_half`
+  fixes exactly the lower-half indices; `strain_cell_along_z` scales only `c`.
+- `analysis`: `cna_fractions` on a perfect fcc cell (≈100 % FCC); `solid_fraction_kde`
+  on a synthetic half-fcc/half-random cell ≈ 0.5; `holes_mask` flags an injected
+  void; `temperatures_/pressures_from_trajectory` against a hand-built
+  `EngineOutput` with known momenta/stress (closed-form T and P).
+- `fitting`: `predict_melting_point` on synthetic linear `P(strain)`,`T(strain)`
+  with a known `T(P=0)`; `ratio_selection` picks the right contiguous window.
+
+**Integration smoke** (`tests/integration/`, `@pytest.mark.slow`, EMT/Al, tiny
+cell ~250 atoms, short MD): Step-1 bisection returns a plausible `T`; one
+coexistence iteration runs end-to-end and returns a finite `T_next`.
+
+**Engine conformance**: `LammpsEngine` passes `EngineConformanceTests`
+(skip-guarded on LAMMPS availability).
+
+---
+
+## 6. Verification plan (this session)
+
+1. **EMT/Al** (clean uv venv): run `estimate_melting_temperature` (cheap), then a
+   scaled-down `coexistence_iteration`; report `T0` and `T_next` (EMT-Al melts
+   ~well below the DFT 933 K; the number need only be self-consistent and finite).
+2. **GRACE**: point the ASE engine at a cached GRACE-FM
+   (`/ptmp/hmai/grace_cache`, e.g. `GRACE-1L-OAM`) and run Step 1 on a real
+   element. (Install grace/tf into the venv, else run in the `grace` conda env
+   with the package pip-installed.)
+3. **LAMMPS + `pair_style grace`**: run a (scaled-down) full coexistence iteration
+   through `LammpsEngine` using `/ptmp/hmai/lammps/build` + an exported GRACE
+   model, confirming the engine-agnostic algorithm runs unchanged on LAMMPS.
+
+Every run logs to `/ptmp` (not `/tmp`, which is node-local on Raven) and reports
+full output paths.
+
+---
+
+## 7. Environment
+
+- Fresh clone: `/ptmp/hmai/pwa_melting` (branch `feat/melting-point-interface-method`).
+- Isolated `uv` venv `.venv` (Python 3.11): `uv pip install -e ".[test]"` +
+  `structuretoolkit` + `pyscal3`. **Built & verified** 2026-06-27 (engine API +
+  structuretoolkit import clean; ASE 3.28.0 / numpy 1.26.4 / pandas 3.0.3).
+- GRACE step may need `tensorflow` + `grace` (TF_USE_LEGACY_KERAS=1) added to the
+  venv, or fall back to the `grace` conda env.
+- LAMMPS step uses the existing GRACE-enabled build at `/ptmp/hmai/lammps`.
+
+---
+
+## 8. Scope / non-goals
+- No new public `EngineOutput` fields or conformance-contract changes.
+- No attempt to reproduce the notebook's exact numbers (different engine,
+  thermostats, cell sizes); correctness = self-consistent coexistence + sane
+  fits, plus the analysis primitives matching closed-form unit tests.
+- Production-scale (8000-atom, 50k-step) runs are *enabled* but not exhaustively
+  run here; verification uses scaled-down sizes for turnaround.
+
+---
+
+## 9. Open questions for review
+1. `LammpsEngine` backend: hand-rolled `lammps`-module templating (closest to the
+   notebook) vs wrapping `pyiron_workflow_lammps`? (Plan will pick; leaning
+   hand-rolled for control over velocity/stress trajectory capture.)
+2. Place CNA/Voronoi as **general** `analysis/` quantities (reusable) vs keep them
+   melting-local? (Leaning: keep melting-local now; promote later.)
+3. GRACE for the ASE step — install into the uv venv, or run that step in the
+   `grace` conda env with the package installed there?

--- a/docs/design/specs/2026-06-27-melting-point-interface-method-design.md
+++ b/docs/design/specs/2026-06-27-melting-point-interface-method-design.md
@@ -104,28 +104,44 @@ temperature is ~½ the initial. To land at the target `T`, NVE/strain runs set
 Verified: a 900 K MaxwellBoltzmann init equilibrates near ~450 K without it.
 
 ### 3.4 Module layout
+
+**General, reusable analysis quantities** (decision: CNA/Voronoi/trajectory
+quantities are *general*, not melting-local) extend the existing `analysis/`
+package so other workflows can reuse them:
+```
+pyiron_workflow_atomistics/analysis/
+  structure_descriptors.py   # NEW: cna_fractions, classify_solid,
+                             #   analyse_reference_structure, voronoi_max_mean, holes_mask
+  trajectory.py              # NEW: temperatures_from_trajectory,
+                             #   pressures_from_trajectory  (operate on EngineOutput)
+  # (quantities.py / featurisers.py unchanged)
+```
+
+**Melting-specific** code (the method itself) lives in the new subpackage:
 ```
 pyiron_workflow_atomistics/physics/melting/
   __init__.py          # public API exports
   inputs.py            # MeltingInput dataclass
   outputs.py           # MeltingResult dataclass (+ MeltingIterationRecord)
   structures.py        # coexistence supercell, freeze_half, strain_cell_along_z, unfreeze
-  analysis.py          # cna_fractions, classify_solid, solid_fraction_kde,
-                       #   voronoi_max_mean / holes_mask,
-                       #   temperatures_from_trajectory, pressures_from_trajectory
-  md_steps.py          # with_calc_input, relax_structure, npt_relax_solid,
+  solid_fraction.py    # solid_fraction_kde (CNA + KDE; melting-specific)
+  md_steps.py          # with_calc_input, npt_relax_solid,
                        #   build_solid_liquid_interface, strain_scan_nvt_nve
   fitting.py           # ratio_selection, predict_melting_point
   initial_guess.py     # estimate_melting_temperature (Step 1 bisection driver)
   coexistence.py       # coexistence_iteration + refine_melting_point (Step 2 loop)
   study.py             # calculate_melting_point (top-level macro/driver)
+```
 
-pyiron_workflow_atomistics/engine/lammps.py   # LammpsEngine (conformant)
-
+**LAMMPS engine** — we do NOT hand-roll one. The melting algorithm consumes the
+existing, protocol-conformant `pyiron_workflow_lammps.engine.LammpsEngine`
+(see §4). The only addition is a surgical velocity-capture patch in that package.
+```
 scripts/meltingpoint.py                        # notebook → script (EMT/Al Step-1 demo)
 
+tests/unit/analysis/test_structure_descriptors.py
+tests/unit/analysis/test_trajectory.py
 tests/unit/physics/melting/                    # fast unit tests
-tests/unit/engine/test_lammps_conformance.py   # LammpsEngine vs conformance suite
 tests/integration/test_melting_emt.py          # EMT/Al smoke (slow marker)
 ```
 
@@ -235,31 +251,50 @@ class MeltingResult:
 
 ---
 
-## 4. The `LammpsEngine`
+## 4. The `LammpsEngine` — wrap `pyiron_workflow_lammps` (examined 2026-06-27)
 
-A new `engine/lammps.py::LammpsEngine` conforming to the `Engine` Protocol so the
-*same* melting algorithm runs on LAMMPS.
+Decision: **reuse the existing `pyiron_workflow_lammps.engine.LammpsEngine`**
+rather than hand-rolling one. As of `origin/main` (commit 4e05b46) it is a pure,
+pickleable `@dataclass` already migrated to *this* package's Engine Protocol:
+`working_directory`, `get_calculate_fn(structure)`, `with_working_directory(subdir)`,
+`EngineInput ∈ {CalcInputStatic, CalcInputMinimize, CalcInputMD}` (the same
+dataclasses), returning an `EngineOutput`. It runs LAMMPS by shelling out to an
+`lmp` binary (configurable `command` field), supports `pair_style grace` (the
+default), and already emits a per-frame trajectory (`structures`, `energies`,
+`stresses`).
 
-- **Backend**: in-process LAMMPS via the `lammps` Python module
-  (`/ptmp/hmai/lammps/python` + `liblammps.so`), reusing the notebook's
-  `atomistics`-style command templating (NPT/NVT/NVE via jinja templates), or
-  `pyiron_workflow_lammps` (pulled by the `free-energy` extra) if it offers a
-  clean structure-in / results-out call. Final choice made in the plan.
-- **Inputs**: `EngineInput ∈ {CalcInputStatic, CalcInputMinimize, CalcInputMD}` —
-  same dataclasses as ASE; the engine translates to LAMMPS commands (units metal,
-  `fix npt/nvt/nve`, `velocity create`, `box/relax`).
-- **Potential**: a `LammpsPotential(pair_style, pair_coeff, potential_file)`
-  (reuse `physics/free_energy/inputs.py::LammpsPotential`); for GRACE,
-  `pair_style grace` + the exported model dir.
-- **Output**: builds `EngineOutput` with `final_structure`, `final_energy`,
-  `converged`, `final_forces/stress`, and trajectory `structures` (**with
-  velocities**), `energies`, `stresses` so the coexistence analysis works
-  unchanged.
-- **Contract methods**: `working_directory`, `get_calculate_fn(structure)`,
-  `with_working_directory(subdir)`; must be a pickleable `@dataclass`.
-- **Validation**: a `tests/unit/engine/test_lammps_conformance.py` inheriting
-  `pyiron_workflow_atomistics.testing.EngineConformanceTests`, plus a short MD
-  smoke test (skipped if `lammps` import / LAMMPS build is unavailable).
+### 4.1 The one gap to fix — velocity capture (so coexistence T is recoverable)
+The backend `pyiron_lammps` **already parses per-atom velocities** from the dump
+(`output_raw.py` collects `velocities`; the engine dump line writes `vx vy vz`).
+But `pyiron_workflow_lammps/lammps.py::arrays_to_ase_atoms` builds each trajectory
+`Atoms` from **positions/cell only** — velocities are dropped. So the coexistence
+analysis (which needs per-frame temperature from momenta) cannot run on LAMMPS as-is.
+
+**Fix (surgical, in `pyiron_workflow_lammps`):** thread the already-parsed
+`generic["velocities"]` through `parse_LammpsOutput` → `arrays_to_ase_atoms`, and
+`atoms.set_velocities(v)` (Å/fs → ASE momenta) on each frame. This makes the
+LAMMPS `EngineOutput.structures` velocity-bearing and **symmetric with the ASE
+engine**, so the *general* `analysis/trajectory.py` quantities compute temperature
+& pressure identically for both. Done on a branch
+(`/ptmp/hmai/pwl_dev`, branch `feat/velocity-capture-for-melting`), installed
+editable `--no-deps` into the dev venv; intended for upstream PR.
+
+### 4.2 Wiring & potential
+- For GRACE: set `command` → `/ptmp/hmai/lammps/build/lmp …`, `path_to_model` →
+  an exported GRACE model dir, `input_script_pair_style="grace"`,
+  `potential_elements` from the structure. (`LammpsEngine` exposes all of these
+  as dataclass fields.)
+- The melting algorithm is unchanged: it just receives a `LammpsEngine` instead of
+  an `ASEEngine`.
+
+### 4.3 Validation
+- A `tests/unit/engine/test_lammps_velocity_capture.py` in `pwl_dev` asserting the
+  patched parser attaches velocities (parse a tiny recorded dump fixture).
+- A short LAMMPS MD smoke test (skipped if no `lmp` binary), plus the full
+  coexistence verification run (§6.3).
+- The engine itself is already covered by `pyiron_workflow_lammps`' own tests;
+  conformance against *our* `testing.EngineConformanceTests` is a light add-on if
+  time permits (skip-guarded on `lmp` availability).
 
 ---
 
@@ -305,12 +340,18 @@ full output paths.
 ## 7. Environment
 
 - Fresh clone: `/ptmp/hmai/pwa_melting` (branch `feat/melting-point-interface-method`).
-- Isolated `uv` venv `.venv` (Python 3.11): `uv pip install -e ".[test]"` +
-  `structuretoolkit` + `pyscal3`. **Built & verified** 2026-06-27 (engine API +
-  structuretoolkit import clean; ASE 3.28.0 / numpy 1.26.4 / pandas 3.0.3).
-- GRACE step may need `tensorflow` + `grace` (TF_USE_LEGACY_KERAS=1) added to the
-  venv, or fall back to the `grace` conda env.
-- LAMMPS step uses the existing GRACE-enabled build at `/ptmp/hmai/lammps`.
+- **Dev/test venv** `/ptmp/hmai/pwa_melting/.venv` (Python 3.11, uv):
+  `uv pip install -e ".[test]"` + `structuretoolkit` + `pyscal3`, plus
+  `pyiron_lammps` and the patched `pyiron_workflow_lammps` (`/ptmp/hmai/pwl_dev`)
+  installed editable `--no-deps` (preserves the ase 3.28 / pandas 3.0.3 pins).
+  **Built & verified** 2026-06-27 (engine API, structuretoolkit, LammpsEngine
+  import clean). Runs unit tests + EMT/Al + LAMMPS (`pair_style grace`, shells to
+  `/ptmp/hmai/lammps/build/lmp`).
+- **GRACE venv** `/ptmp/hmai/pwa_melting/.venv-grace` (fresh uv venv): pwa editable
+  + structuretoolkit + `tensorpotential==0.5.1` + `tensorflow==2.16.2`. Isolated so
+  the TF stack / `pandas 2.3.3` downgrade does not perturb the dev venv. Used only
+  for the ASE-engine GRACE verification (`grace_fm`, `GRACE_CACHE=/ptmp/hmai/grace_cache`).
+- LAMMPS uses the existing GRACE-enabled `lmp` build at `/ptmp/hmai/lammps`.
 
 ---
 
@@ -324,11 +365,11 @@ full output paths.
 
 ---
 
-## 9. Open questions for review
-1. `LammpsEngine` backend: hand-rolled `lammps`-module templating (closest to the
-   notebook) vs wrapping `pyiron_workflow_lammps`? (Plan will pick; leaning
-   hand-rolled for control over velocity/stress trajectory capture.)
-2. Place CNA/Voronoi as **general** `analysis/` quantities (reusable) vs keep them
-   melting-local? (Leaning: keep melting-local now; promote later.)
-3. GRACE for the ASE step — install into the uv venv, or run that step in the
-   `grace` conda env with the package installed there?
+## 9. Resolved decisions (was: open questions)
+1. **LAMMPS engine** → *wrap* `pyiron_workflow_lammps`'s existing protocol-conformant
+   `LammpsEngine`; add a surgical velocity-capture patch to its parser (§4). Not
+   hand-rolled.
+2. **CNA/Voronoi/trajectory quantities** → placed as **general** `analysis/`
+   quantities (reusable), not melting-local (§3.4).
+3. **GRACE** → installed into a dedicated **fresh uv venv** `.venv-grace` (§7), not
+   the conda env.

--- a/pyiron_workflow_atomistics/analysis/__init__.py
+++ b/pyiron_workflow_atomistics/analysis/__init__.py
@@ -9,6 +9,17 @@ from .featurisers import (
 )
 from .gb_plane import find_gb_plane, plot_gb_plane
 from .quantities import get_per_atom_quantity
+from .structure_descriptors import (
+    analyse_reference_structure,
+    classify_solid,
+    cna_fractions,
+    holes_mask,
+    voronoi_max_mean,
+)
+from .trajectory import (
+    pressures_from_trajectory,
+    temperatures_from_trajectory,
+)
 
 __all__ = [
     "voronoi_site_featuriser",
@@ -19,4 +30,11 @@ __all__ = [
     "find_gb_plane",
     "plot_gb_plane",
     "get_per_atom_quantity",
+    "analyse_reference_structure",
+    "classify_solid",
+    "cna_fractions",
+    "holes_mask",
+    "voronoi_max_mean",
+    "pressures_from_trajectory",
+    "temperatures_from_trajectory",
 ]

--- a/pyiron_workflow_atomistics/analysis/structure_descriptors.py
+++ b/pyiron_workflow_atomistics/analysis/structure_descriptors.py
@@ -1,0 +1,61 @@
+"""Common-neighbour-analysis and Voronoi structure descriptors (general)."""
+
+from __future__ import annotations
+
+import operator
+
+import numpy as np
+import pyiron_workflow as pwf
+from structuretoolkit.analyse import (
+    get_adaptive_cna_descriptors,
+    get_voronoi_volumes,
+)
+
+
+@pwf.as_function_node("counts")
+def cna_fractions(structure) -> dict:
+    """Adaptive CNA counts, lowercase keys {'fcc','bcc','hcp','ico','others'}."""
+    counts = get_adaptive_cna_descriptors(
+        structure=structure, mode="total", ovito_compatibility=False
+    )
+    return dict(counts)
+
+
+@pwf.as_function_node("key_max", "n_atoms", "distribution_half")
+def analyse_reference_structure(structure):
+    """Dominant CNA phase, atom count, and half its population fraction.
+
+    ``distribution_half`` is the solid/liquid threshold: a structure counts as
+    *solid* while the dominant-phase fraction stays above this value.
+    """
+    counts = get_adaptive_cna_descriptors(
+        structure=structure, mode="total", ovito_compatibility=False
+    )
+    key_max = max(counts.items(), key=operator.itemgetter(1))[0]
+    n_atoms = len(structure)
+    distribution_half = (counts[key_max] / n_atoms) / 2.0
+    return key_max, n_atoms, distribution_half
+
+
+@pwf.as_function_node("is_solid")
+def classify_solid(structure, key_max: str, distribution_half: float) -> bool:
+    """True if the dominant-phase fraction exceeds ``distribution_half``."""
+    counts = get_adaptive_cna_descriptors(
+        structure=structure, mode="total", ovito_compatibility=False
+    )
+    fraction = counts.get(key_max, 0) / len(structure)
+    return bool(fraction > distribution_half)
+
+
+@pwf.as_function_node("max_volume", "mean_volume")
+def voronoi_max_mean(structure):
+    """Max and mean per-atom Voronoi volume (A^3)."""
+    volumes = get_voronoi_volumes(structure)
+    return float(np.max(volumes)), float(np.mean(volumes))
+
+
+@pwf.as_function_node("keep_mask")
+def holes_mask(max_volumes, mean_volumes, factor: float = 2.0) -> list:
+    """Per-entry True where no cavity: max_volume < factor * mean(mean_volumes)."""
+    threshold = factor * float(np.mean(mean_volumes))
+    return [bool(m < threshold) for m in max_volumes]

--- a/pyiron_workflow_atomistics/analysis/trajectory.py
+++ b/pyiron_workflow_atomistics/analysis/trajectory.py
@@ -14,6 +14,15 @@ from ase import units
 _EV_PER_A3_TO_GPA = 160.21766208
 
 
+def _require_momenta(frames):
+    """Raise if no frame carries momenta (engine failed to record velocities)."""
+    if all(np.abs(np.asarray(f.get_momenta())).sum() == 0.0 for f in frames):
+        raise ValueError(
+            "Trajectory frames carry no momenta; kinetic temperature would be a "
+            "silent 0 K. The engine must record per-atom velocities for MD analyses."
+        )
+
+
 def _virial_pressure_ev_per_a3(stress: np.ndarray) -> float:
     """Hydrostatic virial pressure P = -tr(sigma)/3 from Voigt-6 or 3x3 stress."""
     s = np.asarray(stress, dtype=float)
@@ -33,19 +42,30 @@ def temperatures_from_trajectory(engine_output, last_n: int = 20) -> float:
     if not frames:
         raise ValueError("engine_output.structures is empty; need an MD trajectory")
     window = frames[-last_n:]
+    _require_momenta(window)
     temperature = float(np.mean([f.get_temperature() for f in window]))
     return temperature
 
 
 @pwf.as_function_node("pressure")
 def pressures_from_trajectory(engine_output, last_n: int = 20) -> float:
-    """Mean total pressure (GPa) over the last ``last_n`` frames: virial + kinetic."""
+    """Mean total pressure (GPa) over the last ``last_n`` frames: virial + kinetic.
+
+    Assumes ``EngineOutput.stresses`` are the **potential/virial stress in eV/Å³
+    with the ASE sign convention** (P = -tr(sigma)/3), as the ASEEngine emits; the
+    kinetic ideal-gas term N·kB·T/V is added here. NOTE: the LAMMPS engine instead
+    emits a *total* pressure tensor in GPa (compression-positive), so this node is
+    not yet correct for LAMMPS output — reconciling the stress convention across
+    engines is a prerequisite for the LAMMPS coexistence pressure (see the
+    verification report).
+    """
     frames = engine_output.structures
     stresses = engine_output.stresses
     if not frames or stresses is None or len(stresses) == 0:
         raise ValueError("engine_output needs both .structures and .stresses")
     window_f = frames[-last_n:]
     window_s = stresses[-last_n:]
+    _require_momenta(window_f)
     pressures = []
     for frame, stress in zip(window_f, window_s):
         p_vir = _virial_pressure_ev_per_a3(stress)  # eV/A^3

--- a/pyiron_workflow_atomistics/analysis/trajectory.py
+++ b/pyiron_workflow_atomistics/analysis/trajectory.py
@@ -1,0 +1,56 @@
+"""Derived quantities computed from an EngineOutput trajectory.
+
+Engine-agnostic: works for any engine whose ``EngineOutput.structures`` carry
+per-atom momenta (ASE engine; the velocity-patched LAMMPS engine) and whose
+``.stresses`` hold per-frame virial stress (Voigt-6 or 3x3, in eV/A^3).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pyiron_workflow as pwf
+from ase import units
+
+_EV_PER_A3_TO_GPA = 160.21766208
+
+
+def _virial_pressure_ev_per_a3(stress: np.ndarray) -> float:
+    """Hydrostatic virial pressure P = -tr(sigma)/3 from Voigt-6 or 3x3 stress."""
+    s = np.asarray(stress, dtype=float)
+    if s.shape == (6,):
+        trace = s[0] + s[1] + s[2]
+    elif s.shape == (3, 3):
+        trace = s[0, 0] + s[1, 1] + s[2, 2]
+    else:
+        raise ValueError(f"Unexpected stress shape {s.shape}; expected (6,) or (3, 3)")
+    return -trace / 3.0
+
+
+@pwf.as_function_node("temperature")
+def temperatures_from_trajectory(engine_output, last_n: int = 20) -> float:
+    """Mean kinetic temperature (K) over the last ``last_n`` trajectory frames."""
+    frames = engine_output.structures
+    if not frames:
+        raise ValueError("engine_output.structures is empty; need an MD trajectory")
+    window = frames[-last_n:]
+    temperature = float(np.mean([f.get_temperature() for f in window]))
+    return temperature
+
+
+@pwf.as_function_node("pressure")
+def pressures_from_trajectory(engine_output, last_n: int = 20) -> float:
+    """Mean total pressure (GPa) over the last ``last_n`` frames: virial + kinetic."""
+    frames = engine_output.structures
+    stresses = engine_output.stresses
+    if not frames or stresses is None or len(stresses) == 0:
+        raise ValueError("engine_output needs both .structures and .stresses")
+    window_f = frames[-last_n:]
+    window_s = stresses[-last_n:]
+    pressures = []
+    for frame, stress in zip(window_f, window_s):
+        p_vir = _virial_pressure_ev_per_a3(stress)  # eV/A^3
+        p_kin = (
+            len(frame) * units.kB * frame.get_temperature() / frame.get_volume()
+        )  # eV/A^3
+        pressures.append((p_vir + p_kin) * _EV_PER_A3_TO_GPA)  # GPa
+    return float(np.mean(pressures))

--- a/pyiron_workflow_atomistics/physics/melting/__init__.py
+++ b/pyiron_workflow_atomistics/physics/melting/__init__.py
@@ -1,1 +1,25 @@
 """Melting-point via the interface/coexistence method."""
+
+from pyiron_workflow_atomistics.physics.melting.coexistence import (
+    coexistence_iteration,
+    refine_melting_point,
+)
+from pyiron_workflow_atomistics.physics.melting.initial_guess import (
+    estimate_melting_temperature,
+)
+from pyiron_workflow_atomistics.physics.melting.inputs import MeltingInput
+from pyiron_workflow_atomistics.physics.melting.outputs import (
+    MeltingIterationRecord,
+    MeltingResult,
+)
+from pyiron_workflow_atomistics.physics.melting.study import calculate_melting_point
+
+__all__ = [
+    "MeltingInput",
+    "MeltingIterationRecord",
+    "MeltingResult",
+    "calculate_melting_point",
+    "coexistence_iteration",
+    "estimate_melting_temperature",
+    "refine_melting_point",
+]

--- a/pyiron_workflow_atomistics/physics/melting/__init__.py
+++ b/pyiron_workflow_atomistics/physics/melting/__init__.py
@@ -1,0 +1,1 @@
+"""Melting-point via the interface/coexistence method."""

--- a/pyiron_workflow_atomistics/physics/melting/coexistence.py
+++ b/pyiron_workflow_atomistics/physics/melting/coexistence.py
@@ -26,6 +26,26 @@ def _strain_grid(center, fit_range, n_points):
     ]
 
 
+def _next_center(strains, pressures, fallback=1.0):
+    """Zero-pressure strain from a linear P(strain) fit (reference get_center_point).
+
+    Returns ``fallback`` if the fit is degenerate or the root is unphysical so the
+    strain grid never wanders far from the equilibrium c-length.
+    """
+    if len(strains) < 2:
+        return fallback
+    try:
+        slope, intercept = np.polyfit(strains, pressures, 1)
+        if abs(slope) < 1e-12:
+            return fallback
+        center = abs(-intercept / slope)
+    except Exception:
+        return fallback
+    if not np.isfinite(center) or not (0.5 < center < 1.5):
+        return fallback
+    return float(round(center, 4))
+
+
 @pwf.as_function_node("record")
 def coexistence_iteration(
     structure,
@@ -43,9 +63,15 @@ def coexistence_iteration(
     boundary_value=0.25,
     seed=None,
     npt_thermostat="berendsen",
+    center=1.0,
     subdir="iter",
 ):
-    """One interface-method temperature iteration -> next-T estimate."""
+    """One interface-method temperature iteration -> next-T estimate.
+
+    ``center`` is the strain the grid is built around (the previous iteration's
+    fitted zero-pressure strain); the returned record carries the newly fitted
+    ``center`` for the next iteration.
+    """
     solid, _ = npt_relax_solid.node_function(
         structure, engine, temperature=temperature, n_steps=npt_steps,
         timestep=timestep, seed=seed, npt_thermostat=npt_thermostat,
@@ -55,7 +81,7 @@ def coexistence_iteration(
         solid, engine, t_solid=temperature, t_liquid=temperature + delta_t_melt,
         n_steps=npt_steps, timestep=timestep, seed=seed, subdir=f"{subdir}_iface",
     )
-    strains = _strain_grid(1.0, fit_range, n_strain_points)
+    strains = _strain_grid(center, fit_range, n_strain_points)
     records = strain_scan_nvt_nve.node_function(
         interface, engine, temperature=temperature, strains=strains,
         crystalstructure=crystalstructure, nvt_steps=nvt_steps, nve_steps=nve_steps,
@@ -79,8 +105,10 @@ def coexistence_iteration(
         t_next, _, _, _ = predict_melting_point.node_function(
             sel_s, sel_p, sel_t, boundary_value=boundary_value
         )
+        next_center = _next_center(sel_s, sel_p, fallback=center)
     else:
         t_next = temperature * (1.10 if flag > 0 else 0.90)
+        next_center = center
     record = MeltingIterationRecord(
         temperature_in=float(temperature),
         temperature_next=float(t_next),
@@ -89,19 +117,29 @@ def coexistence_iteration(
         pressures=list(pressures),
         temperatures=list(temps),
         converged=False,
+        center=float(next_center),
     )
     return record
 
 
 @pwf.as_function_node("result")
 def refine_melting_point(structure, engine, t_guess, melting_input, crystalstructure):
-    """Convergence loop over the refinement schedules until |dT| <= goal."""
+    """Iterate coexistence steps until |dT| <= convergence_goal.
+
+    Refinement schedules (timestep, fit_range, nve_steps) advance one entry per
+    iteration and then HOLD at the finest entry, repeating it until the
+    temperature change between consecutive iterations meets the goal (or the
+    ``max_coexistence_iterations`` safety cap is hit). Each iteration re-centres
+    the strain grid on the previous iteration's fitted zero-pressure strain.
+    """
     mi = melting_input
     schedules = list(zip(mi.timestep_lst, mi.fit_range_lst, mi.nve_steps_lst))
     temperature = float(t_guess)
+    center = 1.0
     iterations: list[MeltingIterationRecord] = []
     converged = False
-    for step_idx, (timestep, fit_range, nve_steps) in enumerate(schedules):
+    for step_idx in range(mi.max_coexistence_iterations):
+        timestep, fit_range, nve_steps = schedules[min(step_idx, len(schedules) - 1)]
         rec = coexistence_iteration.node_function(
             structure, engine, temperature=temperature,
             crystalstructure=crystalstructure, fit_range=fit_range,
@@ -109,12 +147,14 @@ def refine_melting_point(structure, engine, t_guess, melting_input, crystalstruc
             nve_steps=nve_steps, npt_steps=mi.npt_run_steps, timestep=timestep,
             delta_t_melt=mi.delta_t_melt, ratio_boundary=mi.ratio_boundary,
             boundary_value=mi.boundary_value, seed=mi.seed,
-            npt_thermostat=mi.npt_thermostat, subdir=f"iter_{step_idx}",
+            npt_thermostat=mi.npt_thermostat, center=center, subdir=f"iter_{step_idx}",
         )
         iterations.append(rec)
         delta = abs(rec.temperature_next - temperature)
         temperature = rec.temperature_next
-        if delta <= mi.convergence_goal:
+        center = rec.center
+        # only declare convergence once the finest schedule is in effect
+        if delta <= mi.convergence_goal and step_idx >= len(schedules) - 1:
             converged = True
             break
     result = MeltingResult(
@@ -126,6 +166,7 @@ def refine_melting_point(structure, engine, t_guess, melting_input, crystalstruc
         n_atoms=len(structure),
         initial_guess=float(t_guess),
         iterations=iterations,
-        report={"schedules": schedules},
+        report={"schedules": schedules,
+                "max_coexistence_iterations": mi.max_coexistence_iterations},
     )
     return result

--- a/pyiron_workflow_atomistics/physics/melting/coexistence.py
+++ b/pyiron_workflow_atomistics/physics/melting/coexistence.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import numpy as np
+import pyiron_workflow as pwf
+
+from pyiron_workflow_atomistics.analysis.structure_descriptors import holes_mask
+from pyiron_workflow_atomistics.physics.melting.fitting import (
+    predict_melting_point,
+    ratio_selection,
+)
+from pyiron_workflow_atomistics.physics.melting.md_steps import (
+    build_solid_liquid_interface,
+    npt_relax_solid,
+    strain_scan_nvt_nve,
+)
+from pyiron_workflow_atomistics.physics.melting.outputs import (
+    MeltingIterationRecord,
+    MeltingResult,
+)
+
+
+def _strain_grid(center, fit_range, n_points):
+    return [
+        round(float(s), 4)
+        for s in np.linspace(center - fit_range, center + fit_range, n_points)
+    ]
+
+
+@pwf.as_function_node("record")
+def coexistence_iteration(
+    structure,
+    engine,
+    temperature,
+    crystalstructure,
+    fit_range=0.05,
+    n_strain_points=21,
+    nvt_steps=10000,
+    nve_steps=20000,
+    npt_steps=50000,
+    timestep=2.0,
+    delta_t_melt=1000.0,
+    ratio_boundary=0.25,
+    boundary_value=0.25,
+    seed=None,
+    subdir="iter",
+):
+    """One interface-method temperature iteration -> next-T estimate."""
+    solid, _ = npt_relax_solid.node_function(
+        structure, engine, temperature=temperature, n_steps=npt_steps,
+        timestep=timestep, seed=seed, subdir=f"{subdir}_npt",
+    )
+    interface = build_solid_liquid_interface.node_function(
+        solid, engine, t_solid=temperature, t_liquid=temperature + delta_t_melt,
+        n_steps=npt_steps, timestep=timestep, seed=seed, subdir=f"{subdir}_iface",
+    )
+    strains = _strain_grid(1.0, fit_range, n_strain_points)
+    records = strain_scan_nvt_nve.node_function(
+        interface, engine, temperature=temperature, strains=strains,
+        crystalstructure=crystalstructure, nvt_steps=nvt_steps, nve_steps=nve_steps,
+        timestep=timestep, seed=seed, subdir=f"{subdir}_strain",
+    )
+    ratios = [r["solid_fraction"] for r in records]
+    pressures = [r["mean_P"] for r in records]
+    temps = [r["mean_T"] for r in records]
+    sel_s, sel_r, sel_p, sel_t, flag = ratio_selection.node_function(
+        strains, ratios, pressures, temps, ratio_boundary=ratio_boundary
+    )
+    if len(sel_s) > 2:
+        sel_index = [strains.index(s) for s in sel_s]
+        vmax = [records[i]["voronoi_max"] for i in sel_index]
+        vmean = [records[i]["voronoi_mean"] for i in sel_index]
+        keep = holes_mask.node_function(vmax, vmean, factor=2.0)
+        sel_s = [s for s, k in zip(sel_s, keep) if k]
+        sel_p = [p for p, k in zip(sel_p, keep) if k]
+        sel_t = [t for t, k in zip(sel_t, keep) if k]
+    if len(sel_s) > 2:
+        t_next, _, _, _ = predict_melting_point.node_function(
+            sel_s, sel_p, sel_t, boundary_value=boundary_value
+        )
+    else:
+        t_next = temperature * (1.10 if flag > 0 else 0.90)
+    record = MeltingIterationRecord(
+        temperature_in=float(temperature),
+        temperature_next=float(t_next),
+        strains=list(strains),
+        ratios=list(ratios),
+        pressures=list(pressures),
+        temperatures=list(temps),
+        converged=False,
+    )
+    return record
+
+
+@pwf.as_function_node("result")
+def refine_melting_point(structure, engine, t_guess, melting_input, crystalstructure):
+    """Convergence loop over the refinement schedules until |dT| <= goal."""
+    mi = melting_input
+    schedules = list(zip(mi.timestep_lst, mi.fit_range_lst, mi.nve_steps_lst))
+    temperature = float(t_guess)
+    iterations: list[MeltingIterationRecord] = []
+    converged = False
+    for step_idx, (timestep, fit_range, nve_steps) in enumerate(schedules):
+        rec = coexistence_iteration.node_function(
+            structure, engine, temperature=temperature,
+            crystalstructure=crystalstructure, fit_range=fit_range,
+            n_strain_points=mi.n_strain_points, nvt_steps=mi.nvt_run_steps,
+            nve_steps=nve_steps, npt_steps=mi.npt_run_steps, timestep=timestep,
+            delta_t_melt=mi.delta_t_melt, ratio_boundary=mi.ratio_boundary,
+            boundary_value=mi.boundary_value, seed=mi.seed, subdir=f"iter_{step_idx}",
+        )
+        iterations.append(rec)
+        delta = abs(rec.temperature_next - temperature)
+        temperature = rec.temperature_next
+        if delta <= mi.convergence_goal:
+            converged = True
+            break
+    result = MeltingResult(
+        melting_temperature=float(temperature),
+        converged=converged,
+        n_iterations=len(iterations),
+        element=mi.element,
+        crystalstructure=crystalstructure,
+        n_atoms=len(structure),
+        initial_guess=float(t_guess),
+        iterations=iterations,
+        report={"schedules": schedules},
+    )
+    return result

--- a/pyiron_workflow_atomistics/physics/melting/coexistence.py
+++ b/pyiron_workflow_atomistics/physics/melting/coexistence.py
@@ -42,12 +42,14 @@ def coexistence_iteration(
     ratio_boundary=0.25,
     boundary_value=0.25,
     seed=None,
+    npt_thermostat="berendsen",
     subdir="iter",
 ):
     """One interface-method temperature iteration -> next-T estimate."""
     solid, _ = npt_relax_solid.node_function(
         structure, engine, temperature=temperature, n_steps=npt_steps,
-        timestep=timestep, seed=seed, subdir=f"{subdir}_npt",
+        timestep=timestep, seed=seed, npt_thermostat=npt_thermostat,
+        subdir=f"{subdir}_npt",
     )
     interface = build_solid_liquid_interface.node_function(
         solid, engine, t_solid=temperature, t_liquid=temperature + delta_t_melt,
@@ -106,7 +108,8 @@ def refine_melting_point(structure, engine, t_guess, melting_input, crystalstruc
             n_strain_points=mi.n_strain_points, nvt_steps=mi.nvt_run_steps,
             nve_steps=nve_steps, npt_steps=mi.npt_run_steps, timestep=timestep,
             delta_t_melt=mi.delta_t_melt, ratio_boundary=mi.ratio_boundary,
-            boundary_value=mi.boundary_value, seed=mi.seed, subdir=f"iter_{step_idx}",
+            boundary_value=mi.boundary_value, seed=mi.seed,
+            npt_thermostat=mi.npt_thermostat, subdir=f"iter_{step_idx}",
         )
         iterations.append(rec)
         delta = abs(rec.temperature_next - temperature)

--- a/pyiron_workflow_atomistics/physics/melting/fitting.py
+++ b/pyiron_workflow_atomistics/physics/melting/fitting.py
@@ -10,10 +10,12 @@ def ratio_selection(strains, ratios, pressures, temperatures, ratio_boundary: fl
 
     ``sl_flag`` is +1 if the selected window is mostly solid (>0.5), else -1.
     """
+    # Group by POSITION (index), not by ratio value: duplicate mid-band ratios in
+    # separate windows would otherwise be merged, breaking contiguity.
     groups, current = [], []
-    for r in ratios:
+    for i, r in enumerate(ratios):
         if (0.5 - ratio_boundary) < r < (0.5 + ratio_boundary):
-            current.append(r)
+            current.append(i)
         elif current:
             groups.append(current)
             current = []
@@ -24,13 +26,11 @@ def ratio_selection(strains, ratios, pressures, temperatures, ratio_boundary: fl
         flag = 1 if np.mean(ratios) > 0.5 else -1
     else:
         best = groups[int(np.argmax([len(g) for g in groups]))]
-        keep = [r in best for r in ratios]
-        sel_r = np.array(ratios)[keep]
-        flag = 1 if np.mean(sel_r) > 0.5 else -1
-        sel_strains = np.array(strains)[keep].tolist()
-        sel_ratios = sel_r.tolist()
-        sel_pressures = np.array(pressures)[keep].tolist()
-        sel_temperatures = np.array(temperatures)[keep].tolist()
+        sel_strains = [strains[i] for i in best]
+        sel_ratios = [ratios[i] for i in best]
+        sel_pressures = [pressures[i] for i in best]
+        sel_temperatures = [temperatures[i] for i in best]
+        flag = 1 if np.mean(sel_ratios) > 0.5 else -1
     return sel_strains, sel_ratios, sel_pressures, sel_temperatures, flag
 
 

--- a/pyiron_workflow_atomistics/physics/melting/fitting.py
+++ b/pyiron_workflow_atomistics/physics/melting/fitting.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import numpy as np
+import pyiron_workflow as pwf
+
+
+@pwf.as_function_node("strains", "ratios", "pressures", "temperatures", "sl_flag")
+def ratio_selection(strains, ratios, pressures, temperatures, ratio_boundary: float = 0.25):
+    """Keep the longest contiguous strain window with ratio in 0.5 +/- boundary.
+
+    ``sl_flag`` is +1 if the selected window is mostly solid (>0.5), else -1.
+    """
+    groups, current = [], []
+    for r in ratios:
+        if (0.5 - ratio_boundary) < r < (0.5 + ratio_boundary):
+            current.append(r)
+        elif current:
+            groups.append(current)
+            current = []
+    if current:
+        groups.append(current)
+    if not groups:
+        sel_strains, sel_ratios, sel_pressures, sel_temperatures = [], [], [], []
+        flag = 1 if np.mean(ratios) > 0.5 else -1
+    else:
+        best = groups[int(np.argmax([len(g) for g in groups]))]
+        keep = [r in best for r in ratios]
+        sel_r = np.array(ratios)[keep]
+        flag = 1 if np.mean(sel_r) > 0.5 else -1
+        sel_strains = np.array(strains)[keep].tolist()
+        sel_ratios = sel_r.tolist()
+        sel_pressures = np.array(pressures)[keep].tolist()
+        sel_temperatures = np.array(temperatures)[keep].tolist()
+    return sel_strains, sel_ratios, sel_pressures, sel_temperatures, flag
+
+
+@pwf.as_function_node("t_next", "t_mean", "t_left", "t_right")
+def predict_melting_point(strains, pressures, temperatures, boundary_value: float = 0.25):
+    """Extrapolate temperature to zero pressure; bracket via boundary_value."""
+    fit_temp_from_press = np.poly1d(np.polyfit(pressures, temperatures, 1))
+    t_next = float(fit_temp_from_press(0.0))
+    t_min, t_max = float(np.min(temperatures)), float(np.max(temperatures))
+    span = t_max - t_min
+    t_mean = t_min + span * 0.5
+    t_left = t_min + span * (0.5 - boundary_value)
+    t_right = t_min + span * (0.5 + boundary_value)
+    return t_next, t_mean, t_left, t_right

--- a/pyiron_workflow_atomistics/physics/melting/initial_guess.py
+++ b/pyiron_workflow_atomistics/physics/melting/initial_guess.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pyiron_workflow as pwf
+
+from pyiron_workflow_atomistics.analysis.structure_descriptors import cna_fractions
+from pyiron_workflow_atomistics.engine import CalcInputMD, calculate
+
+
+def _fraction(structure, key_max):
+    """Population fraction of the dominant crystalline phase ``key_max``."""
+    counts = cna_fractions.node_function(structure)
+    return counts.get(key_max, 0) / len(structure)
+
+
+def _heated_solid(structure, engine, temperature, strain_run_steps, timestep, seed,
+                  subdir):
+    """NPT-heat ``structure`` at ``temperature`` and return the final structure."""
+    md = CalcInputMD(
+        mode="NPT",
+        thermostat="berendsen",
+        temperature=temperature,
+        pressure=0.0,
+        n_ionic_steps=strain_run_steps,
+        n_print=max(1, strain_run_steps // 10),
+        time_step=timestep,
+        initial_temperature=2.0 * temperature,
+        seed=seed,
+        compressibility=1e-6,
+    )
+    tag = f"{subdir}_{int(round(temperature))}"
+    eng = replace(engine, EngineInput=md).with_working_directory(tag)
+    return calculate.node_function(structure, engine=eng).final_structure
+
+
+@pwf.as_function_node("t_guess", "structure")
+def estimate_melting_temperature(
+    structure,
+    engine,
+    key_max,
+    distribution_half,
+    crystalstructure,
+    temperature_left=0.0,
+    temperature_right=1000.0,
+    strain_run_steps=1000,
+    timestep=2.0,
+    seed=None,
+    t_step_min=10.0,
+    max_iterations=40,
+    t_ceiling=None,
+    subdir="guess",
+):
+    """Bisection: heat the bulk solid in NPT; raise T while it stays crystalline.
+
+    Port of ``get_initial_melting_temperature_guess`` + ``next_step_funct`` with
+    a hard ``max_iterations`` guard and ``t_ceiling`` so an undersampled MD run
+    (where nothing melts) cannot expand the bracket without bound.
+    """
+    ceiling = t_ceiling if t_ceiling is not None else max(
+        temperature_right * 3.0, temperature_right + 1.0
+    )
+    t_left, t_right = temperature_left, temperature_right
+    struct_left = structure
+    struct_right = _heated_solid(
+        structure, engine, t_right, strain_run_steps, timestep, seed, subdir
+    )
+    step = t_right - t_left
+    iteration = 0
+    while step > t_step_min and iteration < max_iterations:
+        iteration += 1
+        f_left = _fraction(struct_left, key_max)
+        f_right = _fraction(struct_right, key_max)
+        diff = t_right - t_left
+        if f_left > distribution_half and f_right > distribution_half:
+            if t_right >= ceiling:
+                break
+            struct_left, t_left = struct_right.copy(), t_right
+            t_right = min(t_right + diff, ceiling)
+            struct_right = _heated_solid(
+                structure, engine, t_right, strain_run_steps, timestep, seed, subdir
+            )
+        elif f_left > distribution_half >= f_right:
+            diff /= 2.0
+            t_left += diff
+            struct_left = _heated_solid(
+                structure, engine, t_left, strain_run_steps, timestep, seed, subdir
+            )
+        else:  # both molten
+            diff /= 2.0
+            t_right, struct_right = t_left, struct_left.copy()
+            t_left -= diff
+            struct_left = _heated_solid(
+                structure, engine, t_left, strain_run_steps, timestep, seed, subdir
+            )
+        step = t_right - t_left
+    t_guess = int(round(t_left))
+    return t_guess, struct_left

--- a/pyiron_workflow_atomistics/physics/melting/initial_guess.py
+++ b/pyiron_workflow_atomistics/physics/melting/initial_guess.py
@@ -94,12 +94,21 @@ def estimate_melting_temperature(
                 structure, engine, t_left, strain_run_steps, timestep, seed, subdir,
                 npt_thermostat=npt_thermostat,
             )
-        else:  # both molten
+        elif f_left <= distribution_half and f_right <= distribution_half:  # both molten
             diff /= 2.0
             t_right, struct_right = t_left, struct_left.copy()
             t_left -= diff
             struct_left = _heated_solid(
                 structure, engine, t_left, strain_run_steps, timestep, seed, subdir,
+                npt_thermostat=npt_thermostat,
+            )
+        else:  # inverted (left molten, right solid): non-physical/noisy CNA — shrink
+            # the bracket from the right and re-sample nearer the middle rather than
+            # silently treating it as both-molten.
+            diff /= 2.0
+            t_right -= diff
+            struct_right = _heated_solid(
+                structure, engine, t_right, strain_run_steps, timestep, seed, subdir,
                 npt_thermostat=npt_thermostat,
             )
         step = t_right - t_left

--- a/pyiron_workflow_atomistics/physics/melting/initial_guess.py
+++ b/pyiron_workflow_atomistics/physics/melting/initial_guess.py
@@ -15,11 +15,15 @@ def _fraction(structure, key_max):
 
 
 def _heated_solid(structure, engine, temperature, strain_run_steps, timestep, seed,
-                  subdir):
-    """NPT-heat ``structure`` at ``temperature`` and return the final structure."""
+                  subdir, npt_thermostat="berendsen"):
+    """NPT-heat ``structure`` at ``temperature`` and return the final structure.
+
+    ``npt_thermostat`` must keep the cell isotropic/orthorhombic ("berendsen" for
+    ASE, "nose-hoover" for LAMMPS) so CNA classification stays valid.
+    """
     md = CalcInputMD(
         mode="NPT",
-        thermostat="berendsen",
+        thermostat=npt_thermostat,
         temperature=temperature,
         pressure=0.0,
         n_ionic_steps=strain_run_steps,
@@ -49,6 +53,7 @@ def estimate_melting_temperature(
     t_step_min=10.0,
     max_iterations=40,
     t_ceiling=None,
+    npt_thermostat="berendsen",
     subdir="guess",
 ):
     """Bisection: heat the bulk solid in NPT; raise T while it stays crystalline.
@@ -63,7 +68,8 @@ def estimate_melting_temperature(
     t_left, t_right = temperature_left, temperature_right
     struct_left = structure
     struct_right = _heated_solid(
-        structure, engine, t_right, strain_run_steps, timestep, seed, subdir
+        structure, engine, t_right, strain_run_steps, timestep, seed, subdir,
+        npt_thermostat=npt_thermostat,
     )
     step = t_right - t_left
     iteration = 0
@@ -78,20 +84,23 @@ def estimate_melting_temperature(
             struct_left, t_left = struct_right.copy(), t_right
             t_right = min(t_right + diff, ceiling)
             struct_right = _heated_solid(
-                structure, engine, t_right, strain_run_steps, timestep, seed, subdir
+                structure, engine, t_right, strain_run_steps, timestep, seed, subdir,
+                npt_thermostat=npt_thermostat,
             )
         elif f_left > distribution_half >= f_right:
             diff /= 2.0
             t_left += diff
             struct_left = _heated_solid(
-                structure, engine, t_left, strain_run_steps, timestep, seed, subdir
+                structure, engine, t_left, strain_run_steps, timestep, seed, subdir,
+                npt_thermostat=npt_thermostat,
             )
         else:  # both molten
             diff /= 2.0
             t_right, struct_right = t_left, struct_left.copy()
             t_left -= diff
             struct_left = _heated_solid(
-                structure, engine, t_left, strain_run_steps, timestep, seed, subdir
+                structure, engine, t_left, strain_run_steps, timestep, seed, subdir,
+                npt_thermostat=npt_thermostat,
             )
         step = t_right - t_left
     t_guess = int(round(t_left))

--- a/pyiron_workflow_atomistics/physics/melting/inputs.py
+++ b/pyiron_workflow_atomistics/physics/melting/inputs.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class MeltingInput:
+    """Parameters for an interface-method melting-point run (notebook defaults)."""
+
+    element: str
+    crystalstructure: str | None = None  # default: ASE reference state
+    a: float | None = None
+    n_atoms: int = 8000  # solid cell targets n_atoms/2
+    temperature_left: float = 0.0
+    temperature_right: float = 1000.0
+    convergence_goal: float = 1.0  # K
+    timestep_lst: list[float] = field(default_factory=lambda: [2.0, 2.0, 1.0])
+    fit_range_lst: list[float] = field(default_factory=lambda: [0.05, 0.01, 0.01])
+    nve_steps_lst: list[int] = field(default_factory=lambda: [25000, 20000, 50000])
+    nvt_run_steps: int = 10000
+    npt_run_steps: int = 50000
+    strain_run_steps: int = 1000
+    n_strain_points: int = 21
+    ratio_boundary: float = 0.25
+    boundary_value: float = 0.25
+    delta_t_melt: float = 1000.0  # superheat for interface build
+    seed: int | None = None

--- a/pyiron_workflow_atomistics/physics/melting/inputs.py
+++ b/pyiron_workflow_atomistics/physics/melting/inputs.py
@@ -25,3 +25,6 @@ class MeltingInput:
     boundary_value: float = 0.25
     delta_t_melt: float = 1000.0  # superheat for interface build
     seed: int | None = None
+    # NPT thermostat must keep the cell isotropic/orthorhombic: "berendsen" for the
+    # ASE engine, "nose-hoover" for the LAMMPS engine (fix npt ... iso).
+    npt_thermostat: str = "berendsen"

--- a/pyiron_workflow_atomistics/physics/melting/inputs.py
+++ b/pyiron_workflow_atomistics/physics/melting/inputs.py
@@ -14,6 +14,7 @@ class MeltingInput:
     temperature_left: float = 0.0
     temperature_right: float = 1000.0
     convergence_goal: float = 1.0  # K
+    max_coexistence_iterations: int = 12  # safety cap on the refinement loop
     timestep_lst: list[float] = field(default_factory=lambda: [2.0, 2.0, 1.0])
     fit_range_lst: list[float] = field(default_factory=lambda: [0.05, 0.01, 0.01])
     nve_steps_lst: list[int] = field(default_factory=lambda: [25000, 20000, 50000])

--- a/pyiron_workflow_atomistics/physics/melting/md_steps.py
+++ b/pyiron_workflow_atomistics/physics/melting/md_steps.py
@@ -38,12 +38,19 @@ def npt_relax_solid(
     n_steps=10000,
     timestep=2.0,
     seed=None,
+    npt_thermostat="berendsen",
     subdir="npt_solid",
 ):
-    """NPT MD on the bulk solid at ``temperature`` (P=0)."""
+    """NPT MD on the bulk solid at ``temperature`` (P=0).
+
+    ``npt_thermostat`` must yield an *isotropic* (orthorhombic) cell so the
+    downstream CNA/Voronoi analyses stay valid: use ``"berendsen"`` for the ASE
+    engine (scalar-pressure, orthorhombic) and ``"nose-hoover"`` for the LAMMPS
+    engine (``fix npt ... iso``). Full triclinic NPT must be avoided.
+    """
     md = CalcInputMD(
         mode="NPT",
-        thermostat="berendsen",
+        thermostat=npt_thermostat,
         temperature=temperature,
         pressure=0.0,
         n_ionic_steps=n_steps,

--- a/pyiron_workflow_atomistics/physics/melting/md_steps.py
+++ b/pyiron_workflow_atomistics/physics/melting/md_steps.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pyiron_workflow as pwf
+
+from pyiron_workflow_atomistics.analysis.structure_descriptors import voronoi_max_mean
+from pyiron_workflow_atomistics.analysis.trajectory import (
+    pressures_from_trajectory,
+    temperatures_from_trajectory,
+)
+from pyiron_workflow_atomistics.engine import CalcInputMD, calculate
+from pyiron_workflow_atomistics.physics.melting.solid_fraction import solid_fraction_kde
+from pyiron_workflow_atomistics.physics.melting.structures import (
+    freeze_half,
+    strain_cell_along_z,
+    unfreeze,
+)
+
+
+def _engine_with(engine, calc_input, subdir):
+    """Engine copy carrying ``calc_input`` and a per-step working subdirectory."""
+    return replace(engine, EngineInput=calc_input).with_working_directory(subdir)
+
+
+@pwf.as_function_node("engine_out")
+def with_calc_input(engine, calc_input):
+    """Return an engine copy whose EngineInput is replaced by ``calc_input``."""
+    engine_out = replace(engine, EngineInput=calc_input)
+    return engine_out
+
+
+@pwf.as_function_node("relaxed_structure", "engine_output")
+def npt_relax_solid(
+    structure,
+    engine,
+    temperature,
+    n_steps=10000,
+    timestep=2.0,
+    seed=None,
+    subdir="npt_solid",
+):
+    """NPT MD on the bulk solid at ``temperature`` (P=0)."""
+    md = CalcInputMD(
+        mode="NPT",
+        thermostat="berendsen",
+        temperature=temperature,
+        pressure=0.0,
+        n_ionic_steps=n_steps,
+        n_print=max(1, n_steps // 100),
+        time_step=timestep,
+        initial_temperature=2.0 * temperature,
+        seed=seed,
+        compressibility=1e-6,
+    )
+    out = calculate.node_function(structure, engine=_engine_with(engine, md, subdir))
+    return out.final_structure, out
+
+
+@pwf.as_function_node("interface_structure")
+def build_solid_liquid_interface(
+    structure,
+    engine,
+    t_solid,
+    t_liquid,
+    n_steps=10000,
+    timestep=2.0,
+    seed=None,
+    subdir="interface",
+):
+    """Freeze lower half, melt upper half at t_liquid (NVT), recool to t_solid."""
+    frozen = freeze_half.node_function(structure)
+    melt_md = CalcInputMD(
+        mode="NVT",
+        thermostat="langevin",
+        temperature=t_liquid,
+        n_ionic_steps=n_steps,
+        n_print=max(1, n_steps // 100),
+        time_step=timestep,
+        initial_temperature=2.0 * t_liquid,
+        seed=seed,
+    )
+    melted = calculate.node_function(
+        frozen, engine=_engine_with(engine, melt_md, f"{subdir}_melt")
+    ).final_structure
+    cool_md = CalcInputMD(
+        mode="NVT",
+        thermostat="langevin",
+        temperature=t_solid,
+        n_ionic_steps=n_steps,
+        n_print=max(1, n_steps // 100),
+        time_step=timestep,
+        initial_temperature=2.0 * t_solid,
+        seed=seed,
+    )
+    cooled = calculate.node_function(
+        melted, engine=_engine_with(engine, cool_md, f"{subdir}_cool")
+    ).final_structure
+    interface_structure = unfreeze.node_function(cooled)
+    return interface_structure
+
+
+@pwf.as_function_node("records")
+def strain_scan_nvt_nve(
+    structure,
+    engine,
+    temperature,
+    strains,
+    crystalstructure,
+    nvt_steps=10000,
+    nve_steps=20000,
+    timestep=2.0,
+    seed=None,
+    last_n=20,
+    subdir="strain",
+):
+    """For each strain: NVT-equilibrate then NVE; record T, P, solid fraction, voronoi."""
+    records = []
+    for i, strain in enumerate(strains):
+        strained = strain_cell_along_z.node_function(structure, strain)
+        nvt_md = CalcInputMD(
+            mode="NVT",
+            thermostat="langevin",
+            temperature=temperature,
+            n_ionic_steps=nvt_steps,
+            n_print=max(1, nvt_steps // 100),
+            time_step=timestep,
+            initial_temperature=2.0 * temperature,
+            seed=seed,
+        )
+        equil = calculate.node_function(
+            strained, engine=_engine_with(engine, nvt_md, f"{subdir}_nvt_{i:03d}")
+        ).final_structure
+        nve_md = CalcInputMD(
+            mode="NVE",
+            temperature=temperature,
+            n_ionic_steps=nve_steps,
+            n_print=max(1, nve_steps // 100),
+            time_step=timestep,
+            initial_temperature=2.0 * temperature,
+            seed=seed,
+        )
+        nve_out = calculate.node_function(
+            equil, engine=_engine_with(engine, nve_md, f"{subdir}_nve_{i:03d}")
+        )
+        vmax, vmean = voronoi_max_mean.node_function(nve_out.final_structure)
+        records.append(
+            {
+                "strain": strain,
+                "mean_T": temperatures_from_trajectory.node_function(
+                    nve_out, last_n=last_n
+                ),
+                "mean_P": pressures_from_trajectory.node_function(nve_out, last_n=last_n),
+                "solid_fraction": solid_fraction_kde.node_function(
+                    nve_out.final_structure, crystalstructure
+                ),
+                "voronoi_max": vmax,
+                "voronoi_mean": vmean,
+            }
+        )
+    return records

--- a/pyiron_workflow_atomistics/physics/melting/md_steps.py
+++ b/pyiron_workflow_atomistics/physics/melting/md_steps.py
@@ -23,13 +23,6 @@ def _engine_with(engine, calc_input, subdir):
     return replace(engine, EngineInput=calc_input).with_working_directory(subdir)
 
 
-@pwf.as_function_node("engine_out")
-def with_calc_input(engine, calc_input):
-    """Return an engine copy whose EngineInput is replaced by ``calc_input``."""
-    engine_out = replace(engine, EngineInput=calc_input)
-    return engine_out
-
-
 @pwf.as_function_node("relaxed_structure", "engine_output")
 def npt_relax_solid(
     structure,
@@ -138,13 +131,18 @@ def strain_scan_nvt_nve(
         equil = calculate.node_function(
             strained, engine=_engine_with(engine, nvt_md, f"{subdir}_nvt_{i:03d}")
         ).final_structure
+        # The NVE input `equil` is already NVT-equilibrated at `temperature`
+        # (thermally warm, PE above the lattice minimum). The 2*T half-velocity
+        # trick is only valid from a COLD lattice; re-seeding a warm config at 2*T
+        # equipartitions to a kinetic temperature ~1.5*T. Re-seed at 1*T so the
+        # thermostat-free NVE settles back to ~T (the measured coexistence T).
         nve_md = CalcInputMD(
             mode="NVE",
             temperature=temperature,
             n_ionic_steps=nve_steps,
             n_print=max(1, nve_steps // 100),
             time_step=timestep,
-            initial_temperature=2.0 * temperature,
+            initial_temperature=temperature,
             seed=seed,
         )
         nve_out = calculate.node_function(

--- a/pyiron_workflow_atomistics/physics/melting/outputs.py
+++ b/pyiron_workflow_atomistics/physics/melting/outputs.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields
+from typing import Any
+
+
+@dataclass
+class MeltingIterationRecord:
+    temperature_in: float
+    temperature_next: float
+    strains: list[float]
+    ratios: list[float]
+    pressures: list[float]
+    temperatures: list[float]
+    converged: bool
+
+
+@dataclass
+class MeltingResult:
+    melting_temperature: float
+    converged: bool
+    n_iterations: int
+    element: str
+    crystalstructure: str
+    n_atoms: int
+    initial_guess: float
+    iterations: list[MeltingIterationRecord] = field(default_factory=list)
+    report: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {f.name: getattr(self, f.name) for f in fields(self)}

--- a/pyiron_workflow_atomistics/physics/melting/outputs.py
+++ b/pyiron_workflow_atomistics/physics/melting/outputs.py
@@ -13,6 +13,7 @@ class MeltingIterationRecord:
     pressures: list[float]
     temperatures: list[float]
     converged: bool
+    center: float = 1.0  # fitted zero-pressure strain; next grid re-centres here
 
 
 @dataclass

--- a/pyiron_workflow_atomistics/physics/melting/solid_fraction.py
+++ b/pyiron_workflow_atomistics/physics/melting/solid_fraction.py
@@ -15,6 +15,10 @@ def solid_fraction_kde(structure, crystalstructure: str, threshold: float = 0.1)
     method's ``plot_solid_liquid_ratio`` (minus plotting).
     """
     target = crystalstructure.lower()
+    # Wrap coordinates into the cell (the notebook's center_coordinates_in_unit_cell):
+    # MD lets atoms drift across PBC, so the raw z would smear the KDE slab width.
+    structure = structure.copy()
+    structure.wrap()
     labels = np.array(
         get_adaptive_cna_descriptors(
             structure=structure, mode="str", ovito_compatibility=False

--- a/pyiron_workflow_atomistics/physics/melting/solid_fraction.py
+++ b/pyiron_workflow_atomistics/physics/melting/solid_fraction.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import numpy as np
+import pyiron_workflow as pwf
+from sklearn.neighbors import KernelDensity
+from structuretoolkit.analyse import get_adaptive_cna_descriptors
+
+
+@pwf.as_function_node("solid_fraction")
+def solid_fraction_kde(structure, crystalstructure: str, threshold: float = 0.1) -> float:
+    """Fraction of the z-extent occupied by the crystalline phase.
+
+    Per-atom CNA labels the target phase; a 1-D KDE of those atoms' z-positions
+    gives the solid slab width relative to the cell. Mirrors the interface
+    method's ``plot_solid_liquid_ratio`` (minus plotting).
+    """
+    target = crystalstructure.lower()
+    labels = np.array(
+        get_adaptive_cna_descriptors(
+            structure=structure, mode="str", ovito_compatibility=False
+        )
+    )
+    z = structure.get_positions()[:, 2]
+    mask = labels == target
+    if mask.sum() <= 0.05 * len(structure):
+        ratio = 0.0
+    else:
+        bandwidth = (structure.get_volume() / len(structure)) ** (1.0 / 3.0)
+        kde = KernelDensity(kernel="gaussian", bandwidth=bandwidth).fit(
+            z[mask].reshape(-1, 1)
+        )
+        grid = np.linspace(z.min(), z.max(), 1000)
+        g = np.exp(kde.score_samples(grid.reshape(-1, 1)))
+        g = g / g.max()
+        above = grid[g > threshold]
+        below = grid[g < threshold]
+        span = grid.max() - grid.min()
+        ratio_above = (above.max() - above.min()) / span if len(above) else 1.0
+        ratio_below = 1.0 - (below.max() - below.min()) / span if len(below) else 0.0
+        if ratio_below == 0.0:
+            ratio = ratio_above
+        elif ratio_above == 1.0:
+            ratio = ratio_below
+        else:
+            ratio = min(ratio_below, ratio_above)
+    return float(ratio)

--- a/pyiron_workflow_atomistics/physics/melting/structures.py
+++ b/pyiron_workflow_atomistics/physics/melting/structures.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import numpy as np
+import pyiron_workflow as pwf
+from ase.build import bulk
+from ase.constraints import FixAtoms
+
+
+@pwf.as_function_node("structure")
+def create_coexistence_supercell(
+    element: str,
+    crystalstructure: str | None = None,
+    a: float | None = None,
+    n_atoms: int = 8000,
+):
+    """Cubic bulk repeated i x i x i so the atom count is closest to ``n_atoms/2``."""
+    base = bulk(element, crystalstructure, a=a, cubic=True)
+    target = n_atoms / 2.0
+    reps = range(2, 30)
+    cells = [base.repeat((i, i, i)) for i in reps]
+    structure = cells[int(np.argmin([abs(len(c) - target) for c in cells]))]
+    return structure
+
+
+@pwf.as_function_node("structure")
+def freeze_half(structure, axis: int = 2, fraction: float = 0.5):
+    """Fix atoms whose scaled coordinate along ``axis`` is below ``fraction``."""
+    s = structure.copy()
+    scaled = s.get_scaled_positions()[:, axis]
+    s.set_constraint(FixAtoms(indices=np.where(scaled < fraction)[0]))
+    return s
+
+
+@pwf.as_function_node("structure")
+def unfreeze(structure):
+    """Remove all constraints."""
+    s = structure.copy()
+    s.set_constraint()
+    return s
+
+
+@pwf.as_function_node("structure")
+def strain_cell_along_z(structure, strain: float):
+    """Scale cell vector c by ``strain`` (scale_atoms=True)."""
+    s = structure.copy()
+    cell = s.cell.copy()
+    cell[2, 2] *= strain
+    s.set_cell(cell, scale_atoms=True)
+    return s

--- a/pyiron_workflow_atomistics/physics/melting/structures.py
+++ b/pyiron_workflow_atomistics/physics/melting/structures.py
@@ -13,8 +13,18 @@ def create_coexistence_supercell(
     a: float | None = None,
     n_atoms: int = 8000,
 ):
-    """Cubic bulk repeated i x i x i so the atom count is closest to ``n_atoms/2``."""
-    base = bulk(element, crystalstructure, a=a, cubic=True)
+    """Bulk repeated i x i x i so the atom count is closest to ``n_atoms/2``.
+
+    Uses a cubic conventional cell where possible; hcp falls back to an
+    orthorhombic cell (cubic=True is invalid for hcp), matching the notebook.
+    """
+    cs = (crystalstructure or "").lower()
+    if cs == "hcp":
+        base = bulk(element, crystalstructure, a=a, orthorhombic=True)
+    elif crystalstructure is None:
+        base = bulk(element, a=a)
+    else:
+        base = bulk(element, crystalstructure, a=a, cubic=True)
     target = n_atoms / 2.0
     reps = range(2, 30)
     cells = [base.repeat((i, i, i)) for i in reps]

--- a/pyiron_workflow_atomistics/physics/melting/study.py
+++ b/pyiron_workflow_atomistics/physics/melting/study.py
@@ -39,7 +39,7 @@ def calculate_melting_point(engine, melting_input):
         relaxed, engine, key_max=key_max, distribution_half=distribution_half,
         crystalstructure=crystalstructure, temperature_left=mi.temperature_left,
         temperature_right=mi.temperature_right, strain_run_steps=mi.strain_run_steps,
-        timestep=mi.timestep_lst[0], seed=mi.seed,
+        timestep=mi.timestep_lst[0], seed=mi.seed, npt_thermostat=mi.npt_thermostat,
     )
     result = refine_melting_point.node_function(
         struct_at_guess, engine, t_guess=t_guess, melting_input=mi,

--- a/pyiron_workflow_atomistics/physics/melting/study.py
+++ b/pyiron_workflow_atomistics/physics/melting/study.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pyiron_workflow as pwf
+from ase.data import atomic_numbers, reference_states
+
+from pyiron_workflow_atomistics.analysis.structure_descriptors import (
+    analyse_reference_structure,
+)
+from pyiron_workflow_atomistics.engine import CalcInputMinimize, calculate
+from pyiron_workflow_atomistics.physics.melting.coexistence import refine_melting_point
+from pyiron_workflow_atomistics.physics.melting.initial_guess import (
+    estimate_melting_temperature,
+)
+from pyiron_workflow_atomistics.physics.melting.structures import (
+    create_coexistence_supercell,
+)
+
+
+def _default_crystalstructure(element):
+    return reference_states[atomic_numbers[element]]["symmetry"]
+
+
+@pwf.as_function_node("result")
+def calculate_melting_point(engine, melting_input):
+    """Full interface-method melting point: build -> relax -> Step 1 -> Step 2."""
+    mi = melting_input
+    crystalstructure = mi.crystalstructure or _default_crystalstructure(mi.element)
+    structure = create_coexistence_supercell.node_function(
+        mi.element, crystalstructure, a=mi.a, n_atoms=mi.n_atoms
+    )
+    relax_engine = replace(
+        engine, EngineInput=CalcInputMinimize(relax_cell=True)
+    ).with_working_directory("minimize")
+    relaxed = calculate.node_function(structure, engine=relax_engine).final_structure
+    key_max, _, distribution_half = analyse_reference_structure.node_function(relaxed)
+    t_guess, struct_at_guess = estimate_melting_temperature.node_function(
+        relaxed, engine, key_max=key_max, distribution_half=distribution_half,
+        crystalstructure=crystalstructure, temperature_left=mi.temperature_left,
+        temperature_right=mi.temperature_right, strain_run_steps=mi.strain_run_steps,
+        timestep=mi.timestep_lst[0], seed=mi.seed,
+    )
+    result = refine_melting_point.node_function(
+        struct_at_guess, engine, t_guess=t_guess, melting_input=mi,
+        crystalstructure=crystalstructure,
+    )
+    return result

--- a/scripts/_verify_emt_demo.py
+++ b/scripts/_verify_emt_demo.py
@@ -1,0 +1,38 @@
+import time, json, os
+from ase.calculators.emt import EMT
+from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+from pyiron_workflow_atomistics.physics.melting import MeltingInput, calculate_melting_point
+
+OUT = "/ptmp/hmai/pwa_melting/_verify_runs/emt_full"
+os.makedirs(OUT, exist_ok=True)
+mi = MeltingInput(
+    element="Al", crystalstructure="fcc", a=4.05, n_atoms=500,
+    temperature_left=0.0, temperature_right=1500.0, strain_run_steps=200,
+    timestep_lst=[2.0], fit_range_lst=[0.05], nve_steps_lst=[300],
+    nvt_run_steps=300, npt_run_steps=300, n_strain_points=7,
+    ratio_boundary=0.3, boundary_value=0.25, seed=1,
+)
+eng = ASEEngine(EngineInput=CalcInputStatic(), calculator=EMT(), working_directory=OUT)
+t0 = time.time()
+res = calculate_melting_point.node_function(eng, mi)
+dt = time.time() - t0
+d = res.to_dict()
+# strip heavy iteration structures for the JSON summary
+summary = {
+    "element": d["element"], "crystalstructure": d["crystalstructure"],
+    "n_atoms": d["n_atoms"], "initial_guess_K": d["initial_guess"],
+    "melting_temperature_K": d["melting_temperature"], "converged": d["converged"],
+    "n_iterations": d["n_iterations"], "wall_seconds": round(dt, 1),
+    "iterations": [
+        {"T_in": it.temperature_in, "T_next": it.temperature_next,
+         "ratios": [round(r, 3) for r in it.ratios],
+         "pressures_GPa": [round(p, 4) for p in it.pressures],
+         "temperatures_K": [round(t, 1) for t in it.temperatures]}
+        for it in d["iterations"]
+    ],
+}
+with open(os.path.join(OUT, "summary.json"), "w") as f:
+    json.dump(summary, f, indent=2)
+print("EMT FULL-METHOD DEMO:")
+print(json.dumps(summary, indent=2))
+print("DONE_EMT_DEMO ->", os.path.join(OUT, "summary.json"))

--- a/scripts/_verify_grace_ase_step1.py
+++ b/scripts/_verify_grace_ase_step1.py
@@ -1,0 +1,44 @@
+"""V3: Step-1 melting-temperature estimate through the ASE engine with a GRACE
+foundation-model calculator. Run on a GPU node."""
+
+import json
+import os
+import time
+
+os.environ.setdefault("GRACE_CACHE", "/ptmp/hmai/grace_cache")
+
+from ase.build import bulk  # noqa: E402
+
+from pyiron_workflow_atomistics.analysis.structure_descriptors import (  # noqa: E402
+    analyse_reference_structure,
+)
+from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic  # noqa: E402
+from pyiron_workflow_atomistics.physics.melting.initial_guess import (  # noqa: E402
+    estimate_melting_temperature,
+)
+from tensorpotential.calculator import grace_fm  # noqa: E402
+
+OUT = "/ptmp/hmai/pwa_melting/_verify_runs/grace_ase_step1"
+os.makedirs(OUT, exist_ok=True)
+
+calc = grace_fm("GRACE-1L-OAM")
+atoms = bulk("Al", "fcc", a=4.05, cubic=True).repeat((3, 3, 3))  # 108 atoms
+key_max, _, half = analyse_reference_structure.node_function(atoms)
+eng = ASEEngine(EngineInput=CalcInputStatic(), calculator=calc, working_directory=OUT)
+t0 = time.time()
+t_guess, struct = estimate_melting_temperature.node_function(
+    atoms, eng, key_max=key_max, distribution_half=half, crystalstructure="fcc",
+    temperature_left=0.0, temperature_right=1400.0, strain_run_steps=150,
+    timestep=2.0, seed=1, t_step_min=50.0, max_iterations=10,
+    npt_thermostat="berendsen",
+)
+out = {
+    "engine": "ASEEngine(grace_fm GRACE-1L-OAM)",
+    "n_atoms": len(atoms),
+    "t_guess_K": t_guess,
+    "wall_seconds": round(time.time() - t0, 1),
+}
+with open(os.path.join(OUT, "summary.json"), "w") as f:
+    json.dump(out, f, indent=2)
+print(json.dumps(out, indent=2))
+print("DONE_GRACE_ASE ->", os.path.join(OUT, "summary.json"))

--- a/scripts/_verify_lammps_grace_coex.py
+++ b/scripts/_verify_lammps_grace_coex.py
@@ -1,0 +1,49 @@
+"""V4: one interface-method coexistence iteration through the LAMMPS engine
+(pair_style grace). Demonstrates the engine-agnostic melting algorithm running
+unchanged on LAMMPS. Run on a GPU node (module load cuda)."""
+
+import json
+import os
+import time
+
+from ase.build import bulk
+
+from pyiron_workflow_atomistics.engine import CalcInputStatic
+from pyiron_workflow_atomistics.physics.melting.coexistence import coexistence_iteration
+from pyiron_workflow_lammps.engine import LammpsEngine
+
+OUT = "/ptmp/hmai/pwa_melting/_verify_runs/lammps_grace_coex"
+os.makedirs(OUT, exist_ok=True)
+LMP = "/ptmp/hmai/lammps/build/lmp"
+MODEL = "/ptmp/hmai/grace_cache/GRACE-1L-OAM"
+
+atoms = bulk("Al", "fcc", a=4.05, cubic=True).repeat((3, 3, 6))  # 216 atoms
+eng = LammpsEngine(
+    EngineInput=CalcInputStatic(),
+    working_directory=OUT,
+    command=f"{LMP} -in in.lmp -log log.lammps",
+    path_to_model=MODEL,
+    input_script_pair_style="grace",
+)
+t0 = time.time()
+rec = coexistence_iteration.node_function(
+    atoms, eng, temperature=900.0, crystalstructure="fcc", fit_range=0.05,
+    n_strain_points=5, nvt_steps=200, nve_steps=200, npt_steps=200, timestep=2.0,
+    delta_t_melt=1000.0, ratio_boundary=0.4, boundary_value=0.25, seed=1,
+    npt_thermostat="nose-hoover", subdir="coex",
+)
+out = {
+    "engine": "LammpsEngine(pair_style grace, GRACE-1L-OAM)",
+    "n_atoms": len(atoms),
+    "temperature_in_K": rec.temperature_in,
+    "temperature_next_K": rec.temperature_next,
+    "strains": rec.strains,
+    "solid_fraction": [round(r, 3) for r in rec.ratios],
+    "pressures_GPa": [round(p, 4) for p in rec.pressures],
+    "temperatures_K": [round(t, 1) for t in rec.temperatures],
+    "wall_seconds": round(time.time() - t0, 1),
+}
+with open(os.path.join(OUT, "summary.json"), "w") as f:
+    json.dump(out, f, indent=2)
+print(json.dumps(out, indent=2))
+print("DONE_LAMMPS_COEX ->", os.path.join(OUT, "summary.json"))

--- a/scripts/_verify_lammps_grace_smoke.py
+++ b/scripts/_verify_lammps_grace_smoke.py
@@ -1,0 +1,43 @@
+import os, time, numpy as np
+from ase.build import bulk
+from pyiron_workflow_lammps.engine import LammpsEngine
+from pyiron_workflow_atomistics.engine import CalcInputMD, calculate
+from pyiron_workflow_atomistics.analysis.trajectory import (
+    temperatures_from_trajectory, pressures_from_trajectory,
+)
+
+OUT = "/ptmp/hmai/pwa_melting/_verify_runs/lammps_grace_smoke"
+os.makedirs(OUT, exist_ok=True)
+LMP = "/ptmp/hmai/lammps/build/lmp"
+MODEL = "/ptmp/hmai/grace_cache/GRACE-1L-OAM"
+
+atoms = bulk("Al", "fcc", a=4.05, cubic=True).repeat((3, 3, 3))  # 108 atoms
+md = CalcInputMD(mode="NVT", thermostat="nose-hoover", temperature=600.0,
+                 n_ionic_steps=20, n_print=2, time_step=2.0,
+                 thermostat_time_constant=100.0, seed=1, initial_temperature=1200.0)
+eng = LammpsEngine(
+    EngineInput=md,
+    working_directory=OUT,
+    command=f"{LMP} -in in.lmp -log log.lammps",
+    path_to_model=MODEL,
+    input_script_pair_style="grace",
+)
+t0 = time.time()
+out = calculate.node_function(atoms, engine=eng)
+dt = time.time() - t0
+print("converged:", out.converged)
+nframes = None if out.structures is None else len(out.structures)
+print("n trajectory frames:", nframes)
+print("n stresses:", None if out.stresses is None else len(out.stresses))
+if out.structures:
+    v = out.structures[-1].get_velocities()
+    print("final frame has nonzero velocities:", bool(np.abs(v).sum() > 0))
+    print("final frame get_temperature (K):", round(out.structures[-1].get_temperature(), 1))
+try:
+    T = temperatures_from_trajectory.node_function(out, last_n=5)
+    P = pressures_from_trajectory.node_function(out, last_n=5)
+    print("mean T (K):", round(T, 1), "| mean P (GPa):", round(P, 4))
+except Exception as e:
+    print("analysis ERR:", repr(e))
+print("wall_seconds:", round(dt, 1))
+print("DONE_LAMMPS_SMOKE")

--- a/scripts/meltingpoint.py
+++ b/scripts/meltingpoint.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+"""Interface-method melting point - runnable port of meltingpoint.ipynb.
+
+Step 1 (rough estimate) by default; pass --full for the full coexistence method.
+Uses the ASE engine with EMT by default (swap in a GRACE calculator for production).
+
+Examples
+--------
+    python scripts/meltingpoint.py --element Al --a 4.05            # Step-1 estimate
+    python scripts/meltingpoint.py --element Al --a 4.05 --full     # full method
+"""
+
+from __future__ import annotations
+
+import argparse
+
+
+def run(
+    element="Al",
+    crystalstructure="fcc",
+    a=4.05,
+    n_atoms=4000,
+    working_directory="melting_run",
+    full=False,
+    temperature_right=1000.0,
+    strain_run_steps=1000,
+    seed=12345,
+):
+    from ase.calculators.emt import EMT
+
+    from pyiron_workflow_atomistics.analysis.structure_descriptors import (
+        analyse_reference_structure,
+    )
+    from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+    from pyiron_workflow_atomistics.physics.melting import (
+        MeltingInput,
+        calculate_melting_point,
+    )
+    from pyiron_workflow_atomistics.physics.melting.initial_guess import (
+        estimate_melting_temperature,
+    )
+    from pyiron_workflow_atomistics.physics.melting.structures import (
+        create_coexistence_supercell,
+    )
+
+    engine = ASEEngine(
+        EngineInput=CalcInputStatic(), calculator=EMT(),
+        working_directory=working_directory,
+    )
+    if full:
+        mi = MeltingInput(
+            element=element, crystalstructure=crystalstructure, a=a, n_atoms=n_atoms,
+            temperature_right=temperature_right, strain_run_steps=strain_run_steps,
+            seed=seed,
+        )
+        res = calculate_melting_point.node_function(engine, mi).to_dict()
+        print(
+            f"Melting temperature: {res['melting_temperature']:.1f} K "
+            f"(converged={res['converged']}, guess={res['initial_guess']:.0f} K)"
+        )
+        return res
+
+    structure = create_coexistence_supercell.node_function(
+        element, crystalstructure, a=a, n_atoms=n_atoms
+    )
+    key_max, _, half = analyse_reference_structure.node_function(structure)
+    t_guess, _ = estimate_melting_temperature.node_function(
+        structure, engine, key_max=key_max, distribution_half=half,
+        crystalstructure=crystalstructure, temperature_right=temperature_right,
+        strain_run_steps=strain_run_steps, seed=seed,
+    )
+    print(f"Step-1 melting-temperature estimate: {t_guess} K")
+    return {"initial_guess": float(t_guess)}
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--element", default="Al")
+    p.add_argument("--crystalstructure", default="fcc")
+    p.add_argument("--a", type=float, default=4.05)
+    p.add_argument("--n-atoms", type=int, default=4000)
+    p.add_argument("--working-directory", default="melting_run")
+    p.add_argument("--full", action="store_true")
+    p.add_argument("--temperature-right", type=float, default=1000.0)
+    p.add_argument("--strain-run-steps", type=int, default=1000)
+    p.add_argument("--seed", type=int, default=12345)
+    args = p.parse_args()
+    run(
+        element=args.element, crystalstructure=args.crystalstructure, a=args.a,
+        n_atoms=args.n_atoms, working_directory=args.working_directory, full=args.full,
+        temperature_right=args.temperature_right,
+        strain_run_steps=args.strain_run_steps, seed=args.seed,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/submit_grace_verify.sh
+++ b/scripts/submit_grace_verify.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#SBATCH -J grace_melt_verify
+#SBATCH -o /ptmp/hmai/pwa_melting/_verify_runs/slurm_%j.out
+#SBATCH -e /ptmp/hmai/pwa_melting/_verify_runs/slurm_%j.err
+#SBATCH --partition=gpu
+#SBATCH --constraint=gpu
+#SBATCH --gres=gpu:a100:1
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=60000
+#SBATCH --time=00:25:00
+
+# Self-contained (Raven SBATCH_EXPORT=NONE): set everything inside; log to /ptmp.
+set -x
+module purge 2>/dev/null || true
+module load cuda/12.6 2>/dev/null || module load cuda/12.3-nvhpcsdk 2>/dev/null || true
+export OMP_NUM_THREADS=4
+export TF_CPP_MIN_LOG_LEVEL=1
+nvidia-smi -L || echo "no nvidia-smi"
+
+echo "================ V4: LAMMPS + pair_style grace coexistence iteration ================"
+/ptmp/hmai/pwa_melting/.venv/bin/python \
+    /ptmp/hmai/pwa_melting/scripts/_verify_lammps_grace_coex.py || echo "V4_FAILED"
+
+echo "================ V3: GRACE-ASE Step-1 estimate ================"
+/ptmp/hmai/pwa_melting/.venv-grace/bin/python \
+    /ptmp/hmai/pwa_melting/scripts/_verify_grace_ase_step1.py || echo "V3_FAILED"
+
+echo "ALL_DONE"

--- a/tests/integration/test_ase_npt_metal.py
+++ b/tests/integration/test_ase_npt_metal.py
@@ -1,0 +1,28 @@
+import pytest
+from ase.build import bulk
+from ase.calculators.emt import EMT
+
+from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputMD, calculate
+
+
+@pytest.mark.slow
+def test_npt_berendsen_metal_runs(tmp_path):
+    atoms = bulk("Al", "fcc", a=4.05, cubic=True).repeat((3, 3, 3))
+    md = CalcInputMD(
+        mode="NPT",
+        thermostat="berendsen",
+        temperature=300.0,
+        pressure=0.0,
+        n_ionic_steps=20,
+        n_print=5,
+        time_step=2.0,
+        thermostat_time_constant=100.0,
+        pressure_damping_timescale=1000.0,
+        compressibility=1e-6,
+        seed=1,
+        initial_temperature=600.0,
+    )
+    eng = ASEEngine(EngineInput=md, calculator=EMT(), working_directory=str(tmp_path))
+    out = calculate.node_function(atoms, engine=eng)
+    assert out.converged is True
+    assert out.structures and out.structures[-1].get_temperature() > 0

--- a/tests/integration/test_melting_coexistence.py
+++ b/tests/integration/test_melting_coexistence.py
@@ -1,0 +1,23 @@
+import pytest
+from ase.build import bulk
+from ase.calculators.emt import EMT
+
+from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+from pyiron_workflow_atomistics.physics.melting.coexistence import coexistence_iteration
+
+
+@pytest.mark.slow
+def test_one_coexistence_iteration_runs(tmp_path):
+    s = bulk("Al", "fcc", a=4.05, cubic=True).repeat((3, 3, 6))
+    eng = ASEEngine(
+        EngineInput=CalcInputStatic(), calculator=EMT(), working_directory=str(tmp_path)
+    )
+    rec = coexistence_iteration.node_function(
+        s, eng, temperature=900.0, crystalstructure="fcc", fit_range=0.05,
+        n_strain_points=5, nvt_steps=20, nve_steps=20, npt_steps=20, timestep=2.0,
+        delta_t_melt=1000.0, ratio_boundary=0.4, boundary_value=0.25, seed=1,
+        subdir="iter0",
+    )
+    assert rec.temperature_in == 900.0
+    assert isinstance(rec.temperature_next, float)
+    assert len(rec.strains) == 5

--- a/tests/integration/test_melting_initial_guess.py
+++ b/tests/integration/test_melting_initial_guess.py
@@ -1,0 +1,30 @@
+import math
+
+import pytest
+from ase.build import bulk
+from ase.calculators.emt import EMT
+
+from pyiron_workflow_atomistics.analysis.structure_descriptors import (
+    analyse_reference_structure,
+)
+from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+from pyiron_workflow_atomistics.physics.melting.initial_guess import (
+    estimate_melting_temperature,
+)
+
+
+@pytest.mark.slow
+def test_initial_guess_brackets_a_temperature(tmp_path):
+    s = bulk("Al", "fcc", a=4.05, cubic=True).repeat((3, 3, 3))
+    key_max, _, half = analyse_reference_structure.node_function(s)
+    eng = ASEEngine(
+        EngineInput=CalcInputStatic(), calculator=EMT(), working_directory=str(tmp_path)
+    )
+    t_guess, struct = estimate_melting_temperature.node_function(
+        s, eng, key_max=key_max, distribution_half=half, crystalstructure="fcc",
+        temperature_left=0.0, temperature_right=1400.0, strain_run_steps=40,
+        timestep=2.0, seed=1, t_step_min=200.0, max_iterations=8,
+    )
+    assert math.isfinite(t_guess)
+    assert t_guess >= 0
+    assert len(struct) == len(s)

--- a/tests/integration/test_melting_md_steps.py
+++ b/tests/integration/test_melting_md_steps.py
@@ -1,0 +1,51 @@
+import pytest
+from ase.build import bulk
+from ase.calculators.emt import EMT
+
+from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+from pyiron_workflow_atomistics.physics.melting.md_steps import (
+    build_solid_liquid_interface,
+    npt_relax_solid,
+    strain_scan_nvt_nve,
+)
+
+
+def _engine(tmp_path):
+    return ASEEngine(
+        EngineInput=CalcInputStatic(), calculator=EMT(), working_directory=str(tmp_path)
+    )
+
+
+@pytest.mark.slow
+def test_npt_relax_solid_returns_structure(tmp_path):
+    s = bulk("Al", "fcc", a=4.05, cubic=True).repeat((3, 3, 3))
+    struct, out = npt_relax_solid.node_function(
+        s, _engine(tmp_path), temperature=300.0, n_steps=20, timestep=2.0, seed=1
+    )
+    assert len(struct) == len(s)
+    assert out.converged is True
+
+
+@pytest.mark.slow
+def test_build_interface_runs(tmp_path):
+    s = bulk("Al", "fcc", a=4.05, cubic=True).repeat((3, 3, 6))
+    iface = build_solid_liquid_interface.node_function(
+        s, _engine(tmp_path), t_solid=300.0, t_liquid=2000.0, n_steps=20, timestep=2.0,
+        seed=1,
+    )
+    assert len(iface) == len(s)
+    assert len(iface.constraints) == 0
+
+
+@pytest.mark.slow
+def test_strain_scan_returns_records(tmp_path):
+    s = bulk("Al", "fcc", a=4.05, cubic=True).repeat((3, 3, 6))
+    recs = strain_scan_nvt_nve.node_function(
+        s, _engine(tmp_path), temperature=300.0, strains=[0.99, 1.01],
+        crystalstructure="fcc", nvt_steps=20, nve_steps=20, timestep=2.0, seed=1,
+    )
+    assert len(recs) == 2
+    for r in recs:
+        assert set(r) >= {
+            "strain", "mean_T", "mean_P", "solid_fraction", "voronoi_max", "voronoi_mean",
+        }

--- a/tests/integration/test_melting_study.py
+++ b/tests/integration/test_melting_study.py
@@ -1,0 +1,26 @@
+import pytest
+from ase.calculators.emt import EMT
+
+from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+from pyiron_workflow_atomistics.physics.melting import (
+    MeltingInput,
+    calculate_melting_point,
+)
+
+
+@pytest.mark.slow
+def test_calculate_melting_point_end_to_end(tmp_path):
+    mi = MeltingInput(
+        element="Al", crystalstructure="fcc", a=4.05, n_atoms=500,
+        temperature_right=1400.0, strain_run_steps=40, timestep_lst=[2.0],
+        fit_range_lst=[0.05], nve_steps_lst=[20], nvt_run_steps=20, npt_run_steps=20,
+        n_strain_points=5, ratio_boundary=0.4, seed=1,
+    )
+    eng = ASEEngine(
+        EngineInput=CalcInputStatic(), calculator=EMT(), working_directory=str(tmp_path)
+    )
+    res = calculate_melting_point.node_function(eng, mi)
+    assert res.element == "Al"
+    assert res.initial_guess >= 0
+    assert isinstance(res.melting_temperature, float)
+    assert res.n_iterations >= 1

--- a/tests/integration/test_melting_study.py
+++ b/tests/integration/test_melting_study.py
@@ -14,7 +14,7 @@ def test_calculate_melting_point_end_to_end(tmp_path):
         element="Al", crystalstructure="fcc", a=4.05, n_atoms=500,
         temperature_right=1400.0, strain_run_steps=40, timestep_lst=[2.0],
         fit_range_lst=[0.05], nve_steps_lst=[20], nvt_run_steps=20, npt_run_steps=20,
-        n_strain_points=5, ratio_boundary=0.4, seed=1,
+        n_strain_points=5, ratio_boundary=0.4, max_coexistence_iterations=2, seed=1,
     )
     eng = ASEEngine(
         EngineInput=CalcInputStatic(), calculator=EMT(), working_directory=str(tmp_path)

--- a/tests/integration/test_meltingpoint_script.py
+++ b/tests/integration/test_meltingpoint_script.py
@@ -1,0 +1,23 @@
+import importlib.util
+import pathlib
+
+import pytest
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location(
+        "meltingpoint", pathlib.Path("scripts/meltingpoint.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.slow
+def test_script_run_returns_result(tmp_path):
+    mod = _load_script()
+    res = mod.run(
+        element="Al", a=4.05, n_atoms=500, working_directory=str(tmp_path),
+        full=False, temperature_right=1400.0, strain_run_steps=40, seed=1,
+    )
+    assert res["initial_guess"] >= 0

--- a/tests/unit/analysis/test_structure_descriptors.py
+++ b/tests/unit/analysis/test_structure_descriptors.py
@@ -1,0 +1,50 @@
+import numpy as np
+from ase.build import bulk
+
+from pyiron_workflow_atomistics.analysis.structure_descriptors import (
+    analyse_reference_structure,
+    classify_solid,
+    cna_fractions,
+    holes_mask,
+    voronoi_max_mean,
+)
+
+
+def _fcc_al():
+    return bulk("Al", "fcc", a=4.05, cubic=True).repeat((4, 4, 4))
+
+
+def test_cna_fractions_fcc_dominant():
+    counts = cna_fractions.node_function(_fcc_al())
+    assert counts["fcc"] / sum(counts.values()) > 0.95
+
+
+def test_analyse_reference_structure_fcc():
+    key_max, n_atoms, half = analyse_reference_structure.node_function(_fcc_al())
+    assert key_max == "fcc"
+    assert n_atoms == 256
+    assert abs(half - 0.5) < 0.05
+
+
+def test_classify_solid_true_for_crystal():
+    s = _fcc_al()
+    key_max, _, half = analyse_reference_structure.node_function(s)
+    assert classify_solid.node_function(s, key_max, half) is True
+
+
+def test_classify_solid_false_for_disordered():
+    s = _fcc_al()
+    key_max, _, half = analyse_reference_structure.node_function(s)
+    rng = np.random.RandomState(0)
+    s.set_positions(s.get_positions() + rng.standard_normal((len(s), 3)) * 1.5)
+    assert classify_solid.node_function(s, key_max, half) is False
+
+
+def test_voronoi_max_mean_uniform_fcc():
+    vmax, vmean = voronoi_max_mean.node_function(_fcc_al())
+    assert vmax / vmean < 1.2  # uniform crystal: max ~ mean
+
+
+def test_holes_mask_flags_large_void():
+    keep = holes_mask.node_function([1.0, 1.0, 5.0], [1.0, 1.0, 1.0], factor=2.0)
+    assert keep == [True, True, False]

--- a/tests/unit/analysis/test_trajectory.py
+++ b/tests/unit/analysis/test_trajectory.py
@@ -1,0 +1,61 @@
+import numpy as np
+from ase import Atoms, units
+
+from pyiron_workflow_atomistics.analysis.trajectory import (
+    pressures_from_trajectory,
+    temperatures_from_trajectory,
+)
+from pyiron_workflow_atomistics.engine.protocol import EngineOutput
+
+
+def _frame_at_temperature(T_target, n=64, a=10.0, seed=0):
+    rng = np.random.RandomState(seed)
+    atoms = Atoms(f"Ar{n}", positions=rng.rand(n, 3) * a, cell=[a, a, a], pbc=True)
+    atoms.set_momenta(rng.standard_normal((n, 3)))
+    atoms.set_momenta(atoms.get_momenta() * np.sqrt(T_target / atoms.get_temperature()))
+    return atoms
+
+
+def test_temperatures_from_trajectory_mean():
+    frames = [_frame_at_temperature(300.0, seed=i) for i in range(5)]
+    out = EngineOutput(
+        final_structure=frames[-1], final_energy=0.0, converged=True, structures=frames
+    )
+    T = temperatures_from_trajectory.node_function(out, last_n=5)
+    assert abs(T - 300.0) < 1e-6
+
+
+def test_pressures_from_trajectory_virial_plus_kinetic():
+    n, a = 64, 10.0
+    V = a**3
+    frame = _frame_at_temperature(300.0, n=n, a=a, seed=1)
+    p_vir = 0.01  # eV/A^3
+    svoigt = np.array([-p_vir, -p_vir, -p_vir, 0.0, 0.0, 0.0])
+    out = EngineOutput(
+        final_structure=frame,
+        final_energy=0.0,
+        converged=True,
+        structures=[frame],
+        stresses=[svoigt],
+    )
+    P = pressures_from_trajectory.node_function(out, last_n=1)
+    p_kin = n * units.kB * 300.0 / V  # eV/A^3
+    expected = (p_vir + p_kin) * 160.21766208  # GPa
+    assert abs(P - expected) < 1e-6
+
+
+def test_pressures_accepts_full_3x3_stress():
+    n, a = 64, 10.0
+    frame = _frame_at_temperature(300.0, n=n, a=a, seed=2)
+    p_vir = 0.02
+    full = np.diag([-p_vir, -p_vir, -p_vir])
+    out = EngineOutput(
+        final_structure=frame,
+        final_energy=0.0,
+        converged=True,
+        structures=[frame],
+        stresses=[full],
+    )
+    P = pressures_from_trajectory.node_function(out, last_n=1)
+    p_kin = n * units.kB * 300.0 / (a**3)
+    assert abs(P - (p_vir + p_kin) * 160.21766208) < 1e-6

--- a/tests/unit/physics/melting/test_dataclasses.py
+++ b/tests/unit/physics/melting/test_dataclasses.py
@@ -1,0 +1,38 @@
+from pyiron_workflow_atomistics.physics.melting.inputs import MeltingInput
+from pyiron_workflow_atomistics.physics.melting.outputs import (
+    MeltingIterationRecord,
+    MeltingResult,
+)
+
+
+def test_melting_input_defaults():
+    mi = MeltingInput(element="Al")
+    assert mi.n_atoms == 8000
+    assert mi.timestep_lst == [2.0, 2.0, 1.0]
+    assert mi.convergence_goal == 1.0
+
+
+def test_melting_result_to_dict():
+    rec = MeltingIterationRecord(
+        temperature_in=900.0,
+        temperature_next=905.0,
+        strains=[1.0],
+        ratios=[0.5],
+        pressures=[0.0],
+        temperatures=[905.0],
+        converged=True,
+    )
+    res = MeltingResult(
+        melting_temperature=905.0,
+        converged=True,
+        n_iterations=1,
+        element="Al",
+        crystalstructure="fcc",
+        n_atoms=4000,
+        initial_guess=914.0,
+        iterations=[rec],
+        report={},
+    )
+    d = res.to_dict()
+    assert d["melting_temperature"] == 905.0
+    assert len(d["iterations"]) == 1

--- a/tests/unit/physics/melting/test_fitting.py
+++ b/tests/unit/physics/melting/test_fitting.py
@@ -1,0 +1,28 @@
+from pyiron_workflow_atomistics.physics.melting.fitting import (
+    predict_melting_point,
+    ratio_selection,
+)
+
+
+def test_ratio_selection_picks_coexistence_window():
+    strains = [0.96, 0.98, 1.00, 1.02, 1.04]
+    ratios = [0.05, 0.45, 0.50, 0.55, 0.95]  # middle three near 0.5
+    pressures = [2.0, 1.0, 0.0, -1.0, -2.0]
+    temps = [900, 905, 910, 915, 920]
+    ss, rr, pp, tt, flag = ratio_selection.node_function(
+        strains, ratios, pressures, temps, ratio_boundary=0.25
+    )
+    assert list(ss) == [0.98, 1.00, 1.02]
+    assert flag in (1, -1)
+
+
+def test_predict_melting_point_extrapolates_to_zero_pressure():
+    # T = 910 + 250*P  => T(P=0) = 910; P linear in strain
+    strains = [0.98, 1.00, 1.02]
+    pressures = [1.0, 0.0, -1.0]
+    temps = [910 + 250 * p for p in pressures]
+    t_next, t_mean, t_left, t_right = predict_melting_point.node_function(
+        strains, pressures, temps, boundary_value=0.25
+    )
+    assert abs(t_next - 910.0) < 1e-6
+    assert t_left < t_mean < t_right

--- a/tests/unit/physics/melting/test_solid_fraction.py
+++ b/tests/unit/physics/melting/test_solid_fraction.py
@@ -1,0 +1,32 @@
+import numpy as np
+from ase.build import bulk
+
+from pyiron_workflow_atomistics.physics.melting.solid_fraction import solid_fraction_kde
+
+
+def _half_solid_half_liquid():
+    s = bulk("Al", "fcc", a=4.05, cubic=True).repeat((4, 4, 8))  # long in z
+    z = s.get_scaled_positions()[:, 2]
+    upper = np.where(z >= 0.5)[0]
+    rng = np.random.RandomState(0)
+    pos = s.get_positions()
+    pos[upper] += rng.standard_normal((len(upper), 3)) * 1.6  # melt upper half
+    s.set_positions(pos)
+    return s
+
+
+def test_full_solid_ratio_near_one():
+    s = bulk("Al", "fcc", a=4.05, cubic=True).repeat((4, 4, 8))
+    assert solid_fraction_kde.node_function(s, "fcc") > 0.9
+
+
+def test_half_solid_ratio_near_half():
+    frac = solid_fraction_kde.node_function(_half_solid_half_liquid(), "fcc")
+    assert 0.3 < frac < 0.7
+
+
+def test_all_liquid_ratio_zero():
+    s = bulk("Al", "fcc", a=4.05, cubic=True).repeat((4, 4, 8))
+    rng = np.random.RandomState(1)
+    s.set_positions(s.get_positions() + rng.standard_normal((len(s), 3)) * 2.0)
+    assert solid_fraction_kde.node_function(s, "fcc") == 0.0

--- a/tests/unit/physics/melting/test_structures.py
+++ b/tests/unit/physics/melting/test_structures.py
@@ -1,0 +1,38 @@
+import numpy as np
+from ase.constraints import FixAtoms
+
+from pyiron_workflow_atomistics.physics.melting.structures import (
+    create_coexistence_supercell,
+    freeze_half,
+    strain_cell_along_z,
+    unfreeze,
+)
+
+
+def test_supercell_targets_half_n_atoms():
+    s = create_coexistence_supercell.node_function("Al", "fcc", a=4.05, n_atoms=8000)
+    assert len(s) == 4000  # fcc cubic = 4 atoms; 4*10^3 = 4000 ~ 8000/2
+
+
+def test_freeze_half_fixes_lower_half():
+    s = create_coexistence_supercell.node_function("Al", "fcc", a=4.05, n_atoms=2000)
+    frozen = freeze_half.node_function(s, axis=2, fraction=0.5)
+    cons = [c for c in frozen.constraints if isinstance(c, FixAtoms)]
+    assert len(cons) == 1
+    fixed = set(cons[0].get_indices())
+    zsc = frozen.get_scaled_positions()[:, 2]
+    expected = set(np.where(zsc < 0.5)[0])
+    assert fixed == expected
+
+
+def test_unfreeze_clears_constraints():
+    s = create_coexistence_supercell.node_function("Al", "fcc", a=4.05, n_atoms=2000)
+    assert len(unfreeze.node_function(freeze_half.node_function(s)).constraints) == 0
+
+
+def test_strain_scales_only_c():
+    s = create_coexistence_supercell.node_function("Al", "fcc", a=4.05, n_atoms=2000)
+    c0 = s.cell[2, 2]
+    strained = strain_cell_along_z.node_function(s, 1.05)
+    assert abs(strained.cell[2, 2] - 1.05 * c0) < 1e-8
+    assert abs(strained.cell[0, 0] - s.cell[0, 0]) < 1e-8


### PR DESCRIPTION
## Summary
Adds the full **interface / solid–liquid coexistence melting-point method** as a new engine-agnostic `physics/melting/` subpackage, plus reusable `analysis/` quantities. Ported from a partial notebook (Step 1 only) + `pyiron_atomistics.thermodynamics.interfacemethod` onto the current Engine Protocol — runs on any conformant engine (ASE, LAMMPS) via `calculate()` + `CalcInputMD`.

## What's added
- `analysis/structure_descriptors.py` — CNA fractions, reference-phase analysis, solid classification, Voronoi void detection (general/reusable).
- `analysis/trajectory.py` — per-frame temperature + (virial+kinetic) pressure from `EngineOutput`.
- `physics/melting/` — coexistence supercell/freeze/strain, KDE solid-fraction, ratio-selection + T(P→0) fit, MD step drivers, Step-1 superheating bisection, Step-2 coexistence convergence loop, top-level `calculate_melting_point` (+ `MeltingInput`/`MeltingResult`).
- `scripts/meltingpoint.py` — runnable port of the notebook.
- Design spec, implementation plan, and verification report under `docs/design/`.

## Verification
- 20 fast unit tests + EMT/Al integration incl. the full method end-to-end (`-m slow`).
- **GRACE-1L-OAM via the ASE engine: Step-1 melting estimate = 1006 K for Al** (A100; DFT Al = 933 K).
- A multi-agent adversarial review (34 candidates → 24 confirmed) caught and fixed a critical NVE-overheating runaway, a convergence-loop defect, a missing PBC-wrap, ratio-selection-by-index, and hcp-supercell support.

## Notes
- `npt_thermostat` is configurable because isotropic NPT differs per engine (ASE = berendsen; LAMMPS = nose-hoover `iso`); ASE nose-hoover NPT goes triclinic and breaks pyscal Voronoi.
- LAMMPS `pair_style grace` coexistence pressure needs the `EngineOutput.stresses` convention reconciled (ASE eV/Å³ virial vs LAMMPS GPa total-pressure tensor) — documented in the verification report as a follow-up.
- Companion PR in `pyiron_workflow_lammps` adds per-atom velocity capture so the LAMMPS engine path can recover kinetic temperature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)