### PR TITLE
Across-the-table polymorph melting scan (discover the pre-melt phase)

### DIFF
--- a/docs/design/specs/2026-06-27-melting-point-interface-method-design.md
+++ b/docs/design/specs/2026-06-27-melting-point-interface-method-design.md
@@ -373,3 +373,48 @@ full output paths.
    quantities (reusable), not melting-local (§3.4).
 3. **GRACE** → installed into a dedicated **fresh uv venv** `.venv-grace` (§7), not
    the conda env.
+
+---
+
+## 10. Addendum (2026-06-27): across-the-table polymorph scan
+
+The single-phase macro (`calculate_melting_point`) fixes the solid phase up front.
+Across the periodic table the pre-melt phase varies *per potential* — a potential's
+melting point is a property of **its own** free-energy landscape, so the relevant
+solid is whichever polymorph that potential makes most stable just below melting,
+discovered rather than imposed.
+
+**Driver:** `physics/melting/screen.py::melting_point_scan(engine, melting_input)`.
+
+- **Screen (cheap):** `screen_phase` runs build → cell-relax → **Step 1 only** (the
+  superheating NPT bisection) for each candidate polymorph. Step 1 is cheap enough
+  to use as the phase screen and yields (a) the relaxed cell's dominant CNA class
+  (`observed_phase`), (b) whether the seeded phase held, and (c) a `t_guess` to rank
+  by. Seed lattice constants for non-reference phases come from
+  `estimate_lattice_constant` (relax the ASE reference state, invert the ideal
+  volume-per-atom relation; cell-relax then corrects it).
+- **Select:** dedupe by `observed_phase` (a collapsed seed merges into its product
+  phase, preferring the `held` record), keep CNA-refinable solids (fcc/bcc/hcp),
+  take the top `n_refine` by `t_guess`.
+- **Refine (expensive):** run the full Step-2 coexistence (`refine_melting_point`)
+  on the survivors, labelled by `observed_phase` (the crystal actually present, so
+  the solid-fraction CNA target matches).
+- **Aggregate:** `Tm = max` over refined polymorphs; `selected_phase` is the
+  argmax (the potential's pre-melt phase); `runner_up_phase` + `delta_runner_up`
+  expose near-degeneracy (within Tm error ⇒ report both, do not over-resolve).
+
+Self-correcting by construction: a metastable seed either transforms during
+equilibration (caught by CNA) or yields a lower coexistence `Tm` that `max`
+discards. No TI/free-energy stage is needed — it would be redundant where Step 1
+already screens and fragile exactly on the anharmonically-stabilised high-T bcc
+phases (Ti/Zr/Hf) where a harmonic reference is undefined.
+
+**Inputs:** `MeltingInput.candidate_phases` (default `None` ⇒ {fcc, bcc, hcp} +
+reference state) and `MeltingInput.n_refine` (default 2).
+**Outputs:** `MeltingScanResult` (+ `PhaseScreenRecord` per candidate), both with
+`to_dict()`. **CLI:** `scripts/meltingpoint.py --scan [--candidate-phases ...]
+[--n-refine N]`.
+
+**Known limitation:** non-close-packed reference states (diamond Si/C, etc.) screen
+but are not CNA-refinable; the scan falls back to the deduped set and flags them via
+`observed_phase` ∉ {fcc,bcc,hcp}. Molecular/sublimating elements are out of scope.

--- a/pyiron_workflow_atomistics/physics/melting/__init__.py
+++ b/pyiron_workflow_atomistics/physics/melting/__init__.py
@@ -11,6 +11,12 @@ from pyiron_workflow_atomistics.physics.melting.inputs import MeltingInput
 from pyiron_workflow_atomistics.physics.melting.outputs import (
     MeltingIterationRecord,
     MeltingResult,
+    MeltingScanResult,
+    PhaseScreenRecord,
+)
+from pyiron_workflow_atomistics.physics.melting.screen import (
+    melting_point_scan,
+    screen_phase,
 )
 from pyiron_workflow_atomistics.physics.melting.study import calculate_melting_point
 
@@ -18,8 +24,12 @@ __all__ = [
     "MeltingInput",
     "MeltingIterationRecord",
     "MeltingResult",
+    "MeltingScanResult",
+    "PhaseScreenRecord",
     "calculate_melting_point",
     "coexistence_iteration",
     "estimate_melting_temperature",
+    "melting_point_scan",
     "refine_melting_point",
+    "screen_phase",
 ]

--- a/pyiron_workflow_atomistics/physics/melting/inputs.py
+++ b/pyiron_workflow_atomistics/physics/melting/inputs.py
@@ -11,6 +11,11 @@ class MeltingInput:
     crystalstructure: str | None = None  # default: ASE reference state
     a: float | None = None
     n_atoms: int = 8000  # solid cell targets n_atoms/2
+    # Across-the-table scan (melting_point_scan): candidate solid polymorphs to
+    # screen, and how many top survivors get the expensive coexistence refinement.
+    # ``None`` -> {fcc, bcc, hcp} plus the element's ASE reference state.
+    candidate_phases: list[str] | None = None
+    n_refine: int = 2
     temperature_left: float = 0.0
     temperature_right: float = 1000.0
     convergence_goal: float = 1.0  # K

--- a/pyiron_workflow_atomistics/physics/melting/outputs.py
+++ b/pyiron_workflow_atomistics/physics/melting/outputs.py
@@ -30,3 +30,48 @@ class MeltingResult:
 
     def to_dict(self) -> dict[str, Any]:
         return {f.name: getattr(self, f.name) for f in fields(self)}
+
+
+@dataclass
+class PhaseScreenRecord:
+    """One candidate polymorph's cheap Step-1 screen result.
+
+    ``crystalstructure`` is the *requested* phase; ``observed_phase`` is the
+    dominant CNA class of the relaxed (0 K) cell — they differ when the potential
+    spontaneously transforms the seeded phase. ``held`` is their agreement.
+    ``t_guess`` is the Step-1 superheating estimate used to rank candidates.
+    """
+
+    crystalstructure: str
+    observed_phase: str
+    lattice_constant: float
+    t_guess: float
+    held: bool
+    refined: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {f.name: getattr(self, f.name) for f in fields(self)}
+
+
+@dataclass
+class MeltingScanResult:
+    """Across-polymorph melting scan: screen all candidates, refine survivors.
+
+    The melting point is ``max`` over refined polymorphs and ``selected_phase``
+    is the polymorph achieving it (the potential's own pre-melt phase).
+    """
+
+    element: str
+    melting_temperature: float
+    selected_phase: str
+    runner_up_phase: str | None
+    delta_runner_up: float | None
+    screened: list[PhaseScreenRecord] = field(default_factory=list)
+    refined: list[MeltingResult] = field(default_factory=list)
+    report: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        out = {f.name: getattr(self, f.name) for f in fields(self)}
+        out["screened"] = [r.to_dict() for r in self.screened]
+        out["refined"] = [r.to_dict() for r in self.refined]
+        return out

--- a/pyiron_workflow_atomistics/physics/melting/screen.py
+++ b/pyiron_workflow_atomistics/physics/melting/screen.py
@@ -1,0 +1,206 @@
+"""Across-the-table melting scan: cheap Step-1 screen of candidate polymorphs,
+expensive Step-2 coexistence only on the survivors, ``Tm = max`` over them.
+
+The melting point is a property of the *potential*: the relevant pre-melt solid is
+whichever polymorph that potential makes most stable just below melting. Rather than
+imposing an experimental phase, this module discovers it — Step 1 (the superheating
+NPT bisection) is cheap enough to run on every candidate as a screen, and the
+polymorph with the highest coexistence ``Tm`` (lowest free energy ⇒ melts last) is
+the one the potential selects. Seeding a metastable phase is self-correcting: it
+either transforms during equilibration (caught by CNA) or yields a lower ``Tm`` that
+``max`` discards.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pyiron_workflow as pwf
+from ase.data import atomic_numbers, reference_states
+
+from pyiron_workflow_atomistics.analysis.structure_descriptors import (
+    analyse_reference_structure,
+)
+from pyiron_workflow_atomistics.engine import CalcInputMinimize, calculate
+from pyiron_workflow_atomistics.physics.melting.coexistence import refine_melting_point
+from pyiron_workflow_atomistics.physics.melting.initial_guess import (
+    estimate_melting_temperature,
+)
+from pyiron_workflow_atomistics.physics.melting.outputs import (
+    MeltingScanResult,
+    PhaseScreenRecord,
+)
+from pyiron_workflow_atomistics.physics.melting.structures import (
+    create_coexistence_supercell,
+    estimate_lattice_constant,
+)
+
+# CNA-classifiable solids the coexistence solid-fraction analysis can label.
+_REFINABLE_PHASES = ("fcc", "bcc", "hcp")
+
+
+def _default_candidate_phases(element):
+    """{fcc, bcc, hcp} plus the element's ASE reference state (order-preserving)."""
+    phases = ["fcc", "bcc", "hcp"]
+    ref = reference_states[atomic_numbers[element]]["symmetry"]
+    if ref not in phases:
+        phases.append(ref)
+    return phases
+
+
+@pwf.as_function_node("t_guess", "structure", "observed_phase")
+def screen_phase(
+    engine,
+    element,
+    crystalstructure,
+    a,
+    n_atoms=8000,
+    temperature_left=0.0,
+    temperature_right=1000.0,
+    strain_run_steps=1000,
+    timestep=2.0,
+    seed=None,
+    npt_thermostat="berendsen",
+    subdir="screen",
+):
+    """Build -> relax -> Step-1 estimate for ONE candidate polymorph (cheap screen).
+
+    Returns the Step-1 superheating estimate ``t_guess``, the warm near-melt
+    structure to seed refinement, and the relaxed cell's dominant CNA phase
+    (``observed_phase``) — which differs from ``crystalstructure`` when the seeded
+    polymorph transforms on relaxation.
+    """
+    structure = create_coexistence_supercell.node_function(
+        element, crystalstructure, a=a, n_atoms=n_atoms
+    )
+    relax_engine = replace(
+        engine, EngineInput=CalcInputMinimize(relax_cell=True)
+    ).with_working_directory(f"{subdir}_min")
+    relaxed = calculate.node_function(structure, engine=relax_engine).final_structure
+    observed_phase, _, distribution_half = analyse_reference_structure.node_function(
+        relaxed
+    )
+    t_guess, struct_at_guess = estimate_melting_temperature.node_function(
+        relaxed,
+        engine,
+        key_max=observed_phase,
+        distribution_half=distribution_half,
+        crystalstructure=observed_phase,
+        temperature_left=temperature_left,
+        temperature_right=temperature_right,
+        strain_run_steps=strain_run_steps,
+        timestep=timestep,
+        seed=seed,
+        npt_thermostat=npt_thermostat,
+        subdir=subdir,
+    )
+    return t_guess, struct_at_guess, observed_phase
+
+
+def _dedupe_by_observed(screened):
+    """One record per observed phase: prefer ``held``, then the higher ``t_guess``."""
+    best: dict[str, PhaseScreenRecord] = {}
+    for rec in screened:
+        cur = best.get(rec.observed_phase)
+        if cur is None or (rec.held, rec.t_guess) > (cur.held, cur.t_guess):
+            best[rec.observed_phase] = rec
+    return list(best.values())
+
+
+def _select_for_refinement(screened, n_refine):
+    """Pick the polymorphs worth the expensive coexistence step.
+
+    Dedupe by observed phase, keep only CNA-refinable solids (fcc/bcc/hcp), then
+    take the ``n_refine`` highest Step-1 estimates (most-stable-first). Falls back
+    to the deduped set if nothing is refinable so the scan still returns a number.
+    """
+    deduped = _dedupe_by_observed(screened)
+    refinable = [r for r in deduped if r.observed_phase in _REFINABLE_PHASES]
+    pool = refinable or deduped
+    pool = sorted(pool, key=lambda r: r.t_guess, reverse=True)
+    return pool[: max(1, n_refine)]
+
+
+@pwf.as_function_node("result")
+def melting_point_scan(engine, melting_input):
+    """Discover the pre-melt phase and melting point across candidate polymorphs.
+
+    Screens every candidate phase with the cheap Step-1 estimate, refines the top
+    ``n_refine`` survivors with the full coexistence method, and reports
+    ``Tm = max`` over them with the selected phase and the runner-up gap.
+    """
+    mi = melting_input
+    phases = mi.candidate_phases or _default_candidate_phases(mi.element)
+
+    screened: list[PhaseScreenRecord] = []
+    artifacts: dict[str, tuple] = {}  # requested phase -> (t_guess, struct)
+    for cs in phases:
+        a_cs = (
+            mi.a
+            if mi.a is not None
+            else estimate_lattice_constant.node_function(mi.element, engine, cs)
+        )
+        t_guess, struct, observed = screen_phase.node_function(
+            engine,
+            mi.element,
+            cs,
+            a_cs,
+            n_atoms=mi.n_atoms,
+            temperature_left=mi.temperature_left,
+            temperature_right=mi.temperature_right,
+            strain_run_steps=mi.strain_run_steps,
+            timestep=mi.timestep_lst[0],
+            seed=mi.seed,
+            npt_thermostat=mi.npt_thermostat,
+            subdir=f"screen_{cs}",
+        )
+        screened.append(
+            PhaseScreenRecord(
+                crystalstructure=cs,
+                observed_phase=observed,
+                lattice_constant=float(a_cs),
+                t_guess=float(t_guess),
+                held=bool(observed == cs.lower()),
+            )
+        )
+        artifacts[cs] = (t_guess, struct)
+
+    selected = _select_for_refinement(screened, mi.n_refine)
+    selected_keys = {r.crystalstructure for r in selected}
+    for rec in screened:
+        rec.refined = rec.crystalstructure in selected_keys
+
+    refined = []
+    for rec in selected:
+        t_guess, struct = artifacts[rec.crystalstructure]
+        # Label refinement by the OBSERVED phase: that is the crystal actually
+        # present in the warm seed, and the solid-fraction CNA target must match it.
+        res = refine_melting_point.node_function(
+            struct,
+            engine,
+            t_guess=t_guess,
+            melting_input=mi,
+            crystalstructure=rec.observed_phase,
+        )
+        refined.append(res)
+
+    refined_sorted = sorted(refined, key=lambda r: r.melting_temperature, reverse=True)
+    best = refined_sorted[0]
+    runner = refined_sorted[1] if len(refined_sorted) > 1 else None
+    result = MeltingScanResult(
+        element=mi.element,
+        melting_temperature=best.melting_temperature,
+        selected_phase=best.crystalstructure,
+        runner_up_phase=runner.crystalstructure if runner else None,
+        delta_runner_up=(
+            best.melting_temperature - runner.melting_temperature if runner else None
+        ),
+        screened=screened,
+        refined=refined,
+        report={
+            "candidate_phases": list(phases),
+            "n_refine": mi.n_refine,
+            "refined_phases": [r.crystalstructure for r in refined_sorted],
+        },
+    )
+    return result

--- a/pyiron_workflow_atomistics/physics/melting/structures.py
+++ b/pyiron_workflow_atomistics/physics/melting/structures.py
@@ -1,9 +1,46 @@
 from __future__ import annotations
 
+import math
+from dataclasses import replace
+
 import numpy as np
 import pyiron_workflow as pwf
 from ase.build import bulk
 from ase.constraints import FixAtoms
+
+# Conventional-cell atom counts and ideal volume-per-atom prefactors used to map a
+# relaxed reference atomic volume onto a seed lattice constant for a target phase.
+# ASE ``bulk`` only knows ``a`` for an element's reference state, so seeding fcc/bcc/
+# hcp candidates for a scan needs an explicit estimate (cell-relax refines it after).
+_ATOMS_PER_CUBIC = {"fcc": 4, "bcc": 2, "sc": 1}
+
+
+@pwf.as_function_node("a")
+def estimate_lattice_constant(element, engine, crystalstructure):
+    """Seed lattice constant ``a`` for ``crystalstructure`` from a relaxed reference.
+
+    Relaxes the element's ASE reference-state bulk (cell relaxed) to get the
+    per-atom volume, then inverts the ideal volume-per-atom relation for the
+    requested phase. fcc/bcc/sc use the cubic conventional cell; hcp assumes the
+    ideal c/a = 1.633. Any other phase falls back to the fcc map. This is only a
+    seed — ``calculate``'s cell relaxation corrects it.
+    """
+    from pyiron_workflow_atomistics.engine import CalcInputMinimize, calculate
+
+    ref = bulk(element)
+    relax_engine = replace(
+        engine, EngineInput=CalcInputMinimize(relax_cell=True)
+    ).with_working_directory("a_ref")
+    relaxed = calculate.node_function(ref, engine=relax_engine).final_structure
+    v_atom = relaxed.get_volume() / len(relaxed)
+    cs = (crystalstructure or "fcc").lower()
+    if cs == "hcp":
+        # V_atom = (sqrt(3)/2) * a^2 * c / 2, with c = 1.633 a
+        a = (v_atom / (math.sqrt(3.0) / 2.0 * 1.633)) ** (1.0 / 3.0)
+    else:
+        n = _ATOMS_PER_CUBIC.get(cs, 4)
+        a = (n * v_atom) ** (1.0 / 3.0)
+    return float(a)
 
 
 @pwf.as_function_node("structure")

--- a/pyiron_workflow_atomistics/physics/melting/study.py
+++ b/pyiron_workflow_atomistics/physics/melting/study.py
@@ -1,20 +1,12 @@
 from __future__ import annotations
 
-from dataclasses import replace
-
 import pyiron_workflow as pwf
 from ase.data import atomic_numbers, reference_states
 
-from pyiron_workflow_atomistics.analysis.structure_descriptors import (
-    analyse_reference_structure,
-)
-from pyiron_workflow_atomistics.engine import CalcInputMinimize, calculate
 from pyiron_workflow_atomistics.physics.melting.coexistence import refine_melting_point
-from pyiron_workflow_atomistics.physics.melting.initial_guess import (
-    estimate_melting_temperature,
-)
+from pyiron_workflow_atomistics.physics.melting.screen import screen_phase
 from pyiron_workflow_atomistics.physics.melting.structures import (
-    create_coexistence_supercell,
+    estimate_lattice_constant,
 )
 
 
@@ -24,35 +16,38 @@ def _default_crystalstructure(element):
 
 @pwf.as_function_node("result")
 def calculate_melting_point(engine, melting_input):
-    """Full interface-method melting point: build -> relax -> Step 1 -> Step 2."""
+    """Full interface-method melting point for ONE phase: screen -> refine.
+
+    Builds, relaxes and runs the Step-1 superheating estimate (``screen_phase``),
+    then refines with the Step-2 coexistence loop. Use ``melting_point_scan`` to
+    discover the pre-melt phase across polymorphs instead of fixing it here.
+    """
     mi = melting_input
     crystalstructure = mi.crystalstructure or _default_crystalstructure(mi.element)
-    structure = create_coexistence_supercell.node_function(
-        mi.element, crystalstructure, a=mi.a, n_atoms=mi.n_atoms
-    )
-    relax_engine = replace(
-        engine, EngineInput=CalcInputMinimize(relax_cell=True)
-    ).with_working_directory("minimize")
-    relaxed = calculate.node_function(structure, engine=relax_engine).final_structure
-    key_max, _, distribution_half = analyse_reference_structure.node_function(relaxed)
-    t_guess, struct_at_guess = estimate_melting_temperature.node_function(
-        relaxed,
+    a = mi.a
+    if a is None and crystalstructure != _default_crystalstructure(mi.element):
+        a = estimate_lattice_constant.node_function(
+            mi.element, engine, crystalstructure
+        )
+    t_guess, struct_at_guess, observed = screen_phase.node_function(
         engine,
-        key_max=key_max,
-        distribution_half=distribution_half,
-        crystalstructure=crystalstructure,
+        mi.element,
+        crystalstructure,
+        a,
+        n_atoms=mi.n_atoms,
         temperature_left=mi.temperature_left,
         temperature_right=mi.temperature_right,
         strain_run_steps=mi.strain_run_steps,
         timestep=mi.timestep_lst[0],
         seed=mi.seed,
         npt_thermostat=mi.npt_thermostat,
+        subdir="single",
     )
     result = refine_melting_point.node_function(
         struct_at_guess,
         engine,
         t_guess=t_guess,
         melting_input=mi,
-        crystalstructure=crystalstructure,
+        crystalstructure=observed,
     )
     return result

--- a/scripts/meltingpoint.py
+++ b/scripts/meltingpoint.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python
 """Interface-method melting point - runnable port of meltingpoint.ipynb.
 
-Step 1 (rough estimate) by default; pass --full for the full coexistence method.
-Uses the ASE engine with EMT by default (swap in a GRACE calculator for production).
+Step 1 (rough estimate) by default; pass --full for the full coexistence method on
+one phase, or --scan to screen candidate polymorphs and let ``max(Tm)`` select the
+pre-melt phase. Uses the ASE engine with EMT by default (swap in a GRACE calculator
+for production).
 
 Examples
 --------
     python scripts/meltingpoint.py --element Al --a 4.05            # Step-1 estimate
-    python scripts/meltingpoint.py --element Al --a 4.05 --full     # full method
+    python scripts/meltingpoint.py --element Al --a 4.05 --full     # full, one phase
+    python scripts/meltingpoint.py --element Al --scan              # scan polymorphs
 """
 
 from __future__ import annotations
@@ -22,6 +25,9 @@ def run(
     n_atoms=4000,
     working_directory="melting_run",
     full=False,
+    scan=False,
+    candidate_phases=None,
+    n_refine=2,
     temperature_right=1000.0,
     strain_run_steps=1000,
     seed=12345,
@@ -35,6 +41,7 @@ def run(
     from pyiron_workflow_atomistics.physics.melting import (
         MeltingInput,
         calculate_melting_point,
+        melting_point_scan,
     )
     from pyiron_workflow_atomistics.physics.melting.initial_guess import (
         estimate_melting_temperature,
@@ -48,6 +55,30 @@ def run(
         calculator=EMT(),
         working_directory=working_directory,
     )
+    if scan:
+        mi = MeltingInput(
+            element=element,
+            a=a,
+            n_atoms=n_atoms,
+            temperature_right=temperature_right,
+            strain_run_steps=strain_run_steps,
+            candidate_phases=candidate_phases,
+            n_refine=n_refine,
+            seed=seed,
+        )
+        res = melting_point_scan.node_function(engine, mi).to_dict()
+        print(
+            f"Melting temperature: {res['melting_temperature']:.1f} K "
+            f"(phase={res['selected_phase']}, runner-up={res['runner_up_phase']} "
+            f"by {res['delta_runner_up']} K)"
+        )
+        for s in res["screened"]:
+            tag = "refine" if s["refined"] else "screen-only"
+            print(
+                f"  {s['crystalstructure']:>4} -> {s['observed_phase']:<6} "
+                f"t_guess={s['t_guess']:.0f} K held={s['held']} [{tag}]"
+            )
+        return res
     if full:
         mi = MeltingInput(
             element=element,
@@ -87,10 +118,27 @@ def main():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--element", default="Al")
     p.add_argument("--crystalstructure", default="fcc")
-    p.add_argument("--a", type=float, default=4.05)
+    p.add_argument(
+        "--a",
+        type=float,
+        default=None,
+        help="lattice constant; omit to estimate per phase (required-ish for --scan)",
+    )
     p.add_argument("--n-atoms", type=int, default=4000)
     p.add_argument("--working-directory", default="melting_run")
     p.add_argument("--full", action="store_true")
+    p.add_argument(
+        "--scan",
+        action="store_true",
+        help="screen candidate polymorphs; Tm = max over refined phases",
+    )
+    p.add_argument(
+        "--candidate-phases",
+        nargs="+",
+        default=None,
+        help="phases to screen (default: fcc bcc hcp + reference state)",
+    )
+    p.add_argument("--n-refine", type=int, default=2)
     p.add_argument("--temperature-right", type=float, default=1000.0)
     p.add_argument("--strain-run-steps", type=int, default=1000)
     p.add_argument("--seed", type=int, default=12345)
@@ -102,6 +150,9 @@ def main():
         n_atoms=args.n_atoms,
         working_directory=args.working_directory,
         full=args.full,
+        scan=args.scan,
+        candidate_phases=args.candidate_phases,
+        n_refine=args.n_refine,
         temperature_right=args.temperature_right,
         strain_run_steps=args.strain_run_steps,
         seed=args.seed,

--- a/tests/integration/test_melting_scan.py
+++ b/tests/integration/test_melting_scan.py
@@ -1,0 +1,46 @@
+import pytest
+from ase.calculators.emt import EMT
+
+from pyiron_workflow_atomistics.engine import ASEEngine, CalcInputStatic
+from pyiron_workflow_atomistics.physics.melting import (
+    MeltingInput,
+    melting_point_scan,
+)
+from pyiron_workflow_atomistics.physics.melting.outputs import MeltingScanResult
+
+
+@pytest.mark.slow
+def test_melting_point_scan_end_to_end(tmp_path):
+    # Restrict to fcc/bcc so the scan refines two polymorphs and picks the higher Tm.
+    mi = MeltingInput(
+        element="Al",
+        candidate_phases=["fcc", "bcc"],
+        n_refine=2,
+        n_atoms=120,
+        temperature_right=1400.0,
+        strain_run_steps=40,
+        timestep_lst=[2.0],
+        fit_range_lst=[0.05],
+        nve_steps_lst=[20],
+        nvt_run_steps=20,
+        npt_run_steps=20,
+        n_strain_points=5,
+        ratio_boundary=0.4,
+        max_coexistence_iterations=1,
+        seed=1,
+    )
+    eng = ASEEngine(
+        EngineInput=CalcInputStatic(), calculator=EMT(), working_directory=str(tmp_path)
+    )
+    res = melting_point_scan.node_function(eng, mi)
+    assert isinstance(res, MeltingScanResult)
+    assert res.element == "Al"
+    assert len(res.screened) == 2
+    # selected phase achieves the reported melting temperature ...
+    assert isinstance(res.melting_temperature, float)
+    by_phase = {r.crystalstructure: r.melting_temperature for r in res.refined}
+    assert by_phase[res.selected_phase] == res.melting_temperature
+    assert res.melting_temperature == max(by_phase.values())
+    # ... and the runner-up gap is non-negative when a runner-up exists.
+    if res.runner_up_phase is not None:
+        assert res.delta_runner_up >= 0

--- a/tests/unit/physics/melting/test_dataclasses.py
+++ b/tests/unit/physics/melting/test_dataclasses.py
@@ -2,6 +2,8 @@ from pyiron_workflow_atomistics.physics.melting.inputs import MeltingInput
 from pyiron_workflow_atomistics.physics.melting.outputs import (
     MeltingIterationRecord,
     MeltingResult,
+    MeltingScanResult,
+    PhaseScreenRecord,
 )
 
 
@@ -10,6 +12,8 @@ def test_melting_input_defaults():
     assert mi.n_atoms == 8000
     assert mi.timestep_lst == [2.0, 2.0, 1.0]
     assert mi.convergence_goal == 1.0
+    assert mi.candidate_phases is None
+    assert mi.n_refine == 2
 
 
 def test_melting_result_to_dict():
@@ -36,3 +40,52 @@ def test_melting_result_to_dict():
     d = res.to_dict()
     assert d["melting_temperature"] == 905.0
     assert len(d["iterations"]) == 1
+
+
+def _melting_result(phase, tm):
+    return MeltingResult(
+        melting_temperature=tm,
+        converged=True,
+        n_iterations=1,
+        element="Fe",
+        crystalstructure=phase,
+        n_atoms=2000,
+        initial_guess=tm,
+    )
+
+
+def test_phase_screen_record_to_dict():
+    rec = PhaseScreenRecord(
+        crystalstructure="bcc",
+        observed_phase="bcc",
+        lattice_constant=2.87,
+        t_guess=1800.0,
+        held=True,
+        refined=True,
+    )
+    d = rec.to_dict()
+    assert d["observed_phase"] == "bcc"
+    assert d["held"] is True
+    assert d["refined"] is True
+
+
+def test_melting_scan_result_to_dict_nested():
+    res = MeltingScanResult(
+        element="Fe",
+        melting_temperature=1820.0,
+        selected_phase="bcc",
+        runner_up_phase="fcc",
+        delta_runner_up=40.0,
+        screened=[
+            PhaseScreenRecord("bcc", "bcc", 2.87, 1800.0, True, True),
+            PhaseScreenRecord("fcc", "fcc", 3.6, 1700.0, True, True),
+        ],
+        refined=[_melting_result("bcc", 1820.0), _melting_result("fcc", 1780.0)],
+    )
+    d = res.to_dict()
+    assert d["selected_phase"] == "bcc"
+    assert d["delta_runner_up"] == 40.0
+    # nested dataclasses are serialised to plain dicts
+    assert isinstance(d["screened"][0], dict)
+    assert isinstance(d["refined"][0], dict)
+    assert d["refined"][0]["melting_temperature"] == 1820.0

--- a/tests/unit/physics/melting/test_screen.py
+++ b/tests/unit/physics/melting/test_screen.py
@@ -1,0 +1,73 @@
+"""Pure-logic tests for the across-polymorph melting scan (no MD)."""
+
+from pyiron_workflow_atomistics.physics.melting.outputs import PhaseScreenRecord
+from pyiron_workflow_atomistics.physics.melting.screen import (
+    _dedupe_by_observed,
+    _default_candidate_phases,
+    _select_for_refinement,
+)
+
+
+def test_default_candidate_phases_dedupes_reference():
+    # Reference state already in {fcc,bcc,hcp} -> no duplicate appended.
+    assert _default_candidate_phases("Al") == ["fcc", "bcc", "hcp"]  # fcc ref
+    assert _default_candidate_phases("Fe") == ["fcc", "bcc", "hcp"]  # bcc ref
+    assert _default_candidate_phases("Ti") == ["fcc", "bcc", "hcp"]  # hcp ref
+
+
+def test_default_candidate_phases_appends_nonstandard_reference():
+    # Si reference state is diamond -> appended after the three close-packed phases.
+    phases = _default_candidate_phases("Si")
+    assert phases[:3] == ["fcc", "bcc", "hcp"]
+    assert phases[3] not in ("fcc", "bcc", "hcp")
+
+
+def test_dedupe_prefers_held_then_higher_tguess():
+    # bcc collapsed to fcc (held False) competes with a held fcc on the same
+    # observed phase -> the held record wins regardless of t_guess.
+    recs = [
+        PhaseScreenRecord("bcc", "fcc", 3.2, 999.0, held=False),
+        PhaseScreenRecord("fcc", "fcc", 4.0, 900.0, held=True),
+    ]
+    deduped = _dedupe_by_observed(recs)
+    assert len(deduped) == 1
+    assert deduped[0].crystalstructure == "fcc"
+    assert deduped[0].held is True
+
+
+def test_dedupe_breaks_ties_by_tguess_when_neither_held():
+    recs = [
+        PhaseScreenRecord("bcc", "fcc", 3.2, 800.0, held=False),
+        PhaseScreenRecord("hcp", "fcc", 2.8, 850.0, held=False),
+    ]
+    deduped = _dedupe_by_observed(recs)
+    assert len(deduped) == 1
+    assert deduped[0].t_guess == 850.0
+
+
+def test_select_takes_top_n_refinable_by_tguess():
+    recs = [
+        PhaseScreenRecord("fcc", "fcc", 4.0, 900.0, held=True),
+        PhaseScreenRecord("bcc", "bcc", 3.2, 950.0, held=True),
+        PhaseScreenRecord("hcp", "hcp", 2.8, 600.0, held=True),
+    ]
+    sel = _select_for_refinement(recs, n_refine=2)
+    assert [r.observed_phase for r in sel] == ["bcc", "fcc"]  # top-2 by t_guess
+
+
+def test_select_filters_non_refinable_phases():
+    # 'others'/'ico' cannot be CNA-labelled for solid fraction -> excluded when a
+    # refinable phase exists.
+    recs = [
+        PhaseScreenRecord("fcc", "fcc", 4.0, 900.0, held=True),
+        PhaseScreenRecord("diamond", "others", 5.4, 2000.0, held=False),
+    ]
+    sel = _select_for_refinement(recs, n_refine=2)
+    assert [r.observed_phase for r in sel] == ["fcc"]
+
+
+def test_select_falls_back_when_nothing_refinable():
+    recs = [PhaseScreenRecord("diamond", "others", 5.4, 2000.0, held=True)]
+    sel = _select_for_refinement(recs, n_refine=2)
+    assert len(sel) == 1
+    assert sel[0].observed_phase == "others"


### PR DESCRIPTION
## Across-the-table polymorph melting scan

The single-phase macro (`calculate_melting_point`) fixes the solid phase up front.
But a potential's melting point is a property of **its own** free-energy landscape:
the relevant pre-melt solid is whichever polymorph that potential makes most stable
just below melting — and that varies per element **and** per potential. This adds a
driver that *discovers* the phase instead of imposing it.

### `melting_point_scan(engine, melting_input)`
1. **Screen (cheap):** `screen_phase` runs build → cell-relax → **Step 1 only** (the
   superheating NPT bisection) for each candidate polymorph. Returns the relaxed
   cell's actual CNA phase (`observed_phase`), whether the seed held, and a
   `t_guess` to rank by. Non-reference phases get a seed lattice constant from
   `estimate_lattice_constant` (relax the reference, invert the ideal
   volume-per-atom; cell-relax then corrects it — ASE `bulk` only knows `a` for the
   ground state).
2. **Select:** dedupe by observed phase (a collapsed seed merges into its product,
   preferring the held record), keep CNA-refinable solids (fcc/bcc/hcp), take the
   top `n_refine` by `t_guess`.
3. **Refine (expensive):** full Step-2 coexistence on the survivors, labelled by
   `observed_phase` so the solid-fraction CNA target matches.
4. **Aggregate:** `Tm = max` over refined polymorphs; `selected_phase` is the argmax
   (the potential's pre-melt phase); `runner_up_phase` + `delta_runner_up` expose
   near-degeneracy.

Self-correcting: a metastable seed either transforms during equilibration (caught by
CNA) or yields a lower `Tm` that `max` discards. No TI/free-energy stage — it would
be redundant where Step 1 already screens and fragile exactly on the
anharmonically-stabilised high-T bcc phases (Ti/Zr/Hf) where a harmonic reference is
undefined.

### Changes
- **new** `physics/melting/screen.py` — `melting_point_scan`, `screen_phase`, selection helpers
- `structures.py` — `estimate_lattice_constant`
- `inputs.py` — `candidate_phases` (default {fcc,bcc,hcp}+reference), `n_refine` (=2)
- `outputs.py` — `PhaseScreenRecord`, `MeltingScanResult` (nested `to_dict()`)
- `study.py` — single-phase macro refactored to reuse `screen_phase`
- `scripts/meltingpoint.py --scan [--candidate-phases ...] [--n-refine N]`
- design-doc addendum (§10)

### Tests
9 pure-logic unit tests (selection/dedupe/dataclasses, no MD) + 1 slow EMT
integration test. Validated end-to-end on EMT/Al: all three phases screened, ranked
by `t_guess`, top-2 refined, lowest dropped as screen-only, `Tm = max` with the
runner-up gap. ruff + isort + black clean.

### Known limitation
Non-close-packed reference states (diamond Si/C, etc.) screen but are not
CNA-refinable; the scan falls back to the deduped set and flags them via
`observed_phase` ∉ {fcc,bcc,hcp}. Molecular/sublimating elements are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
