### PR TITLE
Give the optional gb_code dependency an actionable import error

### DIFF
--- a/pyiron_workflow_atomistics/physics/_grain_boundary_code/_gb_code.py
+++ b/pyiron_workflow_atomistics/physics/_grain_boundary_code/_gb_code.py
@@ -1,0 +1,28 @@
+"""Guarded access to the optional ``gb_code`` dependency.
+
+``gb_code`` is distributed on PyPI as ``lz-GB-code`` and is an *optional*
+dependency: it is not on conda-forge, so keeping it out of the mandatory
+requirements is what allows this project to be packaged there. Every module in
+this package imports the ``gb_code`` names from here rather than directly, so a
+missing install produces an actionable message instead of a bare
+``ModuleNotFoundError: No module named 'gb_code'``.
+"""
+
+_MISSING = (
+    "The grain-boundary CSL search needs the optional `gb_code` package "
+    "(distributed on PyPI as `lz-GB-code`), which is not installed.\n\n"
+    "    pip install 'pyiron_workflow_atomistics[gb]'\n\n"
+    "`gb_code` is PyPI-only — there is no conda-forge package for it — so the "
+    "conda distribution of pyiron_workflow_atomistics does not pull it in and "
+    "it must be pip-installed even in a conda environment. Installing "
+    "`lz-GB-code==0.1.0` directly works too."
+)
+
+try:
+    import gb_code.csl_generator as csl_generator
+    from gb_code.csl_generator import get_theta_m_n_list
+    from gb_code.gb_generator import GB_character
+except ModuleNotFoundError as exc:
+    raise ModuleNotFoundError(_MISSING) from exc
+
+__all__ = ["GB_character", "csl_generator", "get_theta_m_n_list"]

--- a/pyiron_workflow_atomistics/physics/_grain_boundary_code/constructor.py
+++ b/pyiron_workflow_atomistics/physics/_grain_boundary_code/constructor.py
@@ -1,10 +1,13 @@
 import flowrep as fr
 import numpy as np
-from gb_code.gb_generator import GB_character
 from pyiron_snippets.logger import logger
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from pymatgen.core import Structure
 from pymatgen.io.ase import AseAtomsAdaptor
+
+from pyiron_workflow_atomistics.physics._grain_boundary_code._gb_code import (
+    GB_character,
+)
 
 
 def _axis_index_to_label(axis: int) -> str:

--- a/pyiron_workflow_atomistics/physics/_grain_boundary_code/searcher.py
+++ b/pyiron_workflow_atomistics/physics/_grain_boundary_code/searcher.py
@@ -2,12 +2,17 @@ from math import degrees
 from multiprocessing import Pool, cpu_count
 
 import flowrep as fr
-import gb_code.csl_generator as csl
 import numpy as np
 import pandas as pd
-from gb_code.csl_generator import get_theta_m_n_list
 from pyiron_snippets.logger import logger
 from tqdm import tqdm
+
+from pyiron_workflow_atomistics.physics._grain_boundary_code._gb_code import (
+    csl_generator as csl,
+)
+from pyiron_workflow_atomistics.physics._grain_boundary_code._gb_code import (
+    get_theta_m_n_list,
+)
 
 
 def _construct_gb_for_sigma(args):

--- a/tests/unit/physics/test_gb_code_optional_dependency.py
+++ b/tests/unit/physics/test_gb_code_optional_dependency.py
@@ -1,0 +1,56 @@
+"""`gb_code` is an optional dependency — the import error must be actionable.
+
+`gb_code` (PyPI: ``lz-GB-code``) is not on conda-forge, so it lives in the
+``[gb]`` extra rather than the mandatory requirements. That means a plain
+install can reach the GB modules without it, and the resulting error is the
+only thing telling the user what to do about it.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+
+import pytest
+
+MODULE = "pyiron_workflow_atomistics.physics._grain_boundary_code._gb_code"
+
+
+def _hide_gb_code(monkeypatch):
+    """Make any ``import gb_code...`` fail, as it would without the extra."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "gb_code" or name.startswith("gb_code."):
+            raise ModuleNotFoundError(f"No module named {name!r}")
+        return real_import(name, *args, **kwargs)
+
+    for name in [m for m in list(sys.modules) if m.startswith("gb_code")]:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.delitem(sys.modules, MODULE, raising=False)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def test_missing_gb_code_names_the_extra(monkeypatch):
+    _hide_gb_code(monkeypatch)
+
+    with pytest.raises(ModuleNotFoundError) as excinfo:
+        importlib.import_module(MODULE)
+
+    message = str(excinfo.value)
+    # The install command is the whole point of the guard.
+    assert "pyiron_workflow_atomistics[gb]" in message
+    # Conda users can't get it from their channel, so say so explicitly.
+    assert "conda-forge" in message
+    # The underlying failure stays reachable for debugging.
+    assert isinstance(excinfo.value.__cause__, ModuleNotFoundError)
+
+
+def test_gb_code_present_exports_the_expected_names():
+    """With the extra installed, the guard is a transparent re-export."""
+    module = pytest.importorskip(MODULE)
+
+    assert module.csl_generator is not None
+    assert callable(module.get_theta_m_n_list)
+    assert module.GB_character is not None


### PR DESCRIPTION
Follow-up to #93. Now that `gb_code` lives in the `[gb]` extra, a plain install can reach the GB modules without it and gets:

```
ModuleNotFoundError: No module named 'gb_code'
```

which says nothing about the extra — or about the fact that conda users must pip-install it, since there is no conda-forge package for `lz-GB-code`. That last part matters more now that 0.2.1 is on conda-forge.

## What

Adds `physics/_grain_boundary_code/_gb_code.py`, a guard that re-exports the three `gb_code` names this package uses (`csl_generator`, `get_theta_m_n_list`, `GB_character`) and turns a missing install into:

```
ModuleNotFoundError: The grain-boundary CSL search needs the optional `gb_code`
package (distributed on PyPI as `lz-GB-code`), which is not installed.

    pip install 'pyiron_workflow_atomistics[gb]'

`gb_code` is PyPI-only — there is no conda-forge package for it — so the conda
distribution of pyiron_workflow_atomistics does not pull it in and it must be
pip-installed even in a conda environment. Installing `lz-GB-code==0.1.0`
directly works too.
```

`constructor.py` and `searcher.py` — the only two `gb_code` importers — now import from the guard. `raise ... from exc` keeps the original failure on `__cause__`.

The guard imports nothing beyond `gb_code` itself, so it stays cheap and can be imported without the rest of the dependency tree.

## Verification

- New `tests/unit/physics/test_gb_code_optional_dependency.py` covers both paths: the message names the extra and mentions conda-forge, `__cause__` is preserved, and with the extra installed the guard is a transparent re-export. **2 passed** locally.
- Confirmed the real failure path end-to-end by importing the guard in an interpreter with no `gb_code` installed — output is the message above.
- `ruff check` (full rule set) and `ruff check --select I` clean; `black --check` leaves all 5 files unchanged.

Behaviour is otherwise unchanged: same names, same values, same import-time failure point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYFeV3UoVeb8mkq8ivgumx