### PR TITLE
Move lz-GB-code to an optional [gb] extra (unblocks conda-forge)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "scikit-learn==1.9.0",
     "structuretoolkit==0.0.45",
     "pyscal3==3.3.2",
-    "lz-GB-code==0.1.0",
     "tqdm==4.70.0",
 ]
 dynamic = ["version"]
@@ -62,6 +61,14 @@ phonons-md = [
 free-energy = [
     "calphy>=1.5.6",
     "pyiron_workflow_lammps",
+]
+# Grain-boundary CSL search. lz-GB-code is PyPI-only (no conda-forge package),
+# so keeping it out of the mandatory dependencies is what lets this project be
+# packaged on conda-forge. It is imported only by
+# physics/_grain_boundary_code/searcher.py and physics/grand_canonical_gb.py,
+# neither of which is reachable from `import pyiron_workflow_atomistics`.
+gb = [
+    "lz-GB-code==0.1.0",
 ]
 
 [project.license]


### PR DESCRIPTION
## Why

The conda-forge feedstock (`conda-forge/pyiron-workflow-atomistics-feedstock`) is stuck at **0.0.2** — it never picked up 0.0.3 through 0.2.0. Four autotick-bot PRs sit open and unmerged, and the newest (#4, v0.0.6) fails to build.

Two separate causes, one of which is already fixed:

1. **Build failure** — `ModuleNotFoundError: No module named 'ase'` during metadata generation, from setuptools' `attr:`-based version import. Already fixed on `main` by the PEP 562 lazy `__init__.py` (its docstring calls out exactly this failure). The 0.2.0 sdist imports clean.
2. **`lz-GB-code` is not on conda-forge** — and can't be satisfied there. This PR.

`lz-GB-code` is PyPI-only. The `gb-code` 1.0.0 package that *is* on conda-forge is upstream `oekosheri/GB_code`, a different project — not a drop-in for the `ligerzero-ai/GB_code` fork we depend on. As a mandatory dependency it makes the project unpackageable on conda-forge, since conda-forge recipes can't carry pip-only run deps and `pip check` in the recipe's test section would fail.

## What

Moves `lz-GB-code==0.1.0` out of `dependencies` into a new `[gb]` optional-dependency group.

This matches how the code already behaves. `gb_code` is imported only by `physics/_grain_boundary_code/searcher.py` and `physics/grand_canonical_gb.py`; `physics/__init__.py` deliberately re-exports nothing, and the top-level `__init__.py` is PEP 562 lazy — so `import pyiron_workflow_atomistics` never reaches it. The dependency was already optional in practice, just declared as mandatory.

I verified every other runtime pin against conda-forge: **13 of 13 exist at the exact pinned version** (flowrep 0.6.2, numpy 2.4.6, pandas 3.0.5, matplotlib-base 3.11.1, ase 3.29.0, scipy 1.17.1, pyiron_workflow 0.19.0, pymatgen 2026.5.4, pyiron_snippets 1.4.0, scikit-learn 1.9.0, structuretoolkit 0.0.45, pyscal3 3.3.2, tqdm 4.70.0). `lz-GB-code` was the only blocker.

## CI impact: none

- `uv_check` runs `uv sync --all-extras`, so the `[gb]` extra is installed and `pip check` still passes.
- `.ci_support/environment.yml` is unchanged and still pip-installs `lz-GB-code`, so `tests/integration/test_gb_code_pipeline.py` keeps its dependency.

`.ci_support/lower_bound.yml` already flagged this dep under a `# PyPI-only deps (not on conda-forge)` comment — this just makes the packaging metadata agree.

## Tradeoff

`pip install pyiron_workflow_atomistics` no longer pulls in GB search; users need `pip install pyiron_workflow_atomistics[gb]`. Without it, importing `physics.grand_canonical_gb` raises a bare `ModuleNotFoundError: No module named 'gb_code'`. Happy to add a friendlier guarded import if you'd prefer.

## Follow-up

Once this lands: release 0.2.1, then a feedstock PR bumping the recipe from 0.0.2 → 0.2.1 with a full dependency sync (the bot only bumps version+sha256, so the recipe still pins `numpy >=1.22.0,<1.27.0` against a codebase that now needs numpy 2.4.6), and close bot PRs #1–#4 as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYFeV3UoVeb8mkq8ivgumx